### PR TITLE
feat: customizable toggle + paste shortcuts (closes #4, #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Clipman are documented in this file.
 
+## [Unreleased]
+
+### Added
+- Customizable toggle shortcut from the settings panel. Click the
+  shortcut button to capture a new key combination; the daemon writes
+  it to GNOME's custom keybinding via gsettings. Default unchanged
+  (`Super+V`). Closes #4.
+- Customizable paste keystroke from the settings panel: `Auto-detect`
+  (default — Ctrl+V, switches to Ctrl+Shift+V for terminals),
+  `Ctrl+V`, `Ctrl+Shift+V`, or `Shift+Insert`. Closes #7.
+- `clipman/keybindings.py` module with gsettings shell-out helpers
+  and a 30-test unit suite (`tests/test_keybindings.py`).
+
+### Changed
+- GNOME Shell extension D-Bus interface: `SimulatePaste()` now
+  accepts an optional `s mode` argument. The daemon falls back to
+  the no-arg signature for older extension builds, so the new
+  daemon remains compatible with an unupgraded extension.
+- `extension/metadata.json`: bumped to version 5.
+
 ## [1.0.4] - 2026-02-28
 
 ### Fixed

--- a/clipman/keybindings.py
+++ b/clipman/keybindings.py
@@ -1,0 +1,131 @@
+"""GNOME gsettings keybinding helpers + display/parsing utilities.
+
+Used by the in-app "Toggle shortcut" customizer in the settings panel.
+Kept in its own module so the gsettings shell-outs can be mocked in
+tests without pulling GTK into the test path.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+
+CUSTOM_KEYS_SCHEMA = "org.gnome.settings-daemon.plugins.media-keys"
+CUSTOM_KEYS_KEY = "custom-keybindings"
+CUSTOM_KEY_PATH = (
+    "/org/gnome/settings-daemon/plugins/media-keys"
+    "/custom-keybindings/clipman/"
+)
+CUSTOM_KEY_SUBSCHEMA = (
+    "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
+)
+DEFAULT_TOGGLE_BINDING = "<Super>v"
+
+_MODIFIER_KEY_NAMES = frozenset({
+    "Shift_L", "Shift_R", "Control_L", "Control_R",
+    "Alt_L", "Alt_R", "Super_L", "Super_R", "Meta_L", "Meta_R",
+    "Hyper_L", "Hyper_R",
+})
+
+
+def _gsettings_get(schema: str, key: str, path: str | None = None) -> str | None:
+    cmd = ["gsettings", "get",
+           f"{schema}:{path}" if path else schema, key]
+    try:
+        return subprocess.check_output(cmd, text=True, timeout=5).strip()
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+
+
+def _gsettings_set(schema: str, key: str, value: str,
+                   path: str | None = None) -> bool:
+    cmd = ["gsettings", "set",
+           f"{schema}:{path}" if path else schema, key, value]
+    try:
+        subprocess.check_call(
+            cmd, timeout=5,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return False
+
+
+def get_toggle_binding() -> str | None:
+    """Read the Clipman custom keybinding's binding string."""
+    raw = _gsettings_get(
+        CUSTOM_KEY_SUBSCHEMA, "binding", path=CUSTOM_KEY_PATH
+    )
+    if raw is None:
+        return None
+    return raw.strip().strip("'").strip('"')
+
+
+def set_toggle_binding(binding: str) -> bool:
+    """Update the binding (keystroke) on the Clipman custom keybinding."""
+    return _gsettings_set(
+        CUSTOM_KEY_SUBSCHEMA, "binding", f"'{binding}'",
+        path=CUSTOM_KEY_PATH,
+    )
+
+
+def format_binding_for_display(binding: str) -> str:
+    """Convert ``<Super><Shift>v`` to ``Super+Shift+V`` for the UI."""
+    if not binding:
+        return ""
+    parts: list[str] = []
+    s = binding
+    while s.startswith("<"):
+        end = s.find(">")
+        if end == -1:
+            break
+        parts.append(s[1:end].title())
+        s = s[end + 1:]
+    if s:
+        parts.append(s.upper() if len(s) == 1 else s.title())
+    return "+".join(parts)
+
+
+def keyval_to_binding(keyval: int, state: int) -> str | None:
+    """Convert a Gtk key event (keyval + modifier state) into gsettings syntax.
+
+    Returns None when the press is a pure modifier or has no usable name.
+    Requires at least one modifier; pure-letter bindings are not allowed.
+    """
+    # Local import so importing this module doesn't require Gdk.
+    from gi.repository import Gdk
+
+    name = Gdk.keyval_name(keyval)
+    if not name or name in _MODIFIER_KEY_NAMES:
+        return None
+
+    parts: list[str] = []
+    if state & Gdk.ModifierType.CONTROL_MASK:
+        parts.append("<Ctrl>")
+    if state & Gdk.ModifierType.SUPER_MASK:
+        parts.append("<Super>")
+    if state & Gdk.ModifierType.MOD1_MASK:
+        parts.append("<Alt>")
+    if state & Gdk.ModifierType.SHIFT_MASK:
+        parts.append("<Shift>")
+
+    if not parts:
+        return None  # at least one modifier required
+
+    parts.append(name)
+    return "".join(parts)
+
+
+def is_clipman_binding_registered() -> bool:
+    """True iff the GNOME custom-keybindings list already contains the
+    Clipman path. Falsey when gsettings is unavailable (snap, etc.)."""
+    raw = _gsettings_get(CUSTOM_KEYS_SCHEMA, CUSTOM_KEYS_KEY)
+    if raw is None:
+        return False
+    try:
+        current = ast.literal_eval(raw.replace("@as ", "").strip())
+    except (SyntaxError, ValueError):
+        return False
+    if not isinstance(current, list):
+        return False
+    return any("clipman" in p for p in current)

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 import gi
 
-from clipman import _
+from clipman import _, keybindings
 from clipman.database import _safe_image_path
 
 gi.require_version("Gtk", "3.0")
@@ -19,6 +19,14 @@ DEFAULT_MAX_HISTORY = 500
 DEFAULT_THEME = "dark"
 DEFAULT_FONT_COLOR = ""
 DEFAULT_SENSITIVE_TIMEOUT = 30
+DEFAULT_PASTE_MODE = "auto"
+
+PASTE_MODES = [
+    ("auto", "Auto-detect"),
+    ("ctrl-v", "Ctrl+V"),
+    ("ctrl-shift-v", "Ctrl+Shift+V"),
+    ("shift-insert", "Shift+Insert"),
+]
 
 THEME_DARK = {
     "bg_crust": "#181825", "bg_base": "#1e1e2e", "bg_surface": "#252536",
@@ -96,6 +104,13 @@ class ClipmanWindow(Gtk.Window):
         saved_sensitive = self.db.get_setting("sensitive_timeout",
                                               str(DEFAULT_SENSITIVE_TIMEOUT))
         self._sensitive_timeout = max(10, min(300, int(float(saved_sensitive))))
+
+        self._toggle_shortcut = self.db.get_setting(
+            "toggle_shortcut", keybindings.DEFAULT_TOGGLE_BINDING
+        )
+        saved_paste = self.db.get_setting("paste_mode", DEFAULT_PASTE_MODE)
+        valid_modes = {m[0] for m in PASTE_MODES}
+        self._paste_mode = saved_paste if saved_paste in valid_modes else DEFAULT_PASTE_MODE
 
         self._apply_css()
         self._build_ui()
@@ -218,6 +233,41 @@ class ClipmanWindow(Gtk.Window):
             10, 300, 10, self._sensitive_timeout,
             self._on_sensitive_timeout_changed, self._sensitive_value_label
         )
+
+        # Toggle shortcut row
+        shortcut_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        shortcut_label = Gtk.Label(label=_("Toggle shortcut"))
+        shortcut_label.get_style_context().add_class("settings-label")
+        shortcut_label.set_halign(Gtk.Align.START)
+        shortcut_row.pack_start(shortcut_label, False, False, 0)
+        shortcut_spacer = Gtk.Box()
+        shortcut_spacer.set_hexpand(True)
+        shortcut_row.pack_start(shortcut_spacer, True, True, 0)
+        self._shortcut_button = Gtk.Button(
+            label=keybindings.format_binding_for_display(self._toggle_shortcut)
+        )
+        self._shortcut_button.set_tooltip_text(_("Click to set a new shortcut"))
+        self._shortcut_button.get_style_context().add_class("backup-btn")
+        self._shortcut_button.connect("clicked", self._on_shortcut_change)
+        shortcut_row.pack_start(self._shortcut_button, False, False, 0)
+        self.settings_panel.pack_start(shortcut_row, False, False, 0)
+
+        # Paste keystroke row
+        paste_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        paste_label = Gtk.Label(label=_("Paste keystroke"))
+        paste_label.get_style_context().add_class("settings-label")
+        paste_label.set_halign(Gtk.Align.START)
+        paste_row.pack_start(paste_label, False, False, 0)
+        paste_spacer = Gtk.Box()
+        paste_spacer.set_hexpand(True)
+        paste_row.pack_start(paste_spacer, True, True, 0)
+        self._paste_combo = Gtk.ComboBoxText()
+        for mode_id, mode_label in PASTE_MODES:
+            self._paste_combo.append(mode_id, _(mode_label))
+        self._paste_combo.set_active_id(self._paste_mode)
+        self._paste_combo.connect("changed", self._on_paste_mode_changed)
+        paste_row.pack_start(self._paste_combo, False, False, 0)
+        self.settings_panel.pack_start(paste_row, False, False, 0)
 
         # Theme toggle row
         theme_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -777,7 +827,12 @@ class ClipmanWindow(Gtk.Window):
                 "org.gnome.Shell.Extensions.clipman", "/org/gnome/Shell/Extensions/clipman"
             )
             iface = dbus.Interface(proxy, "org.gnome.Shell.Extensions.clipman")
