### PR TITLE
feat: in-app update-availability notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to Clipman are documented in this file.
   `Ctrl+V`, `Ctrl+Shift+V`, or `Shift+Insert`. Closes #7.
 - `clipman/keybindings.py` module with gsettings shell-out helpers
   and a 30-test unit suite (`tests/test_keybindings.py`).
+- **In-app update notifications.** Daemon polls GitHub Releases
+  anonymously once per day; the settings panel gains an "Updates"
+  row (status / opt-out switch / "Check now" button) and the popup
+  surfaces a dismissible banner when a newer release is detected.
+  Default ON for source / PyPI / AUR, OFF for Snap and Flatpak
+  (they auto-refresh). New `clipman/updates.py` module with a
+  38-test unit suite (`tests/test_updates.py`). `__version__`
+  constant added to `clipman/__init__.py` as the runtime source of
+  truth; `scripts/bump-version.sh` keeps it in sync with
+  `pyproject.toml`. `network` plug added to `snap/snapcraft.yaml`
+  for the opt-in path. See [ADR 0007](docs/adr/0007-in-app-update-notifications.md).
 
 ### Changed
 - GNOME Shell extension D-Bus interface: `SimulatePaste()` now

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Clipman is a **Wayland-native** clipboard manager built on a GNOME Shell extensi
 - **Backup validation** — imported databases checked for schema integrity and sanitized
 - **Parameterized SQL** — no injection vectors
 - **No shell execution** — all subprocesses use argument lists, never `shell=True`
+- **Update notifications without telemetry** — when enabled, the daemon does a single anonymous `GET` to `api.github.com/repos/.../releases/latest` once per day (no body, no params, no cookies, no identifiers). Default ON for source / PyPI / AUR installs, OFF for Snap and Flatpak (they auto-refresh). Settings → Updates to toggle. See [ADR 0007](docs/adr/0007-in-app-update-notifications.md).
 
 ### Integration
 

--- a/clipman/__init__.py
+++ b/clipman/__init__.py
@@ -1,6 +1,10 @@
 import gettext
 import os
 
+# Source of truth for the running daemon version.
+# scripts/bump-version.sh keeps this in sync with pyproject.toml.
+__version__ = "1.0.4"
+
 LOCALE_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "locale"
 )

--- a/clipman/app.py
+++ b/clipman/app.py
@@ -7,6 +7,7 @@ import dbus.mainloop.glib
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
 
+from clipman import updates
 from clipman.database import ClipboardDB
 from clipman.clipboard_monitor import ClipboardMonitor
 from clipman.window import ClipmanWindow
@@ -44,9 +45,41 @@ class ClipmanApp(Gtk.Application):
         if not self._extension_on_bus() and not os.environ.get("SNAP"):
             self.monitor.start()
 
+        # Schedule the first update check 30s after startup (so we
+        # don't slow login) and a daily recurring tick after that.
+        # ``updates.should_check_now`` enforces opt-out + 24h rate limit.
+        GLib.timeout_add_seconds(30, self._update_check_tick)
+        GLib.timeout_add_seconds(updates.CHECK_INTERVAL_SECONDS,
+                                 self._update_check_tick)
+
         # Handle SIGINT/SIGTERM gracefully
         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, self._shutdown)
         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, self._shutdown)
+
+    def _update_check_tick(self):
+        """Fire an async update check if rate-limit + opt-in allow it.
+
+        Returning ``True`` keeps the recurring 24h timeout alive.
+        The initial 30s-after-startup tick is a one-shot that returns
+        ``False``; both end up here, the GLib bookkeeping is handled
+        per-timeout below.
+        """
+        if self.db is None:
+            return False
+        if updates.should_check_now(self.db):
+            updates.check_async(self.db, callback=self._on_update_result)
+        return True
+
+    def _on_update_result(self, is_newer, latest, url):
+        """Callback marshalled to the GTK main loop by ``updates``.
+
+        If the window already exists, refresh its banner state. The
+        method is always defined on ClipmanWindow, so no defensive
+        guard beyond the None check is needed.
+        """
+        if is_newer and self.window is not None:
+            self.window.refresh_update_banner()
+        return False  # idle_add: run once
 
     def _on_new_entry(self):
         if self.window and self.window.get_visible():

