### PR TITLE
chore: bump to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-05-20
+
 ### Added
 - Customizable toggle shortcut from the settings panel. Click the
   shortcut button to capture a new key combination; the daemon writes

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mohammed El-sayed Ahmed <MohammedEl-sayedAhmed@users.noreply.github.com>
 pkgname=clipman-clipboard
-pkgver=1.0.4
+pkgver=1.0.5
 pkgrel=1
 pkgdesc="A clipboard history manager for Wayland (GNOME, KDE, Sway, Hyprland, etc.)"
 arch=('any')

--- a/clipman/__init__.py
+++ b/clipman/__init__.py
@@ -3,7 +3,7 @@ import os
 
 # Source of truth for the running daemon version.
 # scripts/bump-version.sh keeps this in sync with pyproject.toml.
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 LOCALE_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "locale"

--- a/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
+++ b/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
@@ -41,7 +41,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.0.4.tar.gz",
+                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.0.5.tar.gz",
                     "sha256": "bb5f2ccfb41eea1bf92bfe76fb1b786bb14f782782f155b2575f72d7859cc116"
                 },
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clipman-clipboard"
-version = "1.0.4"
+version = "1.0.5"
 description = "A clipboard history manager for Ubuntu/GNOME on Wayland"
 readme = "README.md"
 license = "Apache-2.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: clipman
-version: '1.0.4'
+version: '1.0.5'
 summary: Clipboard history manager for Wayland
 description: |
   A fast, native clipboard manager for Wayland (GNOME, KDE, Sway,


### PR DESCRIPTION
Cuts the v1.0.5 release. Pipeline trigger comes from the `v1.0.5` tag push **after** this PR merges, not from the merge itself.

## What's in 1.0.5

Promotes the following `[Unreleased]` work to a tagged release. See `CHANGELOG.md` for the full block.

### User-facing
- Customizable toggle shortcut (closes #4).
- Customizable paste keystroke (`auto` / `Ctrl+V` / `Ctrl+Shift+V` / `Shift+Insert`, closes #7).
- In-app update-availability notifications (opt-in, anonymous GET to GitHub Releases once per day, see [ADR 0007](docs/adr/0007-in-app-update-notifications.md)).

### Internal / CI
- CI/security baseline (#8), weekly snap rebuild (#9), tag-triggered release pipeline (#16), CodeQL security-baseline ratchet (#17) + ratchet fix (#20), Scorecard SHA fix (#22), Dependabot bumps (#10/#11/#12/#13/#14), stray manifest cleanup (#18), README architecture diagram (#21), final-review docs sweep (#23), in-app update notifications (#24).

### Files bumped (by `scripts/bump-version.sh 1.0.5`)

| File | Old | New |
|------|-----|-----|
| `pyproject.toml` | 1.0.4 | 1.0.5 |
| `clipman/__init__.py` (`__version__`) | 1.0.4 | 1.0.5 |
| `snap/snapcraft.yaml` | 1.0.4 | 1.0.5 |
| `flathub/io.github.MohammedEl_sayedAhmed.Clipman.json` | 1.0.4 | 1.0.5 |
| `aur/PKGBUILD` | 1.0.4 | 1.0.5 |

The GNOME extension `metadata.json` `version: 5` is intentionally **not** touched — it's an extension-versioning integer bumped on D-Bus / behavior changes, last bumped in #15.

## Verification

- `python -m unittest discover -s tests` — 303/303 pass.
- The release workflow's pre-flight job will re-verify these versions match the `v1.0.5` tag before publishing anything.

## After this merges

1. `git tag v1.0.5 -m v1.0.5 && git push --tags` — triggers `release.yml`.
2. After the pipeline goes green, manually upload the extension zip artifact from the GH Release to https://extensions.gnome.org/upload/ (no API, see ADR 0007 / `docs/releases/README.md`).

## Type of change

- [x] Build / CI / packaging (release prep)