-            iface.SimulatePaste()
+            mode = self._paste_mode or DEFAULT_PASTE_MODE
+            try:
+                iface.SimulatePaste(mode)
+            except dbus.DBusException:
+                # Older extension without the mode argument
+                iface.SimulatePaste()
         except dbus.DBusException:
             pass
         return False
@@ -893,6 +948,49 @@ class ClipmanWindow(Gtk.Window):
         self._sensitive_timeout = int(scale.get_value())
         self._sensitive_value_label.set_text(f"{self._sensitive_timeout}s")
         self.db.set_setting("sensitive_timeout", str(self._sensitive_timeout))
+
+    def _on_paste_mode_changed(self, combo):
+        mode_id = combo.get_active_id()
+        if not mode_id:
+            return
+        self._paste_mode = mode_id
+        self.db.set_setting("paste_mode", mode_id)
+
+    def _on_shortcut_change(self, button):
+        dialog = _ShortcutCaptureDialog(self)
+        response = dialog.run()
+        new_binding = dialog.captured_binding
+        dialog.destroy()
+        if response != Gtk.ResponseType.OK or not new_binding:
+            return
+        if new_binding == self._toggle_shortcut:
+            return
+        if keybindings.is_clipman_binding_registered():
+            ok = keybindings.set_toggle_binding(new_binding)
+        else:
+            ok = False
+        if not ok:
+            # gsettings unavailable or no clipman keybinding registered yet
+            self._show_shortcut_error()
+            return
+        self._toggle_shortcut = new_binding
+        self.db.set_setting("toggle_shortcut", new_binding)
+        button.set_label(keybindings.format_binding_for_display(new_binding))
+
+    def _show_shortcut_error(self):
+        msg = Gtk.MessageDialog(
+            transient_for=self,
+            modal=True,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.OK,
+            text=_("Couldn't update the GNOME shortcut."),
+        )
+        msg.format_secondary_text(_(
+            "The Clipman keybinding isn't registered with GNOME yet. "
+            "Run install.sh once to register it, then try again."
+        ))
+        msg.run()
+        msg.destroy()
 
     def _cleanup_sensitive(self):
         deleted = self.db.delete_expired_sensitive(self._sensitive_timeout)
