### PR TITLE
ci: add weekly snap rebuild workflow

### DIFF
--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -1,0 +1,135 @@
+name: Snap refresh
+
+# Rebuilds the snap weekly to pick up Ubuntu archive security updates
+# (resolves the "outdated stage-packages" review emails). Also builds
+# on PRs/main pushes that touch snap-relevant paths so a packaging
+# break is caught early.
+#
+# Publishing to the Snap Store requires the SNAPCRAFT_STORE_CREDENTIALS
+# secret. Without it, build runs succeed and the artifact is uploaded
+# to the workflow run for manual inspection; publish is skipped.
+
+on:
+  schedule:
+    # Weekly Monday 04:00 UTC.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Snap Store channel to publish to"
+        type: choice
+        options: [edge, beta, candidate, stable]
+        default: edge
+      publish:
+        description: "Publish to the Snap Store (false = build artifact only)"
+        type: boolean
+        default: true
+  push:
+    branches: [main]
+    paths:
+      - 'snap/**'
+      - 'clipman/**'
+      - 'data/**'
+      - 'launcher.sh'
+      - 'clipman.py'
+      - 'pyproject.toml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'snap/**'
+      - 'clipman/**'
+      - 'data/**'
+      - 'launcher.sh'
+      - 'clipman.py'
+      - 'pyproject.toml'
+
+permissions: {}
+
+concurrency:
+  group: snap-refresh-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build snap
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      snap-file: ${{ steps.build.outputs.snap }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Build snap
+        id: build
+        uses: snapcore/action-build@d12445ae70c52b1ead8b8a0ac6635f0432af5c80 # v1.3.0
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: clipman-snap-${{ github.run_id }}
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 14
+          if-no-files-found: error
+
+  publish:
+    name: Publish to Snap Store
+    needs: build
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: clipman-snap-${{ github.run_id }}
+          path: ./snap-artifact
+
+      - name: Check credentials
+        id: creds
+        env:
+          STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          if [ -z "$STORE_CREDENTIALS" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::SNAPCRAFT_STORE_CREDENTIALS secret not set; skipping Snap Store publish. Add the secret to enable automatic publishing."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve snap path
+        if: steps.creds.outputs.enabled == 'true'
+        id: resolve
+        run: |
+          snap_file=$(find ./snap-artifact -maxdepth 1 -name 'clipman_*.snap' -type f | head -n 1)
+          if [ -z "$snap_file" ]; then
+            echo "::error::Built snap not found in artifact"
+            exit 1
+          fi
+          echo "snap=$snap_file" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to Snap Store
+        if: steps.creds.outputs.enabled == 'true'
+        uses: snapcore/action-publish@d383e5c99f47316f8c8d74be837f6a77455ec5a6 # v1.2.0
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.resolve.outputs.snap }}
+          release: ${{ inputs.channel || 'edge' }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/snap-refresh.yml` to rebuild the snap on a schedule and pick up Ubuntu archive security updates automatically — addressing the recurring **"this snap was built with packages that have since received security updates"** emails from the Snap Store (recent USNs noted: USN-8269-1 affecting `libavahi-client3` / `libavahi-common3`, USN-8209-1 affecting `liblcms2-2`).

> **Note on cleanup scope:** the original plan also covered removing committed `clipman_*.snap` blobs. After checking `git ls-files`, those binaries were **never tracked** (already covered by `.gitignore`) — the `.snap` files in your local working directory are leftovers from manual builds. So this PR is just the workflow.

## Triggers

| Trigger | Behavior |
|---------|----------|
| `schedule: '0 4 * * 1'` | Weekly Mon 04:00 UTC — rebuild + auto-publish to `edge` |
| `workflow_dispatch` | Manual rebuild with selectable channel (edge/beta/candidate/stable) and a `publish` boolean toggle |
| `push` to `main` | When snap-relevant paths change (snap/**, clipman/**, data/**, launcher.sh, clipman.py, pyproject.toml) — build only, no publish |
| `pull_request` | Same paths — validates snap build before merge |

## Jobs

- **build** — `snapcore/action-build@v1.3.0`, uploads the `.snap` as a workflow artifact with 14-day retention so you can grab it locally if needed.
- **publish** — only runs on `schedule` or explicit `workflow_dispatch` with `publish: true`. Gracefully **skips with a warning** if `SNAPCRAFT_STORE_CREDENTIALS` isn't set, so this workflow can land before the secret is configured.

## Operational notes

- **No version bump required for rebuilds.** Snap Store assigns a new revision on each upload while reusing the `version` field; the `1.0.4` value in `snap/snapcraft.yaml` stays put until the next feature release.
- **Adding the secret:** `snapcraft export-login --snaps=clipman snap-creds.txt`, then add the file content as the `SNAPCRAFT_STORE_CREDENTIALS` repo secret. Once set, the first scheduled run will publish to `edge` automatically.
- **Manual review caveat:** because the snap declares dbus slots (`com.clipman.Daemon`, `com.clipman.Clipman`), the Snap Store occasionally queues uploads for human review. The publish step still uploads successfully; the queued state will show in the dashboard.

## OWASP / CI hardening

Same posture as PR #8:

- All actions pinned to commit SHAs with version comments
- Top-level `permissions: {}`, job-level least-privilege (`contents: read`)
- Runners pinned to `ubuntu-24.04`, `timeout-minutes` on every job
- `step-security/harden-runner` (egress-policy: audit) first step
- `persist-credentials: false` on checkout
- Concurrency group + `cancel-in-progress` for PR runs
- Explicit `pull_request: types: [opened, synchronize, reopened]` so PR updates re-run jobs

## Type of change

- [x] Build / CI / packaging

## Testing

- [ ] First trigger will be this PR's `pull_request` event — confirms the snap actually builds in CI
- [ ] After merge, the next Monday 04:00 UTC run (or a `workflow_dispatch`) will exercise the publish path

## Follow-ups (out of scope for this PR)

- Add `SNAPCRAFT_STORE_CREDENTIALS` repo secret (manual; only the user can authenticate).
- Once Stream A (custom-shortcut feature) lands and a v1.0.5 release is cut, automate it via the release workflow in Stream C.