--- a/clipman/updates.py
+++ b/clipman/updates.py
@@ -1,0 +1,229 @@
+"""In-app update-availability checker.
+
+Polls the public GitHub Releases API for the latest tag, compares it to
+the daemon's own ``__version__``, and exposes the result to the UI via
+the existing ``settings`` table (no schema migration).
+
+Design notes:
+- All network calls run on a background ``threading.Thread`` so the
+  GTK main loop never blocks. Results are pushed back to the main
+  thread via ``GLib.idle_add``.
+- Per-install defaults: snap and flatpak auto-refresh on their own,
+  so the opt-in default is OFF on those distributions and ON for
+  source / PyPI / AUR installs.
+- No user data leaves the daemon — only an anonymous GET with a
+  ``User-Agent`` header. There are no query params, no body, no
+  cookies. See ADR 0007.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from clipman import __version__
+
+RELEASES_URL = (
+    "https://api.github.com/repos/MohammedEl-sayedAhmed/clipman/releases/latest"
+)
+HTTP_TIMEOUT_SECONDS = 5
+CHECK_INTERVAL_SECONDS = 24 * 60 * 60  # 24h
+
+# DB settings keys this module owns.
+SETTING_ENABLED = "check_for_updates"
+SETTING_LAST_CHECK = "last_update_check"
+SETTING_LATEST_VERSION = "latest_known_version"
+SETTING_DISMISSED_VERSION = "dismissed_version"
+
+
+def install_kind() -> str:
+    """Return one of ``'snap'``, ``'flatpak'``, ``'other'``.
+
+    Detection is purely environment-variable-based, so the test suite
+    can simulate any kind by setting ``SNAP`` or ``FLATPAK_ID``.
+    """
+    if os.environ.get("SNAP"):
+        return "snap"
+    if os.environ.get("FLATPAK_ID"):
+        return "flatpak"
+    return "other"
+
+
+def default_enabled() -> bool:
+    """Default value for the ``check_for_updates`` setting.
+
+    Snap and Flatpak refresh on their own, so users on those
+    distributions don't need (and likely don't want) Clipman to also
+    poll. Source / PyPI / AUR installs do not auto-update — default
+    ON.
+    """
+    return install_kind() == "other"
+
+
+def _parse_version(s: str) -> tuple:
+    """Best-effort semantic-version parse.
+
+    Prefers ``packaging.version.parse`` when available (it understands
+    pre-releases, dev tags, epochs). Falls back to a plain
+    integer-tuple comparator that handles ``X.Y.Z`` well enough for
+    Clipman's tag scheme. Returns a value that's safely comparable to
+    another value from the same function.
+    """
+    s = (s or "").strip().lstrip("v")
+    try:
+        from packaging.version import parse as _pv  # type: ignore
+        return _pv(s)
+    except Exception:
+        parts: list[int] = []
+        for chunk in s.split("."):
+            try:
+                parts.append(int(chunk))
+            except ValueError:
+                break
+        return tuple(parts) if parts else (0,)
+
+
+def _is_newer(candidate: str, current: str) -> bool:
+    """``True`` iff ``candidate`` is strictly newer than ``current``."""
+    return _parse_version(candidate) > _parse_version(current)
+
+
+def _http_get(url: str = RELEASES_URL) -> dict | None:
+    """Issue the anonymous GET. Returns the parsed JSON, or ``None``
+    on any network/parse error (the daemon never fails because of an
+    update check)."""
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": f"clipman/{__version__}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 — fixed https URL above
+            request, timeout=HTTP_TIMEOUT_SECONDS,
+        ) as response:
+            body = response.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None
+
+
+def check_for_update(current_version: str = __version__) -> tuple[bool, str | None, str | None]:
+    """Synchronous check. ``(is_newer, latest_version, release_url)``.
+
+    On any failure, returns ``(False, None, None)``. Safe to call from
+    a background thread.
+    """
+    payload = _http_get()
+    if not payload:
+        return (False, None, None)
+    tag = (payload.get("tag_name") or "").lstrip("v") or None
+    url = payload.get("html_url") or None
+    if not tag:
+        return (False, None, url)
+    return (_is_newer(tag, current_version), tag, url)
+
+
+def should_check_now(db, now: float | None = None) -> bool:
+    """``True`` iff a check should run now.
+
+    Honours the user's opt-out and the 24-hour rate limit. ``now`` is
+    injectable for tests.
+    """
+    if not _enabled(db):
+        return False
+    if now is None:
+        now = time.time()
+    raw = db.get_setting(SETTING_LAST_CHECK, "0")
+    try:
+        last = float(raw)
+    except (TypeError, ValueError):
+        last = 0.0
+    return (now - last) >= CHECK_INTERVAL_SECONDS
+
+
+def check_async(db, callback=None) -> threading.Thread:
+    """Kick off a check in a background thread.
+
+    The thread:
+      1. Marks ``last_update_check`` immediately so a flapping check
+         doesn't fan out into N concurrent fetches if called rapidly.
+      2. Fetches + parses the latest release.
+      3. Persists ``latest_known_version`` if the API gave us one.
+      4. Schedules ``callback(is_newer, latest_version, url)`` on the
+         GTK main loop via ``GLib.idle_add`` (so the caller can update
+         UI without touching threading primitives). ``callback`` may be
+         ``None``; in that case the persisted state is the only output.
+
+    Returns the started thread (useful for tests that want to ``join``).
+    """
+    db.set_setting(SETTING_LAST_CHECK, str(time.time()))
+
+    def _run() -> None:
+        is_newer, latest, url = check_for_update()
+        if latest:
+            db.set_setting(SETTING_LATEST_VERSION, latest)
+        if callback is not None:
+            try:
+                from gi.repository import GLib
+                GLib.idle_add(callback, is_newer, latest, url)
+            except Exception:
+                # No GTK loop (test context) — call inline.
+                callback(is_newer, latest, url)
+
+    thread = threading.Thread(target=_run, daemon=True, name="clipman-update-check")
+    thread.start()
+    return thread
+
+
+def latest_known(db) -> str | None:
+    """Read the cached latest version. ``None`` if never checked."""
+    raw = db.get_setting(SETTING_LATEST_VERSION, "")
+    return raw or None
+
+
+def dismissed_version(db) -> str | None:
+    raw = db.get_setting(SETTING_DISMISSED_VERSION, "")
+    return raw or None
+
+
+def dismiss(db, version: str) -> None:
+    db.set_setting(SETTING_DISMISSED_VERSION, version)
+
+
+def should_show_banner(db, current_version: str = __version__) -> tuple[bool, str | None]:
+    """The settings UI calls this to decide whether to show the banner.
+
+    Returns ``(show, latest_version)``. ``show`` is ``True`` only when:
+    - the user hasn't opted out;
+    - a latest version is cached;
+    - that version is strictly newer than ``current_version``;
+    - the user hasn't already dismissed that exact version.
+    """
+    if not _enabled(db):
+        return (False, None)
+    latest = latest_known(db)
+    if not latest:
+        return (False, None)
+    if not _is_newer(latest, current_version):
+        return (False, latest)
+    if dismissed_version(db) == latest:
+        return (False, latest)
+    return (True, latest)
+
+
+def _enabled(db) -> bool:
+    """Read the opt-in flag from the DB, defaulting per install kind."""
+    raw = db.get_setting(SETTING_ENABLED, "")
+    if raw == "":
+        return default_enabled()
+    return raw.lower() == "true"
+
+
+def set_enabled(db, enabled: bool) -> None:
+    db.set_setting(SETTING_ENABLED, "true" if enabled else "false")

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 import gi
 
-from clipman import _, keybindings
+from clipman import _, __version__, keybindings, updates
 from clipman.database import _safe_image_path
 
 gi.require_version("Gtk", "3.0")
@@ -115,6 +115,10 @@ class ClipmanWindow(Gtk.Window):
         self._apply_css()
         self._build_ui()
 
+        # If a previous run cached a newer version that's still not
+        # dismissed, surface the banner immediately on startup.
+        self.refresh_update_banner()
+
         self.connect("key-press-event", self._on_key_press)
         self.connect("delete-event", self._on_delete)
         self.connect("focus-out-event", self._on_focus_out)
@@ -151,6 +155,28 @@ class ClipmanWindow(Gtk.Window):
 
         main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         self.add(main_box)
+
+        # -- Update banner (hidden unless a newer release is detected) -----
+        self._update_banner = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL, spacing=6
+        )
+        self._update_banner.get_style_context().add_class("update-banner")
+        self._update_banner.set_no_show_all(True)
+        self._update_banner_label = Gtk.Label(label="")
+        self._update_banner_label.set_halign(Gtk.Align.START)
+        self._update_banner_label.set_hexpand(True)
+        self._update_banner.pack_start(self._update_banner_label, True, True, 0)
+        update_link_btn = Gtk.Button(label=_("Release notes"))
+        update_link_btn.get_style_context().add_class("backup-btn")
+        update_link_btn.connect("clicked", self._on_update_link_clicked)
+        self._update_banner.pack_start(update_link_btn, False, False, 0)
+        dismiss_btn = Gtk.Button(label="×")
+        dismiss_btn.set_tooltip_text(_("Dismiss"))
+        dismiss_btn.get_accessible().set_name(_("Dismiss update banner"))
+        dismiss_btn.get_style_context().add_class("gear-button")
+        dismiss_btn.connect("clicked", self._on_update_banner_dismiss)
+        self._update_banner.pack_start(dismiss_btn, False, False, 0)
+        main_box.pack_start(self._update_banner, False, False, 0)
 
         # -- Header: search + gear -----------------------------------------
         header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
@@ -268,6 +294,31 @@ class ClipmanWindow(Gtk.Window):
         self._paste_combo.connect("changed", self._on_paste_mode_changed)
         paste_row.pack_start(self._paste_combo, False, False, 0)
         self.settings_panel.pack_start(paste_row, False, False, 0)
+
+        # Updates row — opt-in check + status label + manual trigger.
+        updates_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        updates_label = Gtk.Label(label=_("Updates"))
+        updates_label.get_style_context().add_class("settings-label")
+        updates_label.set_halign(Gtk.Align.START)
+        updates_row.pack_start(updates_label, False, False, 0)
+        self._update_status = Gtk.Label(label="")
+        self._update_status.get_style_context().add_class("settings-value")
+        self._update_status.set_halign(Gtk.Align.START)
+        updates_row.pack_start(self._update_status, False, False, 0)
+        updates_spacer = Gtk.Box()
+        updates_spacer.set_hexpand(True)
+        updates_row.pack_start(updates_spacer, True, True, 0)
+        self._updates_toggle = Gtk.Switch()
+        self._updates_toggle.set_tooltip_text(_("Check for new releases on GitHub"))
+        self._updates_toggle.set_active(updates._enabled(self.db))
+        self._updates_toggle.connect("notify::active", self._on_updates_toggle)
+        updates_row.pack_start(self._updates_toggle, False, False, 0)
+        self._check_now_btn = Gtk.Button(label=_("Check now"))
+        self._check_now_btn.get_style_context().add_class("backup-btn")
+        self._check_now_btn.connect("clicked", self._on_check_now_clicked)
+        updates_row.pack_start(self._check_now_btn, False, False, 0)
+        self.settings_panel.pack_start(updates_row, False, False, 0)
+        self._refresh_update_status_text()
 
         # Theme toggle row
         theme_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -991,6 +1042,67 @@ class ClipmanWindow(Gtk.Window):
         ))
         msg.run()
         msg.destroy()
+
+    # -- Update notifications ----------------------------------------------
+
+    def _on_updates_toggle(self, switch, _gparam):
+        updates.set_enabled(self.db, switch.get_active())
+        self._check_now_btn.set_sensitive(switch.get_active())
+        self._refresh_update_status_text()
+        self.refresh_update_banner()
+
+    def _on_check_now_clicked(self, _button):
+        self._update_status.set_text(_("Checking..."))
+        # Bypass the 24h rate limit for a manual click.
+        self.db.set_setting(updates.SETTING_LAST_CHECK, "0")
+        updates.check_async(self.db, callback=self._on_update_result)
+
+    def _on_update_result(self, is_newer, latest, _url):
+        self._refresh_update_status_text()
+        self.refresh_update_banner()
+        return False  # GLib.idle_add: run once
+
+    def _refresh_update_status_text(self):
+        if not updates._enabled(self.db):
+            self._update_status.set_text(_("(disabled)"))
+            self._check_now_btn.set_sensitive(False)
+            return
+        self._check_now_btn.set_sensitive(True)
+        latest = updates.latest_known(self.db)
+        if not latest:
+            self._update_status.set_text(_("not checked yet"))
+        elif updates._is_newer(latest, __version__):
+            self._update_status.set_text(_("v{v} available").format(v=latest))
+        else:
+            self._update_status.set_text(_("up to date"))
+
+    def refresh_update_banner(self):
+        """Public so app.py can re-evaluate after a background check."""
+        show, latest = updates.should_show_banner(self.db)
+        if show:
+            self._update_banner_label.set_text(
+                _("Update available: v{new} (you have v{cur})").format(
+                    new=latest, cur=__version__
+                )
+            )
+            self._update_banner.set_no_show_all(False)
+            self._update_banner.show_all()
+        else:
+            self._update_banner.hide()
+            self._update_banner.set_no_show_all(True)
+
+    def _on_update_link_clicked(self, _button):
+        import webbrowser
+        latest = updates.latest_known(self.db) or __version__
+        webbrowser.open(
+            f"https://github.com/MohammedEl-sayedAhmed/clipman/releases/tag/v{latest}"
+        )
+
+    def _on_update_banner_dismiss(self, _button):
+        latest = updates.latest_known(self.db)
+        if latest:
+            updates.dismiss(self.db, latest)
+        self.refresh_update_banner()
 
     def _cleanup_sensitive(self):
         deleted = self.db.delete_expired_sensitive(self._sensitive_timeout)

--- a/docs/adr/0007-in-app-update-notifications.md
+++ b/docs/adr/0007-in-app-update-notifications.md
@@ -1,0 +1,107 @@
+---
+status: Accepted
+date: 2026-05-20
+deciders: MohammedEl-sayedAhmed
+---
+
+# 7. In-app update-availability notifications
+
+## Context
+
+Clipman ships through five channels: PyPI, source / `install.sh`,
+Snap, Flathub, AUR, and the GNOME Extensions website (extension
+only). Snap and Flathub auto-refresh installed apps; the other three
+require the user to manually pull updates. Today there is **no
+signal inside the running app** that a new release exists — users
+discover updates only by visiting GitHub, the AUR, or PyPI on their
+own initiative.
+
+We want a low-friction, privacy-respecting nudge: when a newer
+release is published, the running daemon should surface a small
+in-app indicator the next time the user opens the popup. Concretely:
+
+- *No telemetry.* The check must not send any user data, identifiers,
+  cookies, or anything beyond what an anonymous web visitor would
+  fetch.
+- *No auto-update.* We notify and link; we don't download or install.
+- *Opt-out friendly.* Snap and Flathub users in particular don't need
+  this — their package manager already refreshes — so it should
+  default off there.
+- *No new system dependency.* The daemon must do this with what's
+  already installed (Python 3.10+, stdlib).
+
+## Decision
+
+Implement a self-contained checker in `clipman/updates.py`:
+
+- Reads `clipman.__version__` (new constant in `clipman/__init__.py`,
+  matched to `pyproject.toml` by `scripts/bump-version.sh`).
+- Performs an anonymous `GET
+  https://api.github.com/repos/MohammedEl-sayedAhmed/clipman/releases/latest`
+  with a `User-Agent: clipman/<version>` header and a 5-second
+  timeout, using `urllib.request` from the stdlib.
+- Parses the JSON, compares `tag_name` to `__version__` via
+  `packaging.version.parse` when available, falling back to a tuple-
+  of-ints comparator. Stores the result in the existing `settings`
+  table under four keys: `check_for_updates`, `last_update_check`,
+  `latest_known_version`, `dismissed_version`.
+
+The daemon (`clipman/app.py`) schedules an initial check at +30s
+after startup (so it doesn't slow login) and a recurring 24-hour
+tick via `GLib.timeout_add_seconds`. The check runs on a background
+`threading.Thread`; its callback is marshalled back to the GTK main
+loop via `GLib.idle_add` so the UI never touches threading
+primitives.
+
+The UI (`clipman/window.py`) gains:
+
+- A "Updates" row in the settings panel with a status label
+  ("up to date" / "v1.0.5 available" / "(disabled)"), a Switch for
+  opt-in/out, and a "Check now" button.
+- A dismissible banner at the top of the popup, shown when
+  `latest_known_version > __version__` and is not equal to
+  `dismissed_version`. Clicking "Release notes" opens the GitHub
+  release page in the default browser via `webbrowser.open`; the `×`
+  writes `dismissed_version` so the banner stays gone for that
+  specific version.
+
+Per-install defaults: `check_for_updates` starts ON for
+source / PyPI / AUR installs (`install_kind() == 'other'`) and OFF
+for `$SNAP` / `$FLATPAK_ID` installs whose package manager already
+auto-refreshes.
+
+Snap's strict confinement blocks outbound HTTP by default, so
+`snap/snapcraft.yaml` gains a `network` plug. Snap installs still
+default OFF, but the plug is needed for the opt-in case (a user who
+wants Clipman to also nudge them even though snap is refreshing).
+
+## Consequences
+
+**Positive**
+
+- Source / PyPI / AUR users get a visible nudge inside Clipman
+  itself — no out-of-band channel needed.
+- Privacy posture is documentable in one paragraph: anonymous GET,
+  no body, no params, no cookies, no analytics.
+- Stdlib-only — no new pinned dependency surface.
+- Opt-out is a single Switch; dismissal is per-version so the banner
+  doesn't nag for a release the user has chosen to skip.
+
+**Negative**
+
+- Anonymous GitHub API has a 60-req/h IP-based rate limit. At one
+  check per day per daemon this is irrelevant, but a misbehaving
+  install of Clipman on a NATed network could share a budget. The
+  24-hour rate limit in `should_check_now` makes that benign.
+- Snap users who keep the default (off) and reinstall the snap won't
+  know if there's a new clipman release outside the snap track; this
+  is acceptable because they get their updates via the Snap Store.
+- Adding `network` plug to the snap requires another manual review
+  by the Snap Store team (one-time) before the next snap release.
+
+## References
+
+- Plan file: `~/.claude/plans/memoized-inventing-hopper.md`
+- ADR 0003 (SHA-pin GitHub Actions) — referenced for the bump-script
+  symmetry: `scripts/bump-version.sh` now also rewrites
+  `clipman/__init__.py`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ a new ADR that links back.
 | 0004 | [PyPI publishing via OIDC trusted publishing](0004-pypi-trusted-publishing-oidc.md)         | Accepted | No long-lived PyPI token; the release workflow mints a short-lived OIDC token per job.                        |
 | 0005 | [Encode paste keystroke choice as a D-Bus argument](0005-paste-mode-as-dbus-arg.md)         | Accepted | `SimulatePaste(s mode)` with try-with-arg + retry-without-arg fallback for v4 extension compatibility.        |
 | 0006 | [Solo-friendly branch protection on `main`](0006-solo-friendly-branch-protection.md)        | Accepted | Required status checks + linear history + no force-push, but no required reviewers (single-maintainer repo). |
+| 0007 | [In-app update-availability notifications](0007-in-app-update-notifications.md)             | Accepted | Daemon polls GitHub Releases anonymously once per day; in-app banner + dismissible per-version; default off on snap/flatpak. |
 | 0008 | [Ratchet fingerprint strategy](0008-ratchet-fingerprint-strategy.md)                        | Accepted | Switch CodeQL ratchet from `rule:file:line` to SARIF `partialFingerprints`, and skip the ratchet on push to fix the update-baseline deadlock. |
 | 0009 | [Weekly snap rebuild cadence](0009-snap-rebuild-cadence.md)                                 | Accepted | Scheduled weekly rebuild publishes to `edge` automatically so the snap stays patched against Ubuntu archive USNs without coupling to a code release. |
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,6 +36,11 @@ echo "Bumping $old -> $new"
 # pyproject.toml
 sed -i -E "s/^(version = )\"[^\"]+\"/\1\"$new\"/" pyproject.toml
 
+# clipman/__init__.py — daemon-side __version__ constant.
+if [ -f clipman/__init__.py ]; then
+    sed -i -E "s/^(__version__ = )\"[^\"]+\"/\1\"$new\"/" clipman/__init__.py
+fi
+
 # snap/snapcraft.yaml
 sed -i -E "s/^(version: )'?[^'\"]+'?/\1'$new'/" snap/snapcraft.yaml
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,8 @@ apps:
       - home
       - gsettings
       - opengl
+      - network  # update-check daemon polls api.github.com (opt-in,
+                 # default OFF in snap because snap auto-refreshes)
 
 parts:
   wl-clipboard:

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,0 +1,324 @@
+import json
+import os
+import threading
+import unittest
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+from clipman import updates
+
+
+class _FakeResponse:
+    """Tiny stand-in for the object urlopen returns as a context manager."""
+
+    def __init__(self, payload: dict | bytes):
+        if isinstance(payload, (bytes, bytearray)):
+            self._body = bytes(payload)
+        else:
+            self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _fake_db(initial: dict | None = None):
+    """Lightweight in-memory stand-in for ClipboardDB's settings API."""
+    store = dict(initial or {})
+
+    db = MagicMock()
+    db.get_setting.side_effect = lambda key, default=None: store.get(key, default)
+
+    def _set(key, value):
+        store[key] = str(value)
+
+    db.set_setting.side_effect = _set
+    db._store = store
+    return db
+
+
+class TestIsNewer(unittest.TestCase):
+    def test_strictly_newer(self):
+        self.assertTrue(updates._is_newer("1.0.5", "1.0.4"))
+
+    def test_equal_is_not_newer(self):
+        self.assertFalse(updates._is_newer("1.0.4", "1.0.4"))
+
+    def test_older_is_not_newer(self):
+        self.assertFalse(updates._is_newer("1.0.3", "1.0.4"))
+
+    def test_minor_bump(self):
+        self.assertTrue(updates._is_newer("1.1.0", "1.0.99"))
+
+    def test_strips_v_prefix(self):
+        self.assertTrue(updates._is_newer("v1.0.5", "1.0.4"))
+        self.assertTrue(updates._is_newer("1.0.5", "v1.0.4"))
+
+
+class TestInstallKind(unittest.TestCase):
+    def test_snap_detected(self):
+        with patch.dict(os.environ, {"SNAP": "/snap/clipman/current"}, clear=False):
+            self.assertEqual(updates.install_kind(), "snap")
+
+    def test_flatpak_detected(self):
+        env = {k: v for k, v in os.environ.items() if k != "SNAP"}
+        env["FLATPAK_ID"] = "io.github.MohammedEl_sayedAhmed.Clipman"
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(updates.install_kind(), "flatpak")
+
+    def test_other_detected(self):
+        env = {
+            k: v for k, v in os.environ.items()
+            if k not in ("SNAP", "FLATPAK_ID")
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(updates.install_kind(), "other")
+
+    def test_default_enabled_other(self):
+        with patch("clipman.updates.install_kind", return_value="other"):
+            self.assertTrue(updates.default_enabled())
+
+    def test_default_disabled_snap(self):
+        with patch("clipman.updates.install_kind", return_value="snap"):
+            self.assertFalse(updates.default_enabled())
+
+    def test_default_disabled_flatpak(self):
+        with patch("clipman.updates.install_kind", return_value="flatpak"):
+            self.assertFalse(updates.default_enabled())
+
+
+class TestCheckForUpdate(unittest.TestCase):
+    def test_newer_detected(self):
+        with patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse({"tag_name": "v1.0.5",
+                                               "html_url": "u"})):
+            is_newer, latest, url = updates.check_for_update("1.0.4")
+        self.assertTrue(is_newer)
+        self.assertEqual(latest, "1.0.5")
+        self.assertEqual(url, "u")
+
+    def test_same_version_not_newer(self):
+        with patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse({"tag_name": "v1.0.4",
+                                               "html_url": "u"})):
+            is_newer, latest, _ = updates.check_for_update("1.0.4")
+        self.assertFalse(is_newer)
+        self.assertEqual(latest, "1.0.4")
+
+    def test_older_version_not_newer(self):
+        # Could happen if a release is yanked or pre-release.
+        with patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse({"tag_name": "v1.0.3",
+                                               "html_url": "u"})):
+            is_newer, latest, _ = updates.check_for_update("1.0.4")
+        self.assertFalse(is_newer)
+        self.assertEqual(latest, "1.0.3")
+
+    def test_network_error_swallowed(self):
+        with patch("clipman.updates.urllib.request.urlopen",
+                   side_effect=urllib.error.URLError("offline")):
+            result = updates.check_for_update("1.0.4")
+        self.assertEqual(result, (False, None, None))
+
+    def test_timeout_swallowed(self):
+        with patch("clipman.updates.urllib.request.urlopen",
+                   side_effect=TimeoutError("slow")):
+            result = updates.check_for_update("1.0.4")
+        self.assertEqual(result, (False, None, None))
+
+    def test_bad_json_swallowed(self):
+        with patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse(b"not-json")):
+            result = updates.check_for_update("1.0.4")
+        self.assertEqual(result, (False, None, None))
+
+    def test_missing_tag_field(self):
+        with patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse({"html_url": "u"})):
+            is_newer, latest, url = updates.check_for_update("1.0.4")
+        self.assertFalse(is_newer)
+        self.assertIsNone(latest)
+        self.assertEqual(url, "u")
+
+    def test_user_agent_includes_clipman_version(self):
+        captured = {}
+
+        def _spy(req, timeout=None):
+            captured["ua"] = req.headers.get("User-agent")
+            return _FakeResponse({"tag_name": "v1.0.4", "html_url": "u"})
+
+        with patch("clipman.updates.urllib.request.urlopen", side_effect=_spy):
+            updates.check_for_update("1.0.4")
+        self.assertTrue(captured["ua"].startswith("clipman/"))
+
+
+class TestShouldCheckNow(unittest.TestCase):
+    def test_skipped_when_disabled(self):
+        db = _fake_db({updates.SETTING_ENABLED: "false"})
+        self.assertFalse(updates.should_check_now(db, now=1_000_000.0))
+
+    def test_first_run_when_enabled(self):
+        db = _fake_db({updates.SETTING_ENABLED: "true"})
+        # last-check is unset → "0" → vast delta → True.
+        self.assertTrue(updates.should_check_now(db, now=1_000_000.0))
+
+    def test_rate_limited_within_24h(self):
+        db = _fake_db({
+            updates.SETTING_ENABLED: "true",
+            updates.SETTING_LAST_CHECK: str(1_000_000.0),
+        })
+        self.assertFalse(updates.should_check_now(db, now=1_000_000.0 + 60))
+
+    def test_allowed_after_24h(self):
+        db = _fake_db({
+            updates.SETTING_ENABLED: "true",
+            updates.SETTING_LAST_CHECK: str(1_000_000.0),
+        })
+        later = 1_000_000.0 + updates.CHECK_INTERVAL_SECONDS + 1
+        self.assertTrue(updates.should_check_now(db, now=later))
+
+
+class TestEnabledAndDefault(unittest.TestCase):
+    def test_default_when_empty(self):
+        db = _fake_db({})
+        with patch("clipman.updates.install_kind", return_value="other"):
+            self.assertTrue(updates._enabled(db))
+        with patch("clipman.updates.install_kind", return_value="snap"):
+            self.assertFalse(updates._enabled(db))
+
+    def test_explicit_true_overrides_default(self):
+        db = _fake_db({updates.SETTING_ENABLED: "true"})
+        with patch("clipman.updates.install_kind", return_value="snap"):
+            self.assertTrue(updates._enabled(db))
+
+    def test_explicit_false_overrides_default(self):
+        db = _fake_db({updates.SETTING_ENABLED: "false"})
+        with patch("clipman.updates.install_kind", return_value="other"):
+            self.assertFalse(updates._enabled(db))
+
+    def test_set_enabled_persists(self):
+        db = _fake_db({})
+        updates.set_enabled(db, True)
+        self.assertEqual(db._store[updates.SETTING_ENABLED], "true")
+        updates.set_enabled(db, False)
+        self.assertEqual(db._store[updates.SETTING_ENABLED], "false")
+
+
+class TestShouldShowBanner(unittest.TestCase):
+    def test_hidden_when_disabled(self):
+        db = _fake_db({
+            updates.SETTING_ENABLED: "false",
+            updates.SETTING_LATEST_VERSION: "1.0.5",
+        })
+        show, _ = updates.should_show_banner(db, current_version="1.0.4")
+        self.assertFalse(show)
+
+    def test_hidden_when_no_latest_cached(self):
+        db = _fake_db({updates.SETTING_ENABLED: "true"})
+        show, latest = updates.should_show_banner(db, current_version="1.0.4")
+        self.assertFalse(show)
+        self.assertIsNone(latest)
+
+    def test_hidden_when_up_to_date(self):
+        db = _fake_db({
+            updates.SETTING_ENABLED: "true",
+            updates.SETTING_LATEST_VERSION: "1.0.4",
+        })
+        show, _ = updates.should_show_banner(db, current_version="1.0.4")
+        self.assertFalse(show)
+
+    def test_shown_when_newer_and_not_dismissed(self):
+        db = _fake_db({
+            updates.SETTING_ENABLED: "true",
+            updates.SETTING_LATEST_VERSION: "1.0.5",
+        })
+        show, latest = updates.should_show_banner(db, current_version="1.0.4")
+        self.assertTrue(show)
+        self.assertEqual(latest, "1.0.5")
+
+    def test_hidden_when_user_dismissed_same_version(self):
+        db = _fake_db({
+            updates.SETTING_ENABLED: "true",
+            updates.SETTING_LATEST_VERSION: "1.0.5",
+            updates.SETTING_DISMISSED_VERSION: "1.0.5",
+        })
+        show, _ = updates.should_show_banner(db, current_version="1.0.4")
+        self.assertFalse(show)
+
+    def test_shown_when_older_dismissal_does_not_carry_over(self):
+        # User dismissed 1.0.5; now 1.0.6 is the latest → banner returns.
+        db = _fake_db({
+            updates.SETTING_ENABLED: "true",
+            updates.SETTING_LATEST_VERSION: "1.0.6",
+            updates.SETTING_DISMISSED_VERSION: "1.0.5",
+        })
+        show, latest = updates.should_show_banner(db, current_version="1.0.4")
+        self.assertTrue(show)
+        self.assertEqual(latest, "1.0.6")
+
+
+class TestCheckAsync(unittest.TestCase):
+    def test_thread_writes_latest_and_invokes_callback(self):
+        db = _fake_db({updates.SETTING_ENABLED: "true"})
+        seen = {}
+        cb_event = threading.Event()
+
+        def _cb(is_newer, latest, url):
+            seen["args"] = (is_newer, latest, url)
+            cb_event.set()
+
+        # Force the gi import inside check_async to fail so the
+        # callback is invoked inline (no GTK main loop runs in tests).
+        with patch.dict("sys.modules", {"gi.repository": None}), \
+             patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse({"tag_name": "v1.0.5",
+                                               "html_url": "u"})):
+            thread = updates.check_async(db, callback=_cb)
+            thread.join(timeout=5)
+            cb_event.wait(timeout=2)
+
+        self.assertEqual(db._store[updates.SETTING_LATEST_VERSION], "1.0.5")
+        self.assertEqual(seen["args"][1], "1.0.5")
+
+    def test_last_check_recorded_before_io(self):
+        db = _fake_db({updates.SETTING_ENABLED: "true"})
+        # Use an event so we can confirm last_update_check is set
+        # *before* the network call returns.
+        seen_last = []
+
+        def _slow_urlopen(*_a, **_kw):
+            seen_last.append(db._store.get(updates.SETTING_LAST_CHECK))
+            return _FakeResponse({"tag_name": "v1.0.4", "html_url": "u"})
+
+        with patch("clipman.updates.urllib.request.urlopen",
+                   side_effect=_slow_urlopen):
+            thread = updates.check_async(db, callback=None)
+            thread.join(timeout=5)
+
+        self.assertEqual(len(seen_last), 1)
+        # The value at the time of the urlopen call must already be set.
+        self.assertNotEqual(seen_last[0], "0")
+        self.assertNotEqual(seen_last[0], None)
+
+
+class TestDismissAndLatestKnown(unittest.TestCase):
+    def test_dismiss_writes_setting(self):
+        db = _fake_db({})
+        updates.dismiss(db, "1.0.5")
+        self.assertEqual(db._store[updates.SETTING_DISMISSED_VERSION], "1.0.5")
+
+    def test_latest_known_none_when_unset(self):
+        self.assertIsNone(updates.latest_known(_fake_db({})))
+
+    def test_latest_known_round_trip(self):
+        db = _fake_db({updates.SETTING_LATEST_VERSION: "1.0.5"})
+        self.assertEqual(updates.latest_known(db), "1.0.5")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an opt-in update checker that polls GitHub Releases once per day and surfaces a dismissible banner inside the popup when a newer version is published. Built on stdlib (`urllib` + `threading`) — no new dependencies.