@@ -1252,3 +1350,57 @@ class ClipmanWindow(Gtk.Window):
             self.search_entry.grab_focus()
             self.present()
             GLib.timeout_add(50, self._move_to_cursor)
+
+
+class _ShortcutCaptureDialog(Gtk.Dialog):
+    """Modal dialog that captures the next key combo for the toggle shortcut."""
+
+    def __init__(self, parent):
+        super().__init__(
+            title=_("Set toggle shortcut"),
+            transient_for=parent,
+            modal=True,
+        )
+        self.set_default_size(360, 140)
+        self.captured_binding = None
+
+        self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
+        self._save_btn = self.add_button(_("Save"), Gtk.ResponseType.OK)
+        self._save_btn.set_sensitive(False)
+
+        box = self.get_content_area()
+        box.set_spacing(8)
+        box.set_margin_top(12)
+        box.set_margin_bottom(12)
+        box.set_margin_start(16)
+        box.set_margin_end(16)
+
+        self._instruction = Gtk.Label()
+        self._instruction.set_text(
+            _("Press a key combination (must include Ctrl, Super, Alt, or Shift)")
+        )
+        self._instruction.set_line_wrap(True)
+        self._instruction.set_halign(Gtk.Align.START)
+        box.pack_start(self._instruction, False, False, 0)
+
+        self._preview = Gtk.Label(label=_("(no keys pressed yet)"))
+        self._preview.get_style_context().add_class("settings-value")
+        box.pack_start(self._preview, False, False, 0)
+
+        self.connect("key-press-event", self._on_key_press)
+        self.show_all()
+
+    def _on_key_press(self, _widget, event):
+        # Use defined values when available; treat keyval/state directly.
+        keyval = getattr(event, "keyval", None) or event.get_keyval()[1]
+        state = getattr(event, "state", None)
+        if state is None:
+            state = event.get_state()
+        binding = keybindings.keyval_to_binding(keyval, int(state))
+        if binding is None:
+            # Pure modifier or unusable key — keep waiting.
+            return True
+        self.captured_binding = binding
+        self._preview.set_text(keybindings.format_binding_for_display(binding))
+        self._save_btn.set_sensitive(True)
+        return True

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -8,12 +8,39 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 const PASTE_DBUS_IFACE = `
 <node>
   <interface name="org.gnome.Shell.Extensions.clipman">
-    <method name="SimulatePaste"/>
+    <method name="SimulatePaste">
+      <arg type="s" direction="in" name="mode"/>
+    </method>
     <method name="MoveWindowToCursor">
       <arg type="s" direction="in" name="title"/>
     </method>
   </interface>
 </node>`;
