### PR TITLE
ci(scorecard): fix imposter-commit SHA for ossf/scorecard-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Problem

Every push to `main` fails the "Scorecard supply-chain security" check with:

```
error sending scorecard results to webapp: http response 400, status: 400 Bad Request,
error: {"code":400,"message":"workflow verification failed: workflow verification failed:
imposter commit: ff5dd8929f96a8a4dc67d13f32b8c75057829621 does not belong to ossf/scorecard-action,
see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```

## Root cause

When I pinned `ossf/scorecard-action` to a commit SHA, I queried `repos/ossf/scorecard-action/git/ref/tags/v2.4.0` and used its `.object.sha`. For **annotated tags** that field is the tag object's SHA, not the commit it points to. Scorecard's signature verification checks that the running workflow's action ref is a real commit on `ossf/scorecard-action` — the tag-object SHA isn't, so it's flagged as an imposter and the publish step exits non-zero.

## Fix

One-character change in `.github/workflows/scorecard.yml`:

```diff
- uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+ uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
```

The new SHA was resolved via `gh api repos/ossf/scorecard-action/commits/v2.4.0 --jq .sha` which always returns the actual commit, regardless of tag type.

## Type of change

- [x] Bug fix
- [x] Build / CI / packaging