### PR TITLE
docs: add CODE_OF_CONDUCT, dev guide, release checklist, ADRs 0008+0009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,29 @@ All notable changes to Clipman are documented in this file.
 
 #### Changed
 - **Dependabot bumps**: `actions/labeler` 5.0.0 → 6.1.0 (#10),
-  pinned to commit SHA per the project's supply-chain policy
-  (ADR 0003).
+  `step-security/harden-runner` 2.10.2 → 2.19.3 (#11),
+  `github/codeql-action` SHA bump (#12),
+  `actions/checkout` 4.2.2 → 6.0.2 (#13),
+  `actions/setup-python` 5.3.0 → 6.2.0 (#14), all pinned to commit
+  SHA per the project's supply-chain policy (ADR 0003).
+- **Ratchet fingerprint strategy** (#20): swapped the CodeQL
+  ratchet's `rule:file:line` fingerprints for SARIF
+  `partialFingerprints.primaryLocationLineHash` so PRs that just
+  shift lines no longer surface as "new findings", and added
+  `if: github.event_name == 'pull_request'` on the ratchet step so
+  the `update-baseline` job can run on push without being blocked by
+  the ratchet on main itself. Baseline schema bumped to `2`. See
+  ADR 0008.
+- **Scorecard SHA fix** (#22): the previous `ossf/scorecard-action`
+  SHA was the annotated-tag object, not the commit it points to.
+  Scorecard's webapp rejected it as an imposter commit, failing
+  every push to main. Resolved to the real commit SHA.
+
+#### Removed
+- **Stray root-level Flathub manifest** (#18): the obsolete
+  `com.clipman.Clipman.json` at the repo root used the pre-rename
+  app-id and was not referenced anywhere. The current Flathub
+  manifest lives at `flathub/io.github.MohammedEl_sayedAhmed.Clipman.json`.
 
 #### Docs
 - Added `docs/adr/` with the first six MADR-format ADRs covering
@@ -64,6 +85,13 @@ All notable changes to Clipman are documented in this file.
   branch-protection posture. See `docs/adr/README.md` for the index.
 - Added `docs/releases/README.md` documenting where release notes
   live and how the release pipeline assembles them.
+- Added a Mermaid architecture diagram under the **How It Works**
+  section of `README.md` (#21).
+- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1),
+  `docs/development.md` (build/test/debug guide), and
+  `docs/release-checklist.md` (release runbook).
+- Added ADR 0008 (ratchet fingerprint strategy, documents #20) and
+  ADR 0009 (weekly snap rebuild cadence, documents #9).
 
 ## [1.0.4] - 2026-02-28
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
++++
+version = "2.1"
+aliases = ["/version/2/1"]
+reportingPlaceholder = "[INSERT CONTACT METHOD]"
++++
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/adr/0008-ratchet-fingerprint-strategy.md
+++ b/docs/adr/0008-ratchet-fingerprint-strategy.md
@@ -1,0 +1,81 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 8. Ratchet fingerprint strategy
+
+## Context
+
+ADR 0002 introduced the CodeQL baseline ratchet: a PR fails CodeQL
+only when it introduces a finding whose fingerprint isn't already in
+the baseline. The first implementation used `<rule-id>:<file>:<line>`
+as the fingerprint format. That worked until PR #15 — the first PR
+that added many lines to a file that already had baseline findings.
+The line numbers of the existing findings shifted, so the per-rule
+fingerprints no longer matched the baseline, and the ratchet
+reported every shifted finding as "new".
+
+Worse: the ratchet also ran on push to `main` (with the same step),
+so the merge of PR #15 made `main`'s ratchet step fail on its own
+line shifts. That kept the `update-baseline` job (which lists
+`needs: analyze`) from ever running, freezing the baseline at the
+pre-PR-15 line numbers and inheriting the same false positives on
+every subsequent PR.
+
+We needed a fingerprint format that's stable across unrelated edits.
+
+## Decision
+
+Use the SARIF `partialFingerprints.primaryLocationLineHash` value
+that CodeQL already emits per finding. The fingerprint key becomes
+`<rule-id>:<partial-fingerprint-hash>` (file path and line number
+drop out entirely). CodeQL's `primaryLocationLineHash` is a hash of
+the location's surrounding snippet, so it survives line shifts
+within a function.
+
+Two implementation details landed alongside the format change in PR
+#20:
+
+- **Ratchet skips on push events**. On push to `main`, the analyze
+  job only produces SARIF; `update-baseline` is the consumer.
+  Running the ratchet on push, even with stable fingerprints,
+  preserves the deadlock risk if a new edge case ever appears.
+  Keeping ratchet PR-only makes the failure mode strictly
+  PR-side, never main-side.
+- **Schema bump**. `.github/security-baseline.json` carries
+  `schema_version: 2` to signal the format migration. Loaders accept
+  both legacy `rule:file:line` and new `rule:hash` entries
+  side-by-side during the transition; the first push to main after
+  the migration overwrites the legacy entries.
+
+## Consequences
+
+**Positive**
+
+- PRs that just move code (refactors, top-of-file imports, large
+  feature additions) no longer surface "new" findings for the
+  shifted lines. The ratchet only flags genuinely-new findings.
+- Update-baseline can no longer deadlock on its own line shifts.
+- Behavior matches what GitHub's own Code Scanning UI uses to
+  deduplicate findings across runs — same source of truth.
+
+**Negative**
+
+- `primaryLocationLineHash` isn't a documented API; it's a CodeQL
+  implementation detail that could theoretically change in a future
+  release. Mitigated by the fallback to `rule:file:line` if the
+  partial fingerprint is missing, and by Dependabot keeping the
+  codeql-action SHA pinned + current.
+- Human reviewers reading the baseline can't tell from a fingerprint
+  where the finding lives — they have to look it up via the
+  workflow's annotation. The ratchet step still emits
+  `::error file=...,line=...` annotations on new findings, so the
+  PR-side workflow output is unchanged.
+
+## References
+
+- ADR 0002 (baseline-ratchet pattern) — the original design.
+- PR #20 — the change set.
+- CodeQL SARIF docs: <https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning>

--- a/docs/adr/0009-snap-rebuild-cadence.md
+++ b/docs/adr/0009-snap-rebuild-cadence.md
@@ -1,0 +1,91 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 9. Weekly snap rebuild cadence
+
+## Context
+
+Clipman ships as a strict-confinement snap. The snap embeds
+`stage-packages` resolved from the Ubuntu 22.04 (`core22`) archive at
+build time — Python, GTK runtime, GObject bindings, image libraries,
+etc. When any of those upstream packages gets a security fix, the
+published snap continues to ship the pre-fix version until it is
+rebuilt.
+
+The Snap Store enforces this by emailing publishers on every USN that
+touches a binary in their published snaps. Clipman's r5 (v1.0.4)
+revision received multiple such notices in a short window for
+`libavahi-client3`, `libavahi-common3`, `liblcms2-2`, etc. The fix is
+always the same — "Simply rebuilding the snap will pull in the new
+security updates and resolve this" — but doing it by hand on every
+USN doesn't scale.
+
+We need a way to keep the published snap fresh against upstream
+security without coupling it to clipman's own release cadence.
+
+## Decision
+
+Add a scheduled GitHub Actions workflow
+(`.github/workflows/snap-refresh.yml`) that rebuilds the snap and
+publishes the new revision automatically.
+
+- **Trigger**: weekly cron (`0 4 * * 1` — Monday 04:00 UTC). Also
+  `workflow_dispatch` for manual reruns, and `push` /
+  `pull_request` on snap-relevant paths to validate snap builds
+  before merge.
+- **Build**: `snapcore/action-build` produces the `.snap`, uploaded
+  as a workflow artifact (14-day retention) regardless of whether
+  the publish step runs.
+- **Publish**: `snapcore/action-publish` uploads to the **edge**
+  channel by default on the scheduled run. `workflow_dispatch`
+  exposes a channel input (edge / beta / candidate / stable) and a
+  `publish: true/false` toggle. Publish requires the
+  `SNAPCRAFT_STORE_CREDENTIALS` secret; if it's absent the publish
+  job exits with a `::warning::` instead of failing the workflow.
+- **Channel choice**: edge is the auto-publish default so a broken
+  rebuild doesn't immediately ship to stable. The maintainer can
+  smoke-test edge and promote to stable manually (or via the tag
+  release pipeline) once they're satisfied.
+- **No version bump**: the rebuilt snap reuses the version field in
+  `snap/snapcraft.yaml`. Snap Store assigns a fresh revision
+  number; the user-visible version stays the same until the next
+  proper release.
+
+## Consequences
+
+**Positive**
+
+- USN notification emails get resolved automatically on the next
+  Monday rebuild (worst-case one-week stale).
+- Decouples security-patch rebuilds from clipman's own release
+  cycle. The release pipeline (`release.yml`) still handles
+  user-visible version bumps; this workflow just keeps the build
+  fresh.
+- Build failures surface as a regular workflow run, so packaging
+  regressions show up via the same Actions tab as code-side CI.
+
+**Negative**
+
+- The maintainer must remember to promote edge → stable
+  occasionally if they want stable to also stay fresh. Without
+  promotion, only edge channel users get the rebuilt revision.
+  Acceptable trade-off: stable promotion is a manual safety gate.
+- Strict-confinement snaps that declare D-Bus slots (clipman has
+  two — `com.clipman.Daemon` and `com.clipman.Clipman`) sometimes
+  trigger Snap Store's manual review queue. The publish step
+  succeeds in those cases but the new revision sits unreleased
+  until a human reviews it. Documented; can't be automated away.
+- `SNAPCRAFT_STORE_CREDENTIALS` is a long-lived token (≈1y
+  lifetime). Mitigated by scoping the export-login to the clipman
+  snap only and the `package_push`/`package_release` ACLs, and by
+  the Snap Store's renewal-reminder emails.
+
+## References
+
+- PR #9 — the workflow.
+- `snap/snapcraft.yaml` — the snap definition the workflow rebuilds.
+- Upstream Snap Store policy:
+  <https://forum.snapcraft.io/t/snap-store-security-update-emails/>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,8 @@ a new ADR that links back.
 | 0004 | [PyPI publishing via OIDC trusted publishing](0004-pypi-trusted-publishing-oidc.md)         | Accepted | No long-lived PyPI token; the release workflow mints a short-lived OIDC token per job.                        |
 | 0005 | [Encode paste keystroke choice as a D-Bus argument](0005-paste-mode-as-dbus-arg.md)         | Accepted | `SimulatePaste(s mode)` with try-with-arg + retry-without-arg fallback for v4 extension compatibility.        |
 | 0006 | [Solo-friendly branch protection on `main`](0006-solo-friendly-branch-protection.md)        | Accepted | Required status checks + linear history + no force-push, but no required reviewers (single-maintainer repo). |
+| 0008 | [Ratchet fingerprint strategy](0008-ratchet-fingerprint-strategy.md)                        | Accepted | Switch CodeQL ratchet from `rule:file:line` to SARIF `partialFingerprints`, and skip the ratchet on push to fix the update-baseline deadlock. |
+| 0009 | [Weekly snap rebuild cadence](0009-snap-rebuild-cadence.md)                                 | Accepted | Scheduled weekly rebuild publishes to `edge` automatically so the snap stays patched against Ubuntu archive USNs without coupling to a code release. |
 
 ## Authoring a new ADR
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,174 @@
+# Development guide
+
+A walkthrough for hacking on Clipman locally — building from source,
+running the test suite, debugging the daemon and the GNOME Shell
+extension.
+
+## Source layout
+
+See the **Project structure** block at the bottom of `README.md` for
+the canonical map. Two halves matter for development:
+
+- **Python daemon** under `clipman/` (entry point: `clipman.py`).
+- **GNOME Shell extension** under `extension/` — JavaScript, runs
+  inside GNOME Shell's gjs process.
+
+## Prerequisites
+
+System packages (Ubuntu/Debian):
+
+```bash
+sudo apt-get install -y \
+    python3 python3-gi python3-dbus gir1.2-gtk-3.0 \
+    wl-clipboard libcairo2-dev libgirepository-2.0-dev \
+    gnome-shell-extensions
+```
+
+Fedora equivalents:
+
+```bash
+sudo dnf install -y \
+    python3-gobject python3-dbus gtk3 \
+    wl-clipboard cairo-devel gobject-introspection-devel \
+    gnome-extensions-app
+```
+
+A virtualenv is optional but recommended for lint/test tooling:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install ruff
+```
+
+PyGObject is imported through the system path — don't `pip install
+PyGObject` inside the venv, it'll diverge from the system GIR
+typelibs.
+
+## Running from source
+
+```bash
+git clone git@github.com:MohammedEl-sayedAhmed/clipman.git
+cd clipman
+./install.sh          # registers the keybinding + autostart + extension
+python3 clipman.py    # daemon foreground; Ctrl+C to stop
+```
+
+Pop the popup any time with `Super+V` (or run
+`python3 clipman.py toggle` from another terminal).
+
+`install.sh` is idempotent — re-run it after changing the extension
+to refresh `~/.local/share/gnome-shell/extensions/clipman@clipman.com`.
+
+## Running tests
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+The full suite (~265 tests) hits the actual SQLite layer, mocks
+clipboard subprocesses, and exercises the keybinding parser. Tests
+require the system `python3-gi` package (the project's CI matrix
+covers Python 3.10–3.12 on `ubuntu-24.04`).
+
+Targeted runs:
+
+```bash
+python3 -m unittest tests.test_keybindings
+python3 -m unittest tests.test_database.TestClipboardDB.test_add_text_entry
+```
+
+## Lint
+
+```bash
+ruff check clipman tests
+```
+
+Configuration lives in `pyproject.toml`. The two per-file ignores for
+`E402` in `clipman/app.py` and `clipman/window.py` are intentional —
+`gi.require_version()` legitimately must precede `from gi.repository
+import ...`.
+
+Shell scripts use `shellcheck --severity=warning`:
+
+```bash
+shellcheck --severity=warning install.sh uninstall.sh launcher.sh
+```
+
+## Debugging
+
+### Daemon
+
+Run it in the foreground to see `print()` output and Python tracebacks:
+
+```bash
+python3 clipman.py
+```
+
+Once installed as a systemd user service:
+
+```bash
+journalctl --user -u clipman -f
+```
+
+The database lives at `~/.local/share/clipman/clipman.db` — open it
+with `sqlite3` if you need to inspect history or settings:
+
+```bash
+sqlite3 ~/.local/share/clipman/clipman.db
+sqlite> SELECT key, value FROM settings;
+```
+
+### Extension
+
+GNOME Shell logs every extension exception to the systemd journal:
+
+```bash
+journalctl /usr/bin/gnome-shell -f
+```
+
+To reload the extension without logging out:
+
+- Wayland: log out and back in (Shell restart isn't supported under
+  Wayland).
+- X11: `Alt+F2`, type `r`, Enter.
+
+When iterating on `extension/extension.js`, copy it into
+`~/.local/share/gnome-shell/extensions/clipman@clipman.com/extension.js`
+and reload the Shell. `install.sh` does the copy step too.
+
+## D-Bus surfaces
+
+The daemon owns `com.clipman.Daemon` on the session bus; the extension
+owns `org.gnome.Shell.Extensions.clipman`. Inspect them with:
+
+```bash
+gdbus introspect --session --dest com.clipman.Daemon \
+    --object-path /com/clipman/Daemon
+gdbus introspect --session --dest org.gnome.Shell.Extensions.clipman \
+    --object-path /org/gnome/Shell/Extensions/clipman
+```
+
+Manually trigger the popup:
+
+```bash
+gdbus call --session --dest com.clipman.Daemon \
+    --object-path /com/clipman/Daemon \
+    --method com.clipman.Daemon.Toggle
+```
+
+## Useful environment variables
+
+- `CLIPMAN_DATA_DIR` — override the default `~/.local/share/clipman/`.
+- `SNAP` (set by the snap runtime) — turns on the snap-aware code
+  paths in `clipman/app.py` and skips `wl-paste --watch` (it can't
+  see the host clipboard under strict confinement).
+- `FLATPAK_ID` — flatpak install kind detection.
+
+## Where to read next
+
+- `docs/adr/` — design decisions (CodeQL ratchet, OIDC publishing,
+  D-Bus mode arg, branch-protection posture).
+- `docs/releases/README.md` — how a release is cut.
+- `CONTRIBUTING.md` — PR workflow, commit style, and the issue
+  templates this repo expects.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,114 @@
+# Release checklist
+
+End-to-end runbook for cutting a Clipman release. The release pipeline
+itself (`.github/workflows/release.yml`) is documented in
+`docs/releases/README.md` and ADR 0004 — this file is the *human* steps
+that lead up to pushing the tag.
+
+## Preconditions
+
+- Working tree on `main`, fully up to date with `origin/main`.
+- `gh auth status` shows you logged in as `MohammedEl-sayedAhmed`.
+- `SNAPCRAFT_STORE_CREDENTIALS` repo secret is still set (token is
+  renewed yearly; the Snap Store will email a reminder ~30 days
+  before expiry).
+- PyPI trusted publisher is configured at
+  https://pypi.org/manage/account/publishing — project
+  `clipman-clipboard`, repo `clipman`, workflow `release.yml`,
+  environment `pypi`. First-release-only.
+
+## Cut a release
+
+Assume you're going from `1.0.4` to `1.0.5`.
+
+```bash
+# 1. Sync.
+git checkout main
+git fetch origin --prune --tags
+git reset --hard origin/main
+
+# 2. Bump versions in lockstep.
+./scripts/bump-version.sh 1.0.5
+# This touches pyproject.toml, snap/snapcraft.yaml, flathub/*.json,
+# aur/PKGBUILD, and clipman/__init__.py.
+
+# 3. Promote the Unreleased section in CHANGELOG.md.
+#    Open CHANGELOG.md and rename `## [Unreleased]` to
+#    `## [1.0.5] - YYYY-MM-DD` (today's date). Add a fresh
+#    `## [Unreleased]` block at the top.
+$EDITOR CHANGELOG.md
+
+# 4. Verify locally.
+python3 -m unittest discover -s tests
+ruff check clipman tests
+
+# 5. Commit the bump.
+git add pyproject.toml snap/snapcraft.yaml flathub/*.json aur/PKGBUILD \
+        clipman/__init__.py CHANGELOG.md
+git commit -m "chore: bump to 1.0.5"
+git push origin main
+
+# 6. Tag and push. This is the trigger.
+git tag -s v1.0.5 -m "v1.0.5"   # or unsigned: git tag v1.0.5
+git push origin v1.0.5
+```
+
+The tag push fires `release.yml`. Watch the run in the Actions tab —
+each stage either annotates the failure or moves on:
+
+1. **pre-flight** — confirms `pyproject.toml` and `snap/snapcraft.yaml`
+   match the tag; extracts the matching `CHANGELOG.md` section.
+2. **tests** — Python 3.10 / 3.11 / 3.12 matrix.
+3. **build-pypi** — `python -m build`, uploads dist/ artifact.
+4. **publish-pypi** — OIDC trusted publish.
+5. **build-snap** — `snapcore/action-build`, uploads .snap artifact.
+6. **publish-snap** — releases to the `stable` channel.
+7. **bundle-extension** — `gnome-extensions pack` → versioned zip.
+8. **github-release** — creates the GH Release with all artifacts and
+   the auto-extracted CHANGELOG section as the body.
+
+If a stage fails before publish, the tag is already on `origin` — you
+can:
+
+- Push a fix commit to `main`, delete the tag (`git push --delete
+  origin v1.0.5 && git tag -d v1.0.5`), retag.
+- Or workflow-dispatch the release with the existing tag once main is
+  green.
+
+## After the pipeline goes green
+
+These steps aren't automatable today:
+
+- **GNOME Extensions website** — download
+  `clipman-extension-v1.0.5.zip` from the new GH Release and upload it
+  at https://extensions.gnome.org/upload/. EGO has no programmatic
+  upload API.
+- **AUR** — bump `aur/PKGBUILD` (the bump script already did this) and
+  push to the AUR remote if you maintain a separate AUR repo.
+- **Flathub** — open a PR against the Flathub repo bumping the
+  manifest source URL / commit. The in-repo manifest under `flathub/`
+  is for reference only.
+
+## Verify the release publicly
+
+```bash
+pip index versions clipman-clipboard | head -3
+snap info clipman | grep tracking
+gh release view v1.0.5 --json assets --jq '.assets[].name'
+```
+
+You should see the new version on PyPI within ~1 min of the publish
+step, on the Snap Store stable channel within ~5 min, and the GH
+Release listing wheel + sdist + snap + extension zip.
+
+## Roll back
+
+If a release is broken in a way users will notice:
+
+- **PyPI**: you cannot delete or replace a published version. Bump
+  patch (e.g. `1.0.6`) and re-cut.
+- **Snap Store**: revert to the previous revision via
+  `snapcraft revert clipman --revision=<prev>` or the Snap Store
+  dashboard.
+- **GH Release**: edit notes to add a "yanked" prefix and a pointer to
+  the fixed release. Don't delete the tag.


### PR DESCRIPTION
## Summary

Fills the documentation gaps left after the recent CI/security/release sweep. No code changes.

## New files

| Path | Purpose |
|------|---------|
| `CODE_OF_CONDUCT.md` | Contributor Covenant v2.1, verbatim from the upstream EthicalSource repo. |
| `docs/development.md` | Build-from-source, test, lint, debugging guide for the daemon + the GNOME Shell extension. Includes D-Bus introspection and env vars. |
| `docs/release-checklist.md` | Human runbook around `scripts/bump-version.sh` + CHANGELOG promotion + tag push, plus post-pipeline steps (EGO upload, AUR, Flathub PR). |
| `docs/adr/0008-ratchet-fingerprint-strategy.md` | Documents PR #20's pivot to SARIF `partialFingerprints` and the skip-on-push fix to the ratchet. |
| `docs/adr/0009-snap-rebuild-cadence.md` | Documents PR #9's weekly `snap-refresh.yml` decision and why it ships to `edge` by default. |

## Updates

- `docs/adr/README.md` — index now lists ADRs 0008 + 0009.
- `CHANGELOG.md` — `[Unreleased] → Internal / CI` subsection refreshed with entries for the rest of the Dependabot bumps (#11, #12, #13, #14), #18 (stray manifest removed), #20 (ratchet fix), #21 (README architecture diagram), and #22 (Scorecard SHA fix), plus the docs files added here.

## Type of change

- [x] Documentation

## Testing

- [x] Files render correctly on the GitHub PR preview.
- [x] `ruff check clipman tests` — clean (no code touched).
- [x] All ADR links resolve (relative paths inside `docs/adr/`).