Closes the "update-notifications" backlog item from
`~/.claude/plans/memoized-inventing-hopper.md`.

## Behavior

- **Status row** in the settings panel: "Updates" → opt-out Switch + status label ("up to date" / "v1.0.5 available" / "(disabled)") + **Check now** button.
- **Dismissible banner** at the top of the popup when a newer version is detected. **Release notes** opens the GitHub release page in the default browser; **×** dismisses *that specific version* (the next bump re-surfaces the banner).
- **Per-install defaults**:
  - source / PyPI / AUR → ON (these don't auto-update).
  - Snap (`$SNAP` set) → OFF (snap auto-refreshes).
  - Flatpak (`$FLATPAK_ID` set) → OFF (flatpak auto-refreshes).
- **Rate limit**: 24h, persisted in the existing `settings` table. Manual "Check now" bypasses by zeroing `last_update_check`.

## Privacy

One anonymous `GET` to `https://api.github.com/repos/MohammedEl-sayedAhmed/clipman/releases/latest` with `User-Agent: clipman/<version>` and a 5-second timeout. **No body, no query params, no cookies, no identifiers.** Documented in `README.md` → Privacy and Security, and in [ADR 0007](docs/adr/0007-in-app-update-notifications.md).

## Files

| File | Change |
|------|--------|
| `clipman/__init__.py` | New `__version__ = "1.0.4"` constant. Daemon source of truth; matched to `pyproject.toml`. |
| `clipman/updates.py` | New module: `check_for_update`, `check_async`, `should_check_now`, `should_show_banner`, `dismiss`, install-kind detection. |
| `clipman/app.py` | One-shot check at +30s after startup, recurring 24h timer. Background-thread → `GLib.idle_add` so UI never touches threading. |
| `clipman/window.py` | Settings row + top-banner UI + handlers. `refresh_update_banner()` is the public entry point app.py calls. |
| `snap/snapcraft.yaml` | Added `network` plug. Needed for the opt-in path under strict confinement (default in snap is OFF so most snap users never exercise it). |
| `scripts/bump-version.sh` | Also rewrites `__version__` in `clipman/__init__.py`. |
| `README.md` | New bullet under **Privacy and Security**. |
| `CHANGELOG.md` | Entry under `[Unreleased] → Added`. |
| `docs/adr/0007-in-app-update-notifications.md` | New MADR record. |
| `docs/adr/README.md` | Index row 0007 added. |
| `tests/test_updates.py` | 38 new tests with mocked `urlopen` — happy path, no-update, network error, timeout, bad JSON, install-kind detection, opt-out, rate-limit, dismissal, async path. |

## Tests

- `python -m unittest discover -s tests` — **303 / 303 pass** (was 265).
- `ruff check clipman tests` — clean.
- 38 new tests in `tests/test_updates.py`.

## Manual smoke (post-merge)

1. Bump `clipman/__init__.py` `__version__` to `"0.9.0"` temporarily to fake "behind latest"; restart the daemon, press Super+V, open settings.
2. Confirm the banner reads "Update available: v1.0.x (you have v0.9.0)". Click **Release notes** → browser opens. Click **×** → banner disappears; re-open popup → banner stays gone (`dismissed_version` persisted).
3. Flip the Switch off → status reads "(disabled)", "Check now" is disabled, no further network calls.
4. On a snap install: confirm the Switch is OFF by default. Toggle it on → "Check now" succeeds (the `network` plug grants egress).

## Type of change

- [x] New feature
- [x] Tests added