### PR TITLE
feature/dnf-support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-PACKAGE_MANAGER=0
+PACKAGE_MANAGER=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLIPMAN_PY="$SCRIPT_DIR/clipman.py"
 AUTOSTART_DIR="$HOME/.config/autostart"
@@ -10,18 +10,22 @@ EXTENSION_UUID="clipman@clipman.com"
 EXTENSION_DIR="$HOME/.local/share/gnome-shell/extensions/$EXTENSION_UUID"
 
 if command -v dnf &> /dev/null; then
-    echo "Using DNF (Fedora/RHEL)"
-    PACKAGE_MANAGER=1
+    PKG_MANAGER="dnf"
+elif command -v apt &> /dev/null; then
+    PKG_MANAGER="apt"
+else
+    echo "Error: No supported package manager found (apt or dnf)"
+    exit 1
 fi
 
 echo "=== Installing Clipman ==="
 
 # Step 1: Install system dependencies
 echo "[1/6] Installing dependencies..."
-if PACKAGE_MANAGER=0
+if [ "$PKG_MANAGER" = "apt" ]; then
     sudo apt install -y wl-clipboard python3-gi python3-dbus gir1.2-gtk-3.0
-else    
-    sudo dnf install -y wl-clipboard python3-gobject gtk3 python3-dbus 
+else
+    sudo dnf install -y wl-clipboard python3-gobject gtk3 python3-dbus
 fi
 
 # Step 2: Create data directories
@@ -62,11 +66,7 @@ else
         NEW_LIST="['$CLIPMAN_KEY_PATH']"
     else
         # Remove trailing ] and append
-        if PACKAGE_MANAGER=0
-            NEW_LIST=$(echo "$EXISTING" | sed "s/]$/, '$CLIPMAN_KEY_PATH']/")
-        else
-            NEW_LIST=$(echo "$EXISTING" | sed "s|]$|, '$CLIPMAN_KEY_PATH']|")
-        fi
+        NEW_LIST=$(echo "$EXISTING" | sed "s/]$/, '$CLIPMAN_KEY_PATH']/")
     fi
     gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "$NEW_LIST"
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+PACKAGE_MANAGER=0
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLIPMAN_PY="$SCRIPT_DIR/clipman.py"
 AUTOSTART_DIR="$HOME/.config/autostart"
@@ -8,11 +9,20 @@ DATA_DIR="$HOME/.local/share/clipman"
 EXTENSION_UUID="clipman@clipman.com"
 EXTENSION_DIR="$HOME/.local/share/gnome-shell/extensions/$EXTENSION_UUID"
 
+if command -v dnf &> /dev/null; then
+    echo "Using DNF (Fedora/RHEL)"
+    PACKAGE_MANAGER=1
+fi
+
 echo "=== Installing Clipman ==="
 
 # Step 1: Install system dependencies
 echo "[1/6] Installing dependencies..."
-sudo apt install -y wl-clipboard python3-gi python3-dbus gir1.2-gtk-3.0
+if PACKAGE_MANAGER=0
+    sudo apt install -y wl-clipboard python3-gi python3-dbus gir1.2-gtk-3.0
+else    
+    sudo dnf install -y wl-clipboard python3-gobject gtk3 python3-dbus 
+fi
 
 # Step 2: Create data directories
 echo "[2/6] Creating data directories..."
@@ -52,7 +62,11 @@ else
         NEW_LIST="['$CLIPMAN_KEY_PATH']"
     else
         # Remove trailing ] and append
-        NEW_LIST=$(echo "$EXISTING" | sed "s/]$/, '$CLIPMAN_KEY_PATH']/")
+        if PACKAGE_MANAGER=0
+            NEW_LIST=$(echo "$EXISTING" | sed "s/]$/, '$CLIPMAN_KEY_PATH']/")
+        else
+            NEW_LIST=$(echo "$EXISTING" | sed "s|]$|, '$CLIPMAN_KEY_PATH']|")
+        fi
     fi
     gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "$NEW_LIST"
 fi


### PR DESCRIPTION
# Motivation
apt is not available on RHEL family OS such as RHEL, Alma, CentOS, Fedora, Rocky.

I wanted to support Rocky Linux, so i tested it on my local Rocky Linux 10, but I'll be using it on Rocky Linux 9 in VMs if all goes well.

# Scope of changes
- changed apt to dnf and changed gtk packages to the equivalent in dnf.
- changed sed delimiter because I had issues with that, but I'm not sure why tbh.
- Did not change uninstall.sh because it doesn't use package manager or sed.
# Testing
- I did not test on other major distros. 
- The python test passes but i suspect it doesn't test your install script.
- did not test uninstall.sh