+
+const TERMINAL_WM_CLASSES = [
+    'gnome-terminal-server', 'tilix', 'kitty', 'alacritty',
+    'terminator', 'xterm', 'konsole', 'foot', 'wezterm',
+    'st', 'sakura', 'xfce4-terminal', 'mate-terminal',
+    'lxterminal', 'guake', 'tilda', 'cool-retro-term',
+];
+
+// Keystroke recipes: ordered list of (keyval, modifiers-implied-by-keystroke).
+// The first element of each pair is the actual keyval to press; modifier
+// keys are emitted around the press/release.
+const PASTE_RECIPES = {
+    'ctrl-v': {modifiers: ['Control_L'], key: 'v'},
+    'ctrl-shift-v': {modifiers: ['Control_L', 'Shift_L'], key: 'v'},
+    'shift-insert': {modifiers: ['Shift_L'], key: 'Insert'},
+};
+
+const KEY_LOOKUP = {
+    'Control_L': Clutter.KEY_Control_L,
+    'Shift_L': Clutter.KEY_Shift_L,
+    'Alt_L': Clutter.KEY_Alt_L,
+    'Super_L': Clutter.KEY_Super_L,
+    'v': Clutter.KEY_v,
+    'Insert': Clutter.KEY_Insert,
+};
 
 export default class ClipmanExtension extends Extension {
     enable() {
@@ -57,50 +84,41 @@ export default class ClipmanExtension extends Extension {
         }
     }
 
-    SimulatePaste() {
-        const TERMINAL_CLASSES = [
-            'gnome-terminal-server', 'tilix', 'kitty', 'alacritty',
-            'terminator', 'xterm', 'konsole', 'foot', 'wezterm',
-            'st', 'sakura', 'xfce4-terminal', 'mate-terminal',
-            'lxterminal', 'guake', 'tilda', 'cool-retro-term',
-        ];
+    SimulatePaste(mode) {
+        const recipe = this._resolveRecipe(mode);
+        this._dispatchKeystroke(recipe);
+    }
+
+    _resolveRecipe(mode) {
+        // 'auto' (or missing) -> Ctrl+V unless focused window is a terminal,
+        // in which case Ctrl+Shift+V. Explicit modes override.
+        if (mode && PASTE_RECIPES[mode])
+            return PASTE_RECIPES[mode];
 
         const focusWin = global.display.get_focus_window();
         const wmClass = focusWin?.get_wm_class()?.toLowerCase() ?? '';
-        const needShift = TERMINAL_CLASSES.some(c => wmClass.includes(c));
+        const isTerminal = TERMINAL_WM_CLASSES.some(c => wmClass.includes(c));
+        return isTerminal ? PASTE_RECIPES['ctrl-shift-v'] : PASTE_RECIPES['ctrl-v'];
+    }
 
+    _dispatchKeystroke(recipe) {
         const seat = Clutter.get_default_backend().get_default_seat();
         const vk = seat.create_virtual_device(
             Clutter.InputDeviceType.KEYBOARD_DEVICE
         );
-        vk.notify_keyval(
-            Clutter.CURRENT_TIME,
-            Clutter.KEY_Control_L, Clutter.KeyState.PRESSED
-        );
-        if (needShift) {
-            vk.notify_keyval(
-                Clutter.CURRENT_TIME,
-                Clutter.KEY_Shift_L, Clutter.KeyState.PRESSED
-            );
+
+        for (const mod of recipe.modifiers) {
+            vk.notify_keyval(Clutter.CURRENT_TIME,
+                KEY_LOOKUP[mod], Clutter.KeyState.PRESSED);
         }
-        vk.notify_keyval(
-            Clutter.CURRENT_TIME,
-            Clutter.KEY_v, Clutter.KeyState.PRESSED
-        );
-        vk.notify_keyval(
-            Clutter.CURRENT_TIME,
-            Clutter.KEY_v, Clutter.KeyState.RELEASED
-        );
-        if (needShift) {
-            vk.notify_keyval(
-                Clutter.CURRENT_TIME,
-                Clutter.KEY_Shift_L, Clutter.KeyState.RELEASED
-            );
+        vk.notify_keyval(Clutter.CURRENT_TIME,
+            KEY_LOOKUP[recipe.key], Clutter.KeyState.PRESSED);
+        vk.notify_keyval(Clutter.CURRENT_TIME,
+            KEY_LOOKUP[recipe.key], Clutter.KeyState.RELEASED);
+        for (const mod of [...recipe.modifiers].reverse()) {
+            vk.notify_keyval(Clutter.CURRENT_TIME,
+                KEY_LOOKUP[mod], Clutter.KeyState.RELEASED);
         }
-        vk.notify_keyval(
-            Clutter.CURRENT_TIME,
-            Clutter.KEY_Control_L, Clutter.KeyState.RELEASED
-        );
     }
 
     MoveWindowToCursor(title) {

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,7 +3,7 @@
     "name": "Clipman Clipboard Monitor",
     "description": "Native Wayland clipboard change detection for the Clipman clipboard manager. Listens to Meta.Selection owner-changed signals and forwards clipboard content to the Clipman daemon via D-Bus. Provides paste simulation and window positioning services. Requires the Clipman daemon (clipman.service) to be running.",
     "shell-version": ["45", "46", "47", "48"],
-    "version": 4,
+    "version": 5,
     "url": "https://github.com/MohammedEl-sayedAhmed/clipman",
     "donations": {
         "paypal": "mohammedelsayedammar"

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -1,0 +1,260 @@
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from clipman import keybindings
+
+
+class TestFormatBindingForDisplay(unittest.TestCase):
+    def test_super_v(self):
+        self.assertEqual(
+            keybindings.format_binding_for_display("<Super>v"), "Super+V"
+        )
+
+    def test_ctrl_shift_v(self):
+        self.assertEqual(
+            keybindings.format_binding_for_display("<Ctrl><Shift>v"),
+            "Ctrl+Shift+V",
+        )
+
+    def test_shift_insert(self):
+        self.assertEqual(
+            keybindings.format_binding_for_display("<Shift>Insert"),
+            "Shift+Insert",
+        )
+
+    def test_super_only(self):
+        self.assertEqual(
+            keybindings.format_binding_for_display("<Super>"), "Super"
+        )
+
+    def test_empty(self):
+        self.assertEqual(keybindings.format_binding_for_display(""), "")
+
+    def test_no_modifiers_single_letter_uppercased(self):
+        self.assertEqual(keybindings.format_binding_for_display("a"), "A")
+
+    def test_multichar_keyname_titled(self):
+        self.assertEqual(
+            keybindings.format_binding_for_display("<Ctrl>F1"),
+            "Ctrl+F1",
+        )
+
+
+class TestIsClipmanBindingRegistered(unittest.TestCase):
+    def test_registered_list_contains_clipman_path(self):
+        out = (
+            "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/clipman/']"
+        )
+        with patch("clipman.keybindings._gsettings_get", return_value=out):
+            self.assertTrue(keybindings.is_clipman_binding_registered())
+
+    def test_registered_in_multi_path_list(self):
+        out = (
+            "['/org/.../custom-keybindings/other/', "
+            "'/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/clipman/']"
+        )
+        with patch("clipman.keybindings._gsettings_get", return_value=out):
+            self.assertTrue(keybindings.is_clipman_binding_registered())
+
+    def test_not_registered_empty_list(self):
+        with patch("clipman.keybindings._gsettings_get", return_value="@as []"):
+            self.assertFalse(keybindings.is_clipman_binding_registered())
+
+    def test_not_registered_other_paths_only(self):
+        out = "['/org/.../custom-keybindings/other/']"
+        with patch("clipman.keybindings._gsettings_get", return_value=out):
+            self.assertFalse(keybindings.is_clipman_binding_registered())
+
+    def test_gsettings_unavailable(self):
+        with patch("clipman.keybindings._gsettings_get", return_value=None):
+            self.assertFalse(keybindings.is_clipman_binding_registered())
+
+    def test_garbage_output(self):
+        with patch("clipman.keybindings._gsettings_get", return_value="not parseable"):
+            self.assertFalse(keybindings.is_clipman_binding_registered())
+
+
+class TestGetSetToggleBinding(unittest.TestCase):
+    def test_get_strips_quotes_and_whitespace(self):
+        with patch("clipman.keybindings._gsettings_get", return_value="  '<Super>v'  "):
+            self.assertEqual(keybindings.get_toggle_binding(), "<Super>v")
+
+    def test_get_returns_none_when_unavailable(self):
+        with patch("clipman.keybindings._gsettings_get", return_value=None):
+            self.assertIsNone(keybindings.get_toggle_binding())
+
+    def test_set_passes_quoted_binding_to_gsettings(self):
+        with patch("clipman.keybindings._gsettings_set", return_value=True) as mset:
+            self.assertTrue(keybindings.set_toggle_binding("<Shift><Super>v"))
+            mset.assert_called_once_with(
+                keybindings.CUSTOM_KEY_SUBSCHEMA,
+                "binding",
+                "'<Shift><Super>v'",
+                path=keybindings.CUSTOM_KEY_PATH,
+            )
+
+    def test_set_returns_false_on_failure(self):
+        with patch("clipman.keybindings._gsettings_set", return_value=False):
+            self.assertFalse(keybindings.set_toggle_binding("<Super>v"))
+
+
+class TestGsettingsShellouts(unittest.TestCase):
+    @patch("clipman.keybindings.subprocess.check_output")
+    def test_get_uses_path_suffix_when_provided(self, mock_check):
+        mock_check.return_value = "'<Super>v'\n"
+        keybindings._gsettings_get(
+            keybindings.CUSTOM_KEY_SUBSCHEMA, "binding",
+            path=keybindings.CUSTOM_KEY_PATH,
+        )
+        cmd = mock_check.call_args[0][0]
+        self.assertEqual(cmd[0:2], ["gsettings", "get"])
+        self.assertTrue(cmd[2].endswith(":" + keybindings.CUSTOM_KEY_PATH))
+        self.assertEqual(cmd[3], "binding")
+
+    @patch("clipman.keybindings.subprocess.check_output")
+    def test_get_returns_none_when_gsettings_missing(self, mock_check):
+        mock_check.side_effect = FileNotFoundError("no gsettings")
+        self.assertIsNone(
+            keybindings._gsettings_get(keybindings.CUSTOM_KEYS_SCHEMA, "x")
+        )
+
+    @patch("clipman.keybindings.subprocess.check_output")
+    def test_get_returns_none_on_timeout(self, mock_check):
+        mock_check.side_effect = subprocess.TimeoutExpired(cmd="gsettings", timeout=5)
+        self.assertIsNone(
+            keybindings._gsettings_get(keybindings.CUSTOM_KEYS_SCHEMA, "x")
+        )
+
+    @patch("clipman.keybindings.subprocess.check_call")
+    def test_set_returns_true_on_success(self, mock_call):
+        mock_call.return_value = 0
+        self.assertTrue(
+            keybindings._gsettings_set(
+                keybindings.CUSTOM_KEY_SUBSCHEMA, "binding", "'<Super>v'",
+                path=keybindings.CUSTOM_KEY_PATH,
+            )
+        )
+
+    @patch("clipman.keybindings.subprocess.check_call")
+    def test_set_returns_false_on_nonzero_exit(self, mock_call):
+        mock_call.side_effect = subprocess.CalledProcessError(1, "gsettings")
+        self.assertFalse(
+            keybindings._gsettings_set(
+                keybindings.CUSTOM_KEY_SUBSCHEMA, "binding", "'<Super>v'",
+                path=keybindings.CUSTOM_KEY_PATH,
+            )
+        )
+
+
+class TestKeyvalToBinding(unittest.TestCase):
+    """Use a stub Gdk so the test doesn't require gi at import time."""
+
+    def setUp(self):
+        # Inject a fake gi.repository.Gdk into sys.modules so the
+        # local-import inside keyval_to_binding picks it up.
+        import sys
+        import types
+
+        gi_mod = types.ModuleType("gi")
+        repo_mod = types.ModuleType("gi.repository")
+        gdk_mod = types.ModuleType("gi.repository.Gdk")
+
+        class _ModifierType:
+            CONTROL_MASK = 1 << 2
+            SHIFT_MASK = 1 << 0
+            MOD1_MASK = 1 << 3      # Alt
+            SUPER_MASK = 1 << 26
+
+        # Map of fake keyval -> name; only fixtures we use in tests.
+        _KEYVAL_NAMES = {
+            0x76: "v",
+            0xff63: "Insert",
+            0xffbe: "F1",
+            0xffe1: "Shift_L",
+            0xffe3: "Control_L",
+        }
+
+        def _keyval_name(keyval):
+            return _KEYVAL_NAMES.get(keyval)
+
+        gdk_mod.ModifierType = _ModifierType
+        gdk_mod.keyval_name = _keyval_name
+
+        sys.modules["gi"] = gi_mod
+        sys.modules["gi.repository"] = repo_mod
+        sys.modules["gi.repository.Gdk"] = gdk_mod
+        repo_mod.Gdk = gdk_mod
+        gi_mod.repository = repo_mod
+
+        self._ModifierType = _ModifierType
+        self.addCleanup(self._restore)
+        self._original = {
+            "gi": sys.modules.get("gi"),
+            "gi.repository": sys.modules.get("gi.repository"),
+            "gi.repository.Gdk": sys.modules.get("gi.repository.Gdk"),
+        }
+
+    def _restore(self):
+        import sys
+        for k, v in self._original.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+    def test_super_v(self):
+        m = self._ModifierType.SUPER_MASK
+        self.assertEqual(keybindings.keyval_to_binding(0x76, m), "<Super>v")
+
+    def test_ctrl_shift_v(self):
+        m = self._ModifierType.CONTROL_MASK | self._ModifierType.SHIFT_MASK
+        self.assertEqual(keybindings.keyval_to_binding(0x76, m), "<Ctrl><Shift>v")
+
+    def test_shift_insert(self):
+        m = self._ModifierType.SHIFT_MASK
+        self.assertEqual(
+            keybindings.keyval_to_binding(0xff63, m), "<Shift>Insert"
+        )
+
+    def test_rejects_pure_modifier_key(self):
+        m = self._ModifierType.SHIFT_MASK
+        self.assertIsNone(keybindings.keyval_to_binding(0xffe1, m))
+
+    def test_rejects_no_modifier(self):
+        self.assertIsNone(keybindings.keyval_to_binding(0x76, 0))
+
+    def test_rejects_unknown_keyval(self):
+        m = self._ModifierType.SUPER_MASK
+        self.assertIsNone(keybindings.keyval_to_binding(0xdeadbeef, m))
+
+    def test_alt_plus_function_key(self):
+        m = self._ModifierType.MOD1_MASK  # Alt
+        self.assertEqual(keybindings.keyval_to_binding(0xffbe, m), "<Alt>F1")
+
+    def test_all_four_modifiers(self):
+        m = (self._ModifierType.CONTROL_MASK
+             | self._ModifierType.SHIFT_MASK
+             | self._ModifierType.MOD1_MASK
+             | self._ModifierType.SUPER_MASK)
+        self.assertEqual(
+            keybindings.keyval_to_binding(0x76, m),
+            "<Ctrl><Super><Alt><Shift>v",
+        )
+
+    def test_round_trip_super_v(self):
+        # keyval_to_binding(...) → format_binding_for_display(...)
+        m = self._ModifierType.SUPER_MASK
+        b = keybindings.keyval_to_binding(0x76, m)
+        self.assertEqual(keybindings.format_binding_for_display(b), "Super+V")
+
+    def test_round_trip_ctrl_shift_v(self):
+        m = self._ModifierType.CONTROL_MASK | self._ModifierType.SHIFT_MASK
+        b = keybindings.keyval_to_binding(0x76, m)
+        self.assertEqual(
+            keybindings.format_binding_for_display(b), "Ctrl+Shift+V"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two new rows in the in-app settings panel — one for the GNOME toggle shortcut, one for the paste keystroke — addressing both open shortcut-related issues.

Closes #4 (Toggle-shortcut customization, default kept as Super+V per maintainer direction).
Closes #7 (Shift+Insert paste option).

## Changes

### `clipman/window.py`
- Two new settings rows after "Sensitive auto-clear":
  - **Toggle shortcut** — button shows current keystroke (`Super+V` by default). Clicking opens `_ShortcutCaptureDialog`, a modal that captures the next valid combo. Requires at least one modifier (Ctrl/Super/Alt/Shift) and rejects pure-modifier presses. On Save, writes to `gsettings` + persists `toggle_shortcut` in the settings table.
  - **Paste keystroke** — `Gtk.ComboBoxText` with four modes:
    | Mode | Behavior |
    |------|----------|
    | `auto` | Default — Ctrl+V everywhere, Ctrl+Shift+V on terminals (current behavior) |
    | `ctrl-v` | Force Ctrl+V regardless of focus |
    | `ctrl-shift-v` | Force Ctrl+Shift+V regardless of focus |
    | `shift-insert` | Shift+Insert (X11/terminal convention — issue #7) |
- `_simulate_paste` reads `_paste_mode` and passes it to the extension; catches `DBusException` and retries with the old no-arg signature for **backward compatibility** with an unupgraded extension build.
- `_show_shortcut_error` surfaces a friendly `Gtk.MessageDialog` if `gsettings` writes fail (e.g., PyPI install that never ran `install.sh` to register the keybinding).

### `clipman/keybindings.py` (new)
- gsettings shell-out helpers (`_gsettings_get`, `_gsettings_set`) with timeouts and `FileNotFoundError` handling for environments without gsettings.
- `format_binding_for_display(binding)` — `'<Super><Shift>v'` → `'Super+Shift+V'`.
- `keyval_to_binding(keyval, state)` — converts a GTK key event to gsettings syntax; returns `None` on invalid input (pure modifier, no modifier, unknown keyval).
- `is_clipman_binding_registered()` — checks whether the user's GNOME has a clipman entry in `custom-keybindings` (so the UI can refuse silently failing).
- Public API kept thin; module lives separately so tests don't need GTK.

### `extension/extension.js`
- D-Bus method signature changed from `SimulatePaste()` to `SimulatePaste(s mode)`.
- Refactored into `_resolveRecipe(mode)` + `_dispatchKeystroke(recipe)` — pure mapping from mode → keystroke recipe, no branching inline.
- `'auto'` (or unknown mode) keeps the existing terminal-wm-class detection.

### `extension/metadata.json`
- `version` bumped 4 → 5 to reflect the D-Bus signature change.

### `CHANGELOG.md`
- New `## [Unreleased]` section documenting both features.

## Closes

- Closes #4
- Closes #7

## Tests

### Added in this PR — `tests/test_keybindings.py` (30 unit tests)

| Class | Coverage |
|-------|----------|
| `TestFormatBindingForDisplay` | 7 tests: Super+V, Ctrl+Shift+V, Shift+Insert, modifier-only, empty input, no-modifier single-letter, multi-char keyname (`F1`) |
| `TestIsClipmanBindingRegistered` | 6 tests: present (single), present (multi-path), absent (`@as []`), absent (other paths only), gsettings unavailable, garbage output |
| `TestGetSetToggleBinding` | 4 tests: quote-stripping on get, get returns None when gsettings absent, set passes quoted binding to gsettings, set returns False on failure |
| `TestGsettingsShellouts` | 5 tests: path-suffix construction, missing gsettings binary, timeout, success return-True, non-zero exit return-False |
| `TestKeyvalToBinding` | 8 tests: Super+V, Ctrl+Shift+V, Shift+Insert, pure-modifier rejected, no-modifier rejected, unknown keyval rejected, Alt+F1, all-four-modifiers, two round-trip tests |

Full suite goes from 233 → 265 tests; all pass on local Python 3.12 + system PyGObject.

### Brainstorm — broader test gaps (out of scope here, suggested follow-ups)

These weren't added because they need infrastructure this repo doesn't have yet. Listing here so they're not lost.

**UI / window.py tests** (no existing coverage):
- T1 — `paste_mode` defaults to `auto` when DB is empty.
- T2 — Invalid `paste_mode` in DB falls back to `auto`.
- T3 — Changing the ComboBox persists `paste_mode` to DB.
- T4 — `_simulate_paste` with `paste_mode='shift-insert'` calls `SimulatePaste('shift-insert')`.
- T5 — `_simulate_paste` retries with no-arg when the extension raises `DBusException`.
- T6 — Capture dialog rejects pure modifier presses (Save remains disabled).
- T7 — Capture dialog rejects modifier-less keys.
- T8 — Capture dialog accepts valid combo, Save becomes enabled.
- T9 — Save with captured combo updates `gsettings` + DB.
- T10 — gsettings failure path opens the error dialog and does not update DB.

Implementation note: `ClipmanWindow.__init__` builds the full GTK tree, so unit-testing requires either (a) Xvfb in CI, (b) factoring the settings-load and paste-dispatch logic out of `__init__` into a pure helper, or (c) heavy `unittest.mock` patching of Gdk/Gtk before import.

**GNOME Shell extension tests** (no existing coverage):
- JS T1 — `'auto'` on non-terminal `wm_class` resolves to `ctrl-v` recipe.
- JS T2 — `'auto'` on `gnome-terminal-server` resolves to `ctrl-shift-v` recipe.
- JS T3 — `'shift-insert'` resolves to `shift-insert` recipe regardless of focus.
- JS T4 — Unknown mode falls back to `auto` behavior (not a crash).
- JS T5 — `_dispatchKeystroke` emits modifiers in press-order and reverse release-order.

The codeql workflow already catches some classes of JS bugs (e.g., null deref on `focusWin?.get_wm_class()`). A full unit suite would need a JS test runner (jest / mocha) + mocks for `Clutter`, `Gio`, etc. Probably not worth standing up for ~200 LOC of extension code; manual smoke-test in the PR plan below covers it.

**Manual smoke-test plan (run before merge)**

1. `python3 -m unittest discover -s tests` — confirm 265 tests pass.
2. Source-install on a real GNOME 47/48 Wayland session: `./install.sh && python3 clipman.py &`.
3. Press Super+V → window opens.
4. Open ⚙ Settings panel → confirm both new rows appear.
5. **Toggle shortcut**: click the shortcut button → press `Ctrl+Shift+V` → Save → modal closes, button label updates to `Ctrl+Shift+V`. Close the window. Press `Ctrl+Shift+V` from anywhere — window re-opens.
6. **Paste keystroke**: change ComboBox to `Shift+Insert`. Copy a string. Reopen Clipman. Focus a terminal (e.g., `kitty`). Click the entry → terminal receives the paste via Shift+Insert (verify with a test program if needed).
7. **Backward compat**: temporarily downgrade the extension to v4 (revert `extension/`), restart GNOME Shell, run the new daemon → paste should still work via the no-arg fallback.

## Type of change

- [x] New feature
- [x] Tests added

## Follow-ups noted (deliberately out of scope)

- After this lands, cut **v1.0.5**: bump `pyproject.toml` + `snap/snapcraft.yaml`, publish the v5 extension to extensions.gnome.org (closes #6 as a side effect), publish to PyPI/Snap.
- Add the UI-level tests listed in the brainstorm once Stream C (release automation) and a refactor of `window.py.__init__` for testability land.
- Consider a "Reset to default" button on the shortcut row (low priority).