### PR TITLE
ci(codeql): add security-baseline ratchet so pre-existing findings don't block PRs

### DIFF
--- a/.github/workflows/baseline-guard.yml
+++ b/.github/workflows/baseline-guard.yml
@@ -1,0 +1,82 @@
+name: Baseline guard
+
+# Auto-reverts unauthorized pushes to the security-baseline branch
+# and opens a security issue. The branch is meant to be modified
+# only by the update-baseline job in codeql.yml.
+
+on:
+  push:
+    branches: [security-baseline]
+
+permissions: {}
+
+concurrency:
+  group: baseline-guard
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Validate baseline push
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout security-baseline (with previous commit)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: security-baseline
+          fetch-depth: 2
+
+      - name: Revert the unauthorized push
+        env:
+          GH_COMMIT_AUTHOR: github-actions[bot]
+          GH_COMMIT_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          git config user.name "$GH_COMMIT_AUTHOR"
+          git config user.email "$GH_COMMIT_EMAIL"
+          git revert --no-edit HEAD
+          git push origin HEAD:security-baseline
+
+      - name: Open alert issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "[security] Unauthorized push to security-baseline reverted" \
+            --label "type:security,priority:high" \
+            --body "$(cat <<EOF
+          ## Unauthorized baseline modification
+
+          | Field | Value |
+          |-------|-------|
+          | Actor | \`${{ github.actor }}\` |
+          | Commit | [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}) |
+          | Timestamp | \`${{ github.event.head_commit.timestamp }}\` |
+
+          The push was **automatically reverted**.
+
+          The \`security-baseline\` branch is maintained exclusively by
+          the \`update-baseline\` job in \`.github/workflows/codeql.yml\`,
+          which runs after every push to \`main\`. Manual edits would
+          silently mask new CodeQL findings the ratchet check is meant
+          to catch.
+
+          ### Action required
+
+          - Investigate whether this was accidental or intentional.
+          - Review any recent merge for hidden regressions that would
+            now slip past the ratchet.
+          - If a baseline change is genuinely needed (e.g., a known
+            false positive needs whitelisting), do it via a PR that
+            modifies the rule set in \`.github/codeql/\` or the suppression
+            mechanism rather than rewriting the baseline directly.
+          EOF
+          )"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,192 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
+        id: analyze
         uses: github/codeql-action/analyze@6825d5659bf007b85a0866e2d0f434aacf50de94 # v3.27.5
         with:
           category: "/language:${{ matrix.language }}"
+          output: ./codeql-results
+          upload: always
+
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: ./codeql-results
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Fetch security baseline
+        run: |
+          git fetch origin security-baseline --depth=1 2>/dev/null && \
+            git show origin/security-baseline:.github/security-baseline.json \
+              > /tmp/security-baseline.json || \
+            echo '{"codeql":{"fingerprints":[]}}' > /tmp/security-baseline.json
+          echo "::group::Loaded baseline"
+          cat /tmp/security-baseline.json
+          echo "::endgroup::"
+
+      - name: Ratchet against baseline (${{ matrix.language }})
+        env:
+          MATRIX_LANGUAGE: ${{ matrix.language }}
+        run: |
+          python3 <<'PYEOF'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          lang = os.environ["MATRIX_LANGUAGE"]
+
+          # 1. Load baseline
+          with open("/tmp/security-baseline.json") as f:
+              baseline = json.load(f)
+          known = set(baseline.get("codeql", {}).get("fingerprints", []))
+
+          # 2. Locate SARIF outputs
+          sarif_dir = Path("./codeql-results")
+          sarif_files = sorted(sarif_dir.glob("*.sarif"))
+          if not sarif_files:
+              print(f"::warning::No SARIF produced for {lang}; skipping ratchet")
+              sys.exit(0)
+
+          # 3. Extract fingerprints from current scan
+          current = set()
+          for sf in sarif_files:
+              with open(sf) as f:
+                  doc = json.load(f)
+              for run in doc.get("runs", []):
+                  for result in run.get("results", []):
+                      rule = result.get("ruleId", "?")
+                      for loc in result.get("locations", []):
+                          phys = loc.get("physicalLocation", {})
+                          path = phys.get("artifactLocation", {}).get("uri", "?")
+                          line = phys.get("region", {}).get("startLine", "?")
+                          current.add(f"{rule}:{path}:{line}")
+
+          # 4. Diff
+          new_findings = current - known
+          resolved = known - current
+
+          print(f"::notice::Language: {lang}")
+          print(f"::notice::Baseline known fingerprints: {len(known)}")
+          print(f"::notice::Current scan fingerprints:  {len(current)}")
+          print(f"::notice::New (this PR):              {len(new_findings)}")
+          print(f"::notice::Resolved/moved:             {len(resolved)}")
+
+          if new_findings:
+              print()
+              print("New CodeQL findings introduced by this change:")
+              for fp in sorted(new_findings):
+                  rule, path, line = fp.split(":", 2)
+                  print(f"  - [{rule}] {path}:{line}")
+                  print(
+                      f"::error file={path},line={line}::"
+                      f"[{rule}] New CodeQL finding (not in baseline)"
+                  )
+              print()
+              print(
+                  f"::error::This PR introduces {len(new_findings)} new "
+                  f"CodeQL finding(s) for {lang} beyond the security "
+                  f"baseline. Either fix the finding(s) or, if intentional, "
+                  f"have a maintainer update .github/security-baseline.json "
+                  f"on the security-baseline branch."
+              )
+              sys.exit(1)
+
+          print()
+          print("Ratchet PASS: no new findings beyond baseline.")
+          PYEOF
+
+  update-baseline:
+    name: Update baseline on push to main
+    needs: analyze
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout security-baseline
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: security-baseline
+          fetch-depth: 1
+
+      - name: Download Python SARIF
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: codeql-sarif-python
+          path: ./sarif-python
+
+      - name: Download JavaScript SARIF
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: codeql-sarif-javascript
+          path: ./sarif-javascript
+
+      - name: Rebuild baseline from current SARIF
+        run: |
+          python3 <<'PYEOF'
+          import json
+          from datetime import date
+          from pathlib import Path
+
+          fps = set()
+          for sf in list(Path("./sarif-python").rglob("*.sarif")) + \
+                   list(Path("./sarif-javascript").rglob("*.sarif")):
+              with open(sf) as f:
+                  doc = json.load(f)
+              for run in doc.get("runs", []):
+                  for result in run.get("results", []):
+                      rule = result.get("ruleId", "?")
+                      for loc in result.get("locations", []):
+                          phys = loc.get("physicalLocation", {})
+                          path = phys.get("artifactLocation", {}).get("uri", "?")
+                          line = phys.get("region", {}).get("startLine", "?")
+                          fps.add(f"{rule}:{path}:{line}")
+
+          out = {
+              "schema_version": 1,
+              "updated": date.today().isoformat(),
+              "description": (
+                  "Known-finding fingerprints from main. PR scans compare "
+                  "to this snapshot; new fingerprints fail the ratchet "
+                  "job. Maintained by the codeql update-baseline job on "
+                  "push to main; manual pushes are reverted by "
+                  "baseline-guard.yml."
+              ),
+              "codeql": {
+                  "count": len(fps),
+                  "fingerprints": sorted(fps),
+              },
+          }
+          with open(".github/security-baseline.json", "w") as f:
+              json.dump(out, f, indent=2)
+              f.write("\n")
+          PYEOF
+
+      - name: Commit and push if changed
+        env:
+          GH_COMMIT_AUTHOR: github-actions[bot]
+          GH_COMMIT_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          if git diff --quiet .github/security-baseline.json; then
+            echo "Baseline unchanged; nothing to push."
+            exit 0
+          fi
+          git config user.name "$GH_COMMIT_AUTHOR"
+          git config user.email "$GH_COMMIT_EMAIL"
+          git add .github/security-baseline.json
+          git commit -m "chore(baseline): refresh from main @ ${GITHUB_SHA::7}
+
+          Auto-updated by codeql.yml update-baseline job after the
+          merge of ${{ github.event.head_commit.message }}.
+          "
+          git push origin HEAD:security-baseline


### PR DESCRIPTION
## Summary

CodeQL's `security-and-quality` suite surfaces 18 informational findings on `main` (mostly intentional best-effort `except: pass`, plus cyclic imports and module-level prints). They're not defects to block PRs over, but right now they appear as Copilot Autofix annotations on every PR's Files-changed tab, masking genuinely-new findings.

This PR adds a **baseline-ratchet** pattern: a PR fails CodeQL **only if it introduces fingerprints not already in the baseline**.

## Architecture

```mermaid
flowchart LR
    classDef pr fill:#dbeafe,stroke:#3b82f6,color:#1e40af
    classDef main fill:#dcfce7,stroke:#16a34a,color:#166534
    classDef baseline fill:#fef3c7,stroke:#d97706,color:#92400e
    classDef guard fill:#fee2e2,stroke:#dc2626,color:#991b1b

    PR["PR opened / updated"]:::pr
    PRRun["codeql.yml: analyze + ratchet"]:::pr
    BL[".github/security-baseline.json<br/>(on security-baseline branch)"]:::baseline
    FAIL["FAIL: new fingerprints"]:::pr
    PASS["PASS: current ⊆ baseline"]:::pr

    PR --> PRRun
    BL --> PRRun
    PRRun -- "current - baseline = ∅" --> PASS
    PRRun -- "current - baseline > ∅" --> FAIL

    Main["push to main"]:::main
    MainRun["codeql.yml: analyze + update-baseline"]:::main
    Main --> MainRun
    MainRun -- "rebuild fingerprints from SARIF" --> BL

    Push["push to security-baseline"]:::guard
    Guard["baseline-guard.yml"]:::guard
    Push --> Guard
    Guard -- "actor != bot? revert + open issue" --> BL
