### PR TITLE
docs: add ADRs + expand changelog + release-notes structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,49 @@ All notable changes to Clipman are documented in this file.
   daemon remains compatible with an unupgraded extension.
 - `extension/metadata.json`: bumped to version 5.
 
+### Internal / CI
+
+#### Added
+- **CI/security baseline** (#8): Dependabot for `pip` and
+  `github-actions` (weekly, labeled `dependencies`/`python`/`ci`);
+  CodeQL for Python and JavaScript with the `security-and-quality`
+  suite (weekly + on PR/push); ruff on `clipman/` and `tests/`;
+  shellcheck on `install.sh`/`uninstall.sh`/`launcher.sh`; gitleaks
+  secret scan on PR/push; `SECURITY.md` with the private-disclosure
+  policy; PR template + issue forms (bug, feature, and a config that
+  routes security reports through GitHub Security Advisories).
+- **Weekly Snap Store rebuild** (#9): `snap-refresh.yml` rebuilds and
+  re-publishes the Snap on a weekly cron so the published artifact
+  always carries the latest security patches for its base + python
+  layer, even when no code changed in this repo.
+- **Tag-triggered release automation** (#16): `release.yml` builds
+  and publishes a tagged release end-to-end — pre-flight sanity
+  checks (tag matches `pyproject.toml` and `snap/snapcraft.yaml`,
+  CHANGELOG has a matching section), full test matrix
+  (Python 3.10 / 3.11 / 3.12), PyPI publish via OIDC trusted
+  publishing (no long-lived token), Snap publish to the stable
+  channel, versioned GNOME extension bundle, and a GitHub Release
+  with all artifacts attached and the body extracted from
+  `CHANGELOG.md`. See `docs/releases/README.md` and ADR 0004.
+- **CodeQL security-baseline ratchet** (#17): a PR fails CodeQL only
+  if it introduces fingerprints not already in the on-disk baseline.
+  Baseline lives on the `security-baseline` orphan branch, is
+  refreshed automatically on `push: main`, and is protected against
+  manual tampering by `baseline-guard.yml` (auto-revert + open
+  issue). See ADR 0002.
+
+#### Changed
+- **Dependabot bumps**: `actions/labeler` 5.0.0 → 6.1.0 (#10),
+  pinned to commit SHA per the project's supply-chain policy
+  (ADR 0003).
+
+#### Docs
+- Added `docs/adr/` with the first six MADR-format ADRs covering
+  the decisions behind PRs #8, #15, #16, and #17 plus the project's
+  branch-protection posture. See `docs/adr/README.md` for the index.
+- Added `docs/releases/README.md` documenting where release notes
+  live and how the release pipeline assembles them.
+
 ## [1.0.4] - 2026-02-28
 
 ### Fixed

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,54 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 1. Record architecture decisions
+
+## Context
+
+Clipman has accumulated several non-obvious choices in its CI, packaging,
+and IPC layers (CodeQL baseline ratchet, OIDC-based PyPI publishing,
+D-Bus interface design, etc.). Without a written record, every revisit
+of those areas re-litigates the same trade-offs and risks reversing
+intentional choices.
+
+We need a lightweight, in-repo home for those decisions that:
+
+- lives next to the code (so it travels with the repo and is reviewed
+  in the same PR flow);
+- is short, readable, and easy to add to;
+- doesn't require a separate tool or static-site generator.
+
+## Decision
+
+Adopt [MADR](https://adr.github.io/madr/) (Markdown Architecture
+Decision Records) for all significant architecture and infrastructure
+decisions.
+
+- Records live under `docs/adr/`.
+- File names follow `NNNN-kebab-case-title.md`, monotonically numbered.
+- Each record has YAML frontmatter (`status`, `date`, `deciders`) and
+  three sections: **Context**, **Decision**, **Consequences**.
+- Status values: `Proposed`, `Accepted`, `Deprecated`, `Superseded by
+  NNNN`. Once a record is `Accepted`, do not edit the original;
+  supersede it with a new ADR that links back.
+- `docs/adr/README.md` is the index, with one-line summaries.
+
+## Consequences
+
+**Positive**
+
+- Reviewers and future maintainers get the "why" inline with the code.
+- Each non-trivial PR can cite an ADR instead of repeating rationale
+  in the PR body.
+- The index doubles as onboarding documentation for the project's
+  CI/security posture.
+
+**Negative**
+
+- Every architecturally significant PR now carries a small extra cost:
+  authoring or amending an ADR.
+- Records can drift from reality if not maintained; the `Superseded by`
+  status is the only way to deprecate, which requires discipline.

--- a/docs/adr/0002-baseline-ratchet-for-codeql.md
+++ b/docs/adr/0002-baseline-ratchet-for-codeql.md
@@ -1,0 +1,85 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 2. Baseline-ratchet pattern for CodeQL findings
+
+## Context
+
+CodeQL's `security-and-quality` suite surfaces ~18 informational
+findings on `main` (best-effort `except: pass` blocks, cyclic imports,
+module-level prints). They are intentional and not defects.
+
+Without intervention these findings appeared as Copilot Autofix
+annotations on every PR's *Files changed* tab, including PRs that did
+not touch the affected files. This drowned out any *new* finding a PR
+might introduce and trained reviewers to ignore the annotations
+altogether — exactly the failure mode the scanner is meant to prevent.
+
+Options considered:
+
+1. **Dismiss each finding individually** via the GitHub Security UI.
+   Loses provenance, scales poorly, and per-finding dismissals don't
+   re-trigger if the rule version changes.
+2. **Rule-level suppression** (e.g. ban the rule from the suite).
+   Too coarse: a future genuine `py/empty-except` regression would
+   also be silenced.
+3. **A baseline-ratchet**: persist a fingerprint set of findings that
+   exist on `main` and fail a PR only if it adds fingerprints not in
+   that set.
+
+## Decision
+
+Implement the baseline-ratchet (option 3) with three pieces:
+
+- **`.github/security-baseline.json`** lives on a dedicated orphan
+  branch `security-baseline`. Fingerprint format:
+  `<rule-id>:<path>:<startLine>`. Stored as a sorted list for
+  deterministic diffs.
+- **`.github/workflows/codeql.yml`** — the existing `analyze` job
+  gains a `Ratchet` step that parses SARIF, compares against the
+  baseline, and fails iff `current - baseline ≠ ∅`. A new
+  `update-baseline` job runs on `push: main`, rebuilds fingerprints
+  from the fresh SARIF, and commits the refreshed baseline back to
+  the `security-baseline` branch as `github-actions[bot]`.
+- **`.github/workflows/baseline-guard.yml`** — triggers on
+  `push: security-baseline`. If the actor is not
+  `github-actions[bot]`, the workflow auto-reverts the push and opens
+  a labeled (`type:security`, `priority:high`) issue. Without this,
+  anyone with write access could silently zero out the baseline.
+
+Pre-existing findings remain visible in the Security tab. The ratchet
+only governs PR pass/fail.
+
+## Consequences
+
+**Positive**
+
+- New CodeQL findings introduced by a PR are flagged in the
+  *Files changed* tab and block the merge.
+- Pre-existing findings stop generating annotation noise on unrelated
+  PRs.
+- The baseline cannot be tampered with silently — the guard workflow
+  reverts and surfaces the attempt.
+
+**Negative / trade-offs**
+
+- **Line-drift fragility.** Fingerprints encode line numbers, so an
+  unrelated edit above an existing finding shifts the line and looks
+  like a "new" finding. Mitigation: `update-baseline` refreshes the
+  baseline as soon as the line-shifting PR merges, so subsequent PRs
+  rebase to pick up the new lines. In practice this means the first
+  PR after a refactor may need a rebase, not a code change.
+- The fingerprint format is internal to this repo; if CodeQL changes
+  its SARIF schema in a way that affects rule IDs or paths, the
+  baseline becomes wrong en masse and must be rebuilt by running the
+  `update-baseline` job manually.
+- Per-matrix runs (Python, JavaScript) each see the *full*
+  multi-language baseline, which means a Python ratchet step shows
+  "resolved" entries that are JS-only. This is informational and was
+  deemed acceptable to keep the workflow simple.
+
+Supersedes nothing; ADR 0003 (SHA-pinning) and 0006 (branch
+protection) reinforce the same posture from different angles.

--- a/docs/adr/0003-sha-pin-github-actions.md
+++ b/docs/adr/0003-sha-pin-github-actions.md
@@ -1,0 +1,65 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 3. Pin all third-party GitHub Actions to commit SHAs
+
+## Context
+
+GitHub Actions referenced by mutable tags (`@v4`, `@main`) are a known
+supply-chain attack vector: a compromised maintainer account or a
+force-pushed tag can swap the action's code without changing the
+reference in this repo, and the malicious version runs with the same
+permissions as the original.
+
+OWASP's *CI/CD Security Cheat Sheet* and GitHub's own hardening guide
+both recommend pinning third-party actions to a full 40-character
+commit SHA. The trade-off is staleness: SHAs don't move, so security
+patches in upstream actions are not picked up automatically.
+
+## Decision
+
+PR #8 ("CI/security baseline") and every workflow added since (PRs #9,
+#16, #17) follow this rule:
+
+- **All third-party actions are pinned to a full commit SHA.** First-
+  party actions (`actions/checkout`, `actions/setup-python`,
+  `actions/upload-artifact`, etc.) are also pinned, even though
+  they're maintained by GitHub.
+- **Each pin carries a `# v1.2.3` comment** so a human can tell at a
+  glance which version is in use. Dependabot uses this comment to
+  generate readable PR titles.
+- **Dependabot is configured for `github-actions`** with a weekly
+  schedule. Bumps come in as PRs (e.g. PR #10: `actions/labeler 5 →
+  6.1.0`), get reviewed, run the full CI matrix, and merge only when
+  green.
+- **`step-security/harden-runner`** is the first step on every job
+  (egress-policy: `audit`), so any unexpected outbound call from a
+  compromised action would be logged.
+
+## Consequences
+
+**Positive**
+
+- A compromised upstream tag cannot affect this repo until a
+  Dependabot PR is reviewed and merged.
+- The diff of a Dependabot bump shows exactly the SHA delta, making
+  it easy to spot a wildly unexpected change of repository owner or
+  scope.
+- Hardened-runner audits give a forensic trail if something does
+  slip through.
+
+**Negative / trade-offs**
+
+- **Staleness window.** Between an upstream security fix and the
+  Dependabot PR merging, this repo is exposed to whatever the fix
+  addresses. Mitigated by Dependabot's weekly cadence and by treating
+  Dependabot PRs as priority work.
+- **Visual noise.** Workflow YAML is uglier than `@v4`. The
+  `# v1.2.3` comment is mandatory to keep it scannable.
+- **Slightly higher review cost** for Dependabot PRs (must spot-check
+  the SHA belongs to the claimed version), but this is a one-time
+  check per bump and pays for itself the first time an upstream
+  account is compromised.

--- a/docs/adr/0004-pypi-trusted-publishing-oidc.md
+++ b/docs/adr/0004-pypi-trusted-publishing-oidc.md
@@ -1,0 +1,70 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 4. PyPI publishing via OIDC trusted publishing (no long-lived token)
+
+## Context
+
+The tag-triggered release pipeline (PR #16) needs to push a wheel +
+sdist to PyPI. Three viable mechanisms exist:
+
+1. **`PYPI_API_TOKEN` repo secret** — historically the default. A
+   long-lived token with upload scope sits in GitHub Secrets. Leak
+   risk: any workflow with `secrets:` access (including a malicious
+   PR from a fork if not gated) can read it, and a compromised
+   maintainer token persists until manually rotated.
+2. **Project-scoped trusted publisher (OIDC)** — PyPI verifies a
+   short-lived OIDC token GitHub mints per-job, scoped to a specific
+   repository + workflow + environment. No long-lived secret exists.
+3. **Manual upload from a workstation** — defeats the purpose of an
+   automated pipeline.
+
+## Decision
+
+Use **OIDC trusted publishing** (option 2) for the `clipman-clipboard`
+project on PyPI.
+
+- The `publish-pypi` job in `.github/workflows/release.yml` requests
+  an OIDC token via `permissions: id-token: write`, scoped **only** to
+  that job. Every other job in the workflow has `contents: read`.
+- The job runs inside a GitHub *environment* named `pypi`, which
+  gives a single stop-button between the tag push and the upload
+  (and a place to add a manual approval gate later without changing
+  the workflow).
+- The upload step is `pypa/gh-action-pypi-publish` pinned to a SHA
+  (see ADR 0003). The action negotiates the OIDC exchange with PyPI
+  automatically.
+- A *pending publisher* must be registered manually at
+  <https://pypi.org/manage/account/publishing/> before the first
+  release. The fields are documented in the PR #16 body and in
+  `docs/releases/README.md`. After the first successful release the
+  entry becomes a regular trusted publisher.
+
+## Consequences
+
+**Positive**
+
+- **No long-lived PyPI credential exists anywhere in this repo or in
+  GitHub Secrets.** A repo-wide secrets leak cannot push to PyPI.
+- The OIDC token is single-use, scoped to one job in one workflow,
+  and expires in minutes.
+- The `pypi` environment is the natural place to add a manual
+  approval step or environment-level restrictions later, without
+  rewriting the workflow.
+
+**Negative / trade-offs**
+
+- **One-time manual setup** at pypi.org is unavoidable and cannot be
+  automated from this repo. A new maintainer would need to repeat
+  it (or be added as a PyPI project collaborator with publish
+  rights).
+- The workflow filename (`release.yml`), workflow job name, and
+  environment name (`pypi`) are baked into the trusted-publisher
+  config on PyPI. Renaming any of them silently breaks the publish
+  step until the PyPI side is updated.
+- If GitHub's OIDC infrastructure has an outage during a release,
+  the publish step fails. There is no fall-back token to use
+  manually — by design.

--- a/docs/adr/0005-paste-mode-as-dbus-arg.md
+++ b/docs/adr/0005-paste-mode-as-dbus-arg.md
@@ -1,0 +1,81 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 5. Encode paste keystroke choice as a D-Bus argument, not separate methods
+
+## Context
+
+PR #15 adds a user-facing setting for which keystroke the GNOME Shell
+extension should synthesize when pasting:
+
+| Mode | Behavior |
+|------|----------|
+| `auto` | Ctrl+V on most apps, Ctrl+Shift+V on terminals (existing behavior) |
+| `ctrl-v` | Force Ctrl+V regardless of focus |
+| `ctrl-shift-v` | Force Ctrl+Shift+V regardless of focus |
+| `shift-insert` | Shift+Insert (X11/terminal convention — issue #7) |
+
+Two interface designs were on the table:
+
+1. **One method per mode**: `SimulatePaste()`, `SimulatePasteShiftInsert()`,
+   `SimulatePasteCtrlV()`, ...
+2. **One method, one argument**: `SimulatePaste(s mode)`.
+
+Option 1 keeps each method's body trivial but multiplies the D-Bus
+surface every time a new keystroke recipe is added. Option 2 keeps the
+surface stable but introduces a backward-compatibility question: the
+shipped extension (v4) exposes `SimulatePaste()` with no arguments, so
+a new daemon calling `SimulatePaste('auto')` on an unupgraded
+extension would raise `DBusException`.
+
+## Decision
+
+Use **one method with a string argument** (option 2).
+
+- The D-Bus interface becomes `SimulatePaste(s mode)`. Valid values:
+  `auto` / `ctrl-v` / `ctrl-shift-v` / `shift-insert`. Unknown
+  strings fall back to `auto`.
+- The extension's `extension.js` is refactored into a pure
+  `_resolveRecipe(mode) → recipe` function plus a
+  `_dispatchKeystroke(recipe)` action. This keeps mode→keystroke
+  mapping branch-free and unit-testable.
+- The extension's `metadata.json` bumps `version` from 4 to 5 to
+  reflect the breaking interface change for downstream consumers.
+- **Backward compatibility**: the daemon's `_simulate_paste` wraps
+  the call in `try / except DBusException` and, on failure, retries
+  with the old no-argument signature. A new daemon paired with an
+  unupgraded v4 extension therefore still pastes via the legacy
+  behavior (which is `auto` by definition).
+
+## Consequences
+
+**Positive**
+
+- **Future modes cost one string constant**, not a new D-Bus method
+  + GVariant signature + extension export.
+- **The compatibility fallback is local to the daemon**, so the
+  extension's v4 → v5 upgrade is not blocking. Users who installed
+  the daemon via PyPI but haven't refreshed the extension on
+  extensions.gnome.org keep working.
+- The `_resolveRecipe` split makes the extension testable without a
+  live GNOME Shell — a future test runner only has to assert that
+  mode strings map to the right recipes.
+
+**Negative / trade-offs**
+
+- **D-Bus introspection** now requires a string argument; quick
+  manual smoke tests via `gdbus call` get slightly more verbose
+  (`gdbus call ... SimulatePaste 'auto'`).
+- The **try-with-arg + retry-without-arg** fallback only handles
+  the v4 → v5 transition. If a future v6 changes the signature
+  again, the daemon will need a second fallback layer or a version
+  probe. Acceptable: rare event, and the version-probe option is
+  cleaner than chained fallbacks.
+- **Validation is loose**: the extension treats any unknown mode as
+  `auto` rather than raising. This is intentional (forward
+  compatibility — newer daemons shipping a mode the extension
+  doesn't know about don't crash), but means typos in the daemon
+  go silently to `auto` instead of surfacing.

--- a/docs/adr/0006-solo-friendly-branch-protection.md
+++ b/docs/adr/0006-solo-friendly-branch-protection.md
@@ -1,0 +1,86 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 6. Solo-friendly branch protection on `main`
+
+## Context
+
+Standard "best practice" branch protection assumes a team: required
+review from a non-author, codeowners, etc. Clipman is currently a
+solo-maintainer project. Requiring review-from-another-human would
+either:
+
+- block every merge until a reviewer is invited (defeats the
+  purpose of CI gating), or
+- be self-bypassed by the maintainer (defeats the purpose of the
+  policy).
+
+What the project *does* benefit from is **mechanical** gating: a
+merge cannot land if the test suite, linters, secret scanner,
+dependency-review scanner, or CodeQL ratchet fail. Those checks are
+identity-blind and impossible to self-approve.
+
+## Decision
+
+Branch protection on `main` is configured as follows:
+
+- **Required status checks** (must all be green to merge):
+  - `Tests (3.10)` / `Tests (3.11)` / `Tests (3.12)` — full pytest
+    matrix across supported Python versions.
+  - `ruff` — lint gate.
+  - `shellcheck` — gates `install.sh`, `uninstall.sh`,
+    `launcher.sh`.
+  - `gitleaks` — secret scanner.
+  - `Dependency review` — flags newly introduced vulnerable
+    dependencies.
+  - `Analyze (python)` and `Analyze (javascript)` — CodeQL, with
+    the baseline-ratchet from ADR 0002 enforced as a step inside
+    each.
+- **Require branches to be up to date before merging** — yes.
+- **Require linear history** — yes. No merge commits on `main`.
+  PRs are squashed or rebased.
+- **No force-push** to `main`.
+- **No deletions** of `main`.
+- **Require conversation resolution before merging** — yes.
+- **Require pull request reviews before merging** — **NO** (single
+  maintainer; would either block everything or be vacuously self-
+  approved).
+- **Restrict who can push** — administrators only (the maintainer).
+  Dependabot uses GitHub-managed permissions for its bump PRs and
+  still has to clear all of the above checks.
+
+The `security-baseline` branch has its own protection enforced by the
+`baseline-guard.yml` workflow (ADR 0002): any push by a non-bot
+actor is auto-reverted and surfaces an issue.
+
+## Consequences
+
+**Positive**
+
+- Every merge to `main` is gated on a non-trivial battery of
+  automated checks that the maintainer cannot bypass without
+  explicitly disabling protection.
+- Linear history keeps `git log` and `git bisect` clean, which
+  matters disproportionately for a small project with no dedicated
+  release engineer.
+- The policy is honest: it doesn't pretend to enforce reviewer
+  independence that doesn't exist, so the team isn't trained to
+  rubber-stamp.
+
+**Negative / trade-offs**
+
+- **No second pair of eyes** is enforced. The maintainer is
+  responsible for self-review discipline (e.g., reading the diff
+  in the PR tab before merging, not from local working tree). Once
+  a co-maintainer joins, this ADR should be superseded with one
+  that flips on `Require pull request reviews` and codeowners.
+- **Stale-PR friction.** "Branch up to date" + linear history means
+  rebasing PRs after every merge. With Dependabot's weekly cadence
+  this is a few rebases per week. Acceptable.
+- **No emergency bypass.** If a required check is broken (e.g.,
+  CodeQL infra outage), the maintainer must either fix the check
+  or temporarily disable the protection rule to merge a hotfix —
+  there is no "admin override" toggle on the merge button.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,30 @@
+# Architecture Decision Records
+
+This directory holds the project's architecture decision records (ADRs).
+We use the [MADR](https://adr.github.io/madr/) format: Markdown with a
+short YAML frontmatter (`status`, `date`, `deciders`) and three sections
+(Context, Decision, Consequences).
+
+New ADRs are numbered monotonically and named `NNNN-kebab-case-title.md`.
+Once an ADR is `Accepted`, it is not edited in place — supersede it with
+a new ADR that links back.
+
+## Index
+
+| #    | Title                                                                                       | Status   | Summary                                                                                                       |
+|------|---------------------------------------------------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------|
+| 0001 | [Record architecture decisions](0001-record-architecture-decisions.md)                      | Accepted | Adopt MADR-format ADRs under `docs/adr/` for non-trivial architecture and infra decisions.                    |
+| 0002 | [Baseline-ratchet pattern for CodeQL findings](0002-baseline-ratchet-for-codeql.md)         | Accepted | Pre-existing CodeQL findings don't block PRs; new fingerprints do. Baseline lives on a guarded orphan branch. |
+| 0003 | [Pin all third-party GitHub Actions to commit SHAs](0003-sha-pin-github-actions.md)         | Accepted | OWASP-aligned supply-chain hardening; Dependabot keeps SHAs current with weekly bumps.                        |
+| 0004 | [PyPI publishing via OIDC trusted publishing](0004-pypi-trusted-publishing-oidc.md)         | Accepted | No long-lived PyPI token; the release workflow mints a short-lived OIDC token per job.                        |
+| 0005 | [Encode paste keystroke choice as a D-Bus argument](0005-paste-mode-as-dbus-arg.md)         | Accepted | `SimulatePaste(s mode)` with try-with-arg + retry-without-arg fallback for v4 extension compatibility.        |
+| 0006 | [Solo-friendly branch protection on `main`](0006-solo-friendly-branch-protection.md)        | Accepted | Required status checks + linear history + no force-push, but no required reviewers (single-maintainer repo). |
+
+## Authoring a new ADR
+
+1. Copy the structure of an existing record (e.g.
+   `0001-record-architecture-decisions.md`).
+2. Pick the next free number and a short kebab-case slug.
+3. Open the PR with the ADR alongside the change it documents — that's
+   the whole point of keeping them in-repo.
+4. Once merged, add a row to the index above.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,71 @@
+# Release notes
+
+GitHub Releases are the authoritative home for Clipman's release notes.
+They are **auto-generated** by `.github/workflows/release.yml` from the
+matching `## [x.y.z]` section in `CHANGELOG.md` whenever a `v*.*.*` tag
+is pushed.
+
+## How a release happens
+
+1. Bump versions with `./scripts/bump-version.sh <new-version>` —
+   updates `pyproject.toml`, `snap/snapcraft.yaml`, `flathub/*.json`,
+   and `aur/PKGBUILD` in one shot.
+2. Rename the `## [Unreleased]` section in `CHANGELOG.md` to
+   `## [<new-version>] - YYYY-MM-DD`.
+3. Commit, tag (`git tag v<new-version>`), and push (`git push --tags`).
+4. The `release.yml` workflow takes over — see the diagram below.
+
+## Pipeline shape
+
+```mermaid
+flowchart TD
+    classDef trigger fill:#dbeafe,stroke:#3b82f6,color:#1e40af
+    classDef gate    fill:#fef3c7,stroke:#d97706,color:#92400e
+    classDef build   fill:#dcfce7,stroke:#16a34a,color:#166534
+    classDef publish fill:#ede9fe,stroke:#7c3aed,color:#5b21b6
+    classDef final   fill:#fee2e2,stroke:#dc2626,color:#991b1b
+
+    Tag["push tag v*.*.*"]:::trigger
+    PF["pre-flight<br/>tag/version sanity<br/>+ extract CHANGELOG section"]:::gate
+    Tests["tests<br/>Python 3.10 / 3.11 / 3.12"]:::gate
+
+    BPyPI["build-pypi<br/>wheel + sdist"]:::build
+    BSnap["build-snap"]:::build
+    BExt["bundle-extension<br/>versioned zip"]:::build
+
+    PPyPI["publish-pypi<br/>OIDC trusted publishing"]:::publish
+    PSnap["publish-snap<br/>stable channel"]:::publish
+
+    Release["github-release<br/>attaches wheel + sdist + snap + extension zip<br/>body = extracted CHANGELOG section"]:::final
+
+    Tag --> PF --> Tests
+    Tests --> BPyPI
+    Tests --> BSnap
+    Tests --> BExt
+    BPyPI --> PPyPI
+    BSnap --> PSnap
+    BExt --> Release
+    PPyPI --> Release
+    PSnap --> Release
+```
+
+## Why CHANGELOG.md drives the release body
+
+- One source of truth: `CHANGELOG.md` ships with the source tarball
+  and PyPI sdist, so users who never visit the GitHub UI still see the
+  same notes.
+- Reviewable in a PR: release notes are part of the diff that lands on
+  `main`, not a free-text field edited after the fact.
+- Auditable: the tag's release body is exactly the section that was
+  committed at the tag — no out-of-band edits.
+
+## Related decisions
+
+- **ADR 0004** — *PyPI publishing via OIDC trusted publishing*. The
+  `publish-pypi` job has no long-lived token; PyPI must have a
+  matching trusted-publisher entry registered manually.
+- **ADR 0003** — *Pin all third-party GitHub Actions to commit SHAs*.
+  Every action in `release.yml` is SHA-pinned with a version comment.
+- **ADR 0006** — *Solo-friendly branch protection on `main`*. The
+  same required status checks gate the commit that the release tag
+  points at.


### PR DESCRIPTION
## Summary

Documentation-only PR. Captures the architecture and infrastructure
decisions behind the recent CI/release work as MADR-format ADRs,
expands `CHANGELOG.md` with an Internal / CI section for those changes,
and introduces a `docs/releases/` home for the tag-triggered release
flow.

No runtime code changes; nothing in `clipman/`, `extension/`, or
`tests/` is touched. The full 233-test suite still passes locally.

## Files

### `docs/adr/` (new)

| File | Topic |
|------|-------|
| `README.md` | Index of ADRs + how to add new ones (links to <https://adr.github.io/madr/>). |
| `0001-record-architecture-decisions.md` | Meta-ADR adopting MADR for the project. |
| `0002-baseline-ratchet-for-codeql.md` | The pattern behind PR #17 — pre-existing CodeQL findings don't block PRs; baseline lives on the guarded `security-baseline` orphan branch. Notes the line-drift trade-off. |
| `0003-sha-pin-github-actions.md` | OWASP-aligned supply-chain choice from PR #8 — every third-party action pinned to a commit SHA with a version comment; Dependabot keeps them current. |
| `0004-pypi-trusted-publishing-oidc.md` | PR #16's choice to publish to PyPI via OIDC trusted publishing — no long-lived token, manual one-time pending-publisher setup at pypi.org. |
| `0005-paste-mode-as-dbus-arg.md` | PR #15's `SimulatePaste(s mode)` interface, with the try-with-arg + retry-without-arg compatibility fallback. |
| `0006-solo-friendly-branch-protection.md` | Current `main` protection: required status checks (Tests 3.10/3.11/3.12, ruff, shellcheck, gitleaks, dependency review, CodeQL python + javascript), linear history, no force-push, no deletions, conversation resolution required — but **no required reviewers** (solo maintainer). |

### `CHANGELOG.md`

New `### Internal / CI` subsection appended under the existing
`## [Unreleased]` section. Documents PRs #8, #9, #10, #16, and #17.
User-facing entries (the custom-shortcut entries from PR #15) are
left untouched and remain above the new subsection.

### `docs/releases/README.md` (new)

Brief note that GitHub Releases are the authoritative release-notes
home and are auto-generated by `.github/workflows/release.yml` from
the matching `CHANGELOG.md` section on tag push. Includes a Mermaid
diagram of the release pipeline (mirroring the shape from PR #16's
body: tag → pre-flight → tests → PyPI / Snap / extension bundle →
GitHub Release).

## Conflict notes

- `CHANGELOG.md` shares the `## [Unreleased]` block with PR #15.
  Whichever PR merges second will need a trivial rebase to append /
  prepend its subsection. No file owned by PR #15 (`window.py`,
  `keybindings.py`, `extension.js`, `metadata.json`,
  `test_keybindings.py`) is touched here.

## Type of change

- Type of change: docs

## Testing

- `python3 -m unittest discover -s tests` — 233/233 pass locally.
- ADRs and the releases doc render correctly as Markdown (Mermaid
  diagrams use GitHub-native syntax).