### PR TITLE
docs(readme): add architecture diagram to How It Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,56 @@ Settings are saved automatically and persist across sessions.
 5. Pressing **Super+V** sends a **D-Bus toggle** to the daemon, which shows the popup window near the cursor
 6. Clicking an entry copies it via `wl-copy`, hides the popup, and the extension simulates a **paste keystroke** using a Clutter virtual keyboard
 
+### Architecture
+
+```mermaid
+flowchart LR
+    classDef user fill:#dbeafe,stroke:#3b82f6,color:#1e40af
+    classDef gshell fill:#fef3c7,stroke:#d97706,color:#92400e
+    classDef daemon fill:#dcfce7,stroke:#16a34a,color:#166534
+    classDef storage fill:#f3e8ff,stroke:#9333ea,color:#6b21a8
+
+    User((User)):::user
+    App["Any GTK / Qt / Electron / terminal app"]:::user
+
+    subgraph SHELL ["GNOME Shell"]
+        Ext["clipman extension<br/>extension.js"]:::gshell
+        KB["custom-keybinding<br/>(gsettings)"]:::gshell
+    end
+
+    Clip["Wayland clipboard"]:::gshell
+
+    subgraph DAEMON ["clipman daemon (Python, GTK3)"]
+        DbusSvc["dbus_service.py<br/>(com.clipman.Daemon)"]:::daemon
+        Monitor["clipboard_monitor.py<br/>(dedupe + sensitive detect)"]:::daemon
+        Window["window.py<br/>(GTK popup + settings)"]:::daemon
+        Fallback["wl-paste --watch<br/>(used when extension absent)"]:::daemon
+    end
+
+    DB[("SQLite WAL<br/>~/.local/share/clipman/")]:::storage
+
+    App -->|Ctrl+C| Clip
+    Clip -. owner-changed .-> Ext
+    Clip -. owner-changed .-> Fallback
+    Ext -->|D-Bus: NewEntry text or image| DbusSvc
+    Fallback --> DbusSvc
+
+    DbusSvc --> Monitor
+    Monitor -->|SHA256 dedup| DB
+
+    User -->|Super+V| KB
+    KB -->|launcher.sh toggle| DbusSvc
+    DbusSvc -->|Toggle| Window
+    Window <-->|history + snippets| DB
+
+    User -->|click entry| Window
+    Window -->|wl-copy| Clip
+    Window -->|D-Bus: SimulatePaste mode| Ext
+    Ext -->|virtual keyboard| App
+```
+
+The `wl-paste --watch` fallback only runs when the GNOME Shell extension is absent (e.g., other Wayland compositors). Inside snap confinement, neither path is available — snap users rely on the extension running in their host session.
+
 <details>
 <summary><strong>Project structure</strong></summary>
 


### PR DESCRIPTION
Adds a Mermaid flowchart under the existing **How It Works** section so the data flow is visible at a glance: copy event → Wayland clipboard → GNOME Shell extension → D-Bus → daemon → SQLite, and the mirror-image paste path back out. Surfaces the `wl-paste --watch` fallback and the snap-confinement caveat too.

Inline Mermaid renders natively on GitHub — no screenshot or external diagram service.

## Type of change

- [x] Documentation