```

## Mechanics

### `.github/security-baseline.json` (on dedicated `security-baseline` orphan branch)

Stable on-disk format:

```json
{
  "schema_version": 1,
  "updated": "2026-05-20",
  "codeql": {
    "count": 18,
    "fingerprints": [
      "py/empty-except:clipman/window.py:781",
      "py/cyclic-import:clipman/app.py:12",
      ...
    ]
  }
}
```

Fingerprint format: `<rule-id>:<path>:<startLine>`. Stored as a sorted list for deterministic diffs.

### `.github/workflows/codeql.yml` (modified)

1. **`analyze`** job (existing) — now writes SARIF to `./codeql-results` and uploads it as an artifact for the `update-baseline` job.
2. **`analyze`** gains a **Ratchet** step that parses the SARIF, extracts fingerprints, fetches the baseline from `origin/security-baseline`, and fails the job iff `current - baseline ≠ ∅`. Each new finding is emitted as a `::error file=...` annotation so the PR's Files-changed tab shows the exact location.
3. **`update-baseline`** job (new) — only runs on `push: main`. Downloads both Python and JavaScript SARIFs, rebuilds the fingerprint set from scratch, commits the refreshed baseline back to the `security-baseline` branch as `github-actions[bot]`.

### `.github/workflows/baseline-guard.yml` (new)

Triggers on `push: security-baseline`. If the actor isn't `github-actions[bot]`, it auto-reverts the push and opens a labeled (`type:security`, `priority:high`) issue. Without this, anyone with write access could silently zero out the baseline and mask future regressions.

## Trade-offs

| Concern | Mitigation |
|---------|------------|
| Line numbers in fingerprints — unrelated edits that shift lines look like "new findings" | When this PR merges to main, `update-baseline` immediately refreshes the baseline. PRs opened against the older baseline can rebase to pick up the new lines. |
| Per-matrix runs see the full multi-language baseline | Intentional. A new Python finding is flagged by the Python job even though the baseline contains JS fingerprints. False "resolved" entries for the other language are informational only. |
| Drift between SARIF fingerprints and `code-scanning/alerts` API IDs | We use the SARIF directly (deterministic, available immediately), not the alerts API (eventual consistency after upload). |
| What if someone *needs* a finding suppressed? | Two paths: (a) fix the finding (preferred), (b) merge a PR that legitimately adds a `# noqa: <rule>` comment or a CodeQL rule-suppression file under `.github/codeql/`. Editing `security-baseline.json` directly is blocked by the guard. |

## What's NOT in this PR

- The 18 existing findings stay flagged in the GitHub Security tab. The ratchet only affects PR pass/fail behavior; it doesn't dismiss anything. If you want them silenced from the Security view, that's a separate change (per-finding "dismiss as won't fix" via the UI, or rule-level suppression).
- The required-status-checks list on `main` still only requires `Analyze (python)` / `Analyze (javascript)`. Since the ratchet runs as a step inside those jobs, those checks already cover it — no branch-protection update needed.

## Type of change

- [x] Build / CI / packaging
- [x] Security

## Testing

This PR is itself the first exercise of the ratchet. Expected behavior:
1. Ratchet steps run on Python + JavaScript matrix.
2. Since this PR doesn't touch any analyzed source files, current scan results should match the baseline → both ratchet steps PASS.
3. Once merged, the `update-baseline` job runs and updates the baseline on the `security-baseline` branch (no-op if the fingerprints haven't changed).

If you want to deliberately exercise the FAIL path, open a follow-up PR that introduces a new `except: pass` block in `clipman/` and watch the Python ratchet flag it.