### PR TITLE
docs(release): polish v1.0.5 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to Clipman are documented in this file.
 
 ## [1.0.5] - 2026-05-20
 
+### Highlights
+
+The first release with **customizable keyboard shortcuts** and an
+**in-app update checker**. Two long-standing community requests
+(issues [#4](https://github.com/MohammedEl-sayedAhmed/clipman/issues/4)
+and [#7](https://github.com/MohammedEl-sayedAhmed/clipman/issues/7))
+are addressed: pick any combo to open Clipman, pick how it sends the
+paste keystroke (Auto / Ctrl+V / Ctrl+Shift+V / Shift+Insert).
+
+Under the hood, this release also ships the entire CI/security and
+release-automation overhaul — Dependabot, CodeQL with a
+hash-stable baseline ratchet, OpenSSF Scorecard, secret scanning,
+gitleaks, a tag-triggered release pipeline (PyPI via OIDC, Snap
+stable, GitHub Release, extension bundle), weekly snap rebuilds for
+Ubuntu security updates, and a documentation sweep covering nine
+ADRs, a development guide, and a release runbook. See the full
+breakdown below.
+
+### Install / upgrade
+
+| Channel | Command |
+|---------|---------|
+| **PyPI** | `pip install --upgrade clipman-clipboard` |
+| **Snap** | auto-refreshes, or `snap refresh clipman` |
+| **AUR** | `yay -S clipman` (or `paru -S clipman`) |
+| **Source** | `git pull && ./install.sh` |
+| **GNOME Extension** | re-run `install.sh`, or upload the attached `clipman-extension-v1.0.5.zip` at <https://extensions.gnome.org/upload/> |
+
+### Compatibility
+
+- **GNOME Shell** 45, 46, 47, 48 (extension `metadata.json` is at
+  version 5 — `SimulatePaste(s mode)`; the daemon retries
+  no-arg automatically against an unupgraded v4 extension).
+- **Python** 3.10 – 3.12 (tested on `ubuntu-24.04`).
+
 ### Added
 - Customizable toggle shortcut from the settings panel. Click the
   shortcut button to capture a new key combination; the daemon writes

--- a/docs/releases/v1.0.5.md
+++ b/docs/releases/v1.0.5.md
@@ -1,0 +1,109 @@
+# v1.0.5 — Customizable shortcuts + in-app updates
+
+**Released 2026-05-20.**
+Latest release page on GitHub:
+<https://github.com/MohammedEl-sayedAhmed/clipman/releases/tag/v1.0.5>
+
+This file is a verbose mirror of the release notes auto-extracted
+from `CHANGELOG.md` by `release.yml`. The GitHub Release page is the
+canonical surface; this Markdown lives in-repo so the same content
+travels with the source.
+
+## Headlines
+
+- **Customizable toggle shortcut** — open the settings panel, click
+  the shortcut button, press any modifier-bearing combo. The new
+  binding writes to GNOME's `custom-keybindings` via `gsettings` and
+  also persists in the app's settings table so it survives a
+  reinstall. Default is unchanged (`Super+V`). Closes
+  [#4](https://github.com/MohammedEl-sayedAhmed/clipman/issues/4).
+- **Customizable paste keystroke** — `Auto-detect` (today's behavior:
+  `Ctrl+V` for most apps, `Ctrl+Shift+V` for terminals), `Ctrl+V`,
+  `Ctrl+Shift+V`, or `Shift+Insert` (the X11/terminal convention).
+  Closes [#7](https://github.com/MohammedEl-sayedAhmed/clipman/issues/7).
+- **In-app update notifications** — opt-in. The daemon does a single
+  anonymous GET to `api.github.com/.../releases/latest` once per day
+  (no body, no params, no cookies, no identifiers). When a newer
+  version is found, the popup shows a dismissible banner. Default
+  ON for source / PyPI / AUR installs, OFF for Snap and Flatpak
+  (their package managers already auto-refresh). See
+  [ADR 0007](../adr/0007-in-app-update-notifications.md).
+
+## Compatibility
+
+| Surface | Versions |
+|---------|----------|
+| GNOME Shell | 45, 46, 47, 48 |
+| Python | 3.10, 3.11, 3.12 |
+| Wayland compositor (without the extension) | KDE, Sway, Hyprland — any compositor with `wl-clipboard` |
+| Snap base | `core22` (Ubuntu 22.04) |
+| Extension `metadata.json` `version` | 5 (D-Bus `SimulatePaste(s mode)`) |
+
+The new daemon stays compatible with the published v4 extension:
+`SimulatePaste(mode)` raises a `DBusException` against the old
+signature, and the daemon retries with the no-arg form.
+
+## Install / upgrade
+
+| Channel | Command |
+|---------|---------|
+| PyPI | `pip install --upgrade clipman-clipboard` |
+| Snap | `snap refresh clipman` (or wait for auto-refresh) |
+| AUR | `yay -S clipman` |
+| Source | `git pull && ./install.sh` |
+| GNOME Extension | re-run `install.sh`, or upload the attached `clipman-extension-v1.0.5.zip` at <https://extensions.gnome.org/upload/> |
+
+After a source / PyPI / AUR upgrade, log out and back in once so
+GNOME Shell loads the v5 extension.
+
+## Under the hood (no user-visible change)
+
+Most of this release is invisible to a clipboard-user but central to
+maintainability:
+
+- **Supply-chain hardening** — every third-party action pinned to a
+  commit SHA with version comment (Dependabot keeps them current);
+  least-privilege `permissions:` blocks; runner pinned to
+  `ubuntu-24.04`; egress-audit via `step-security/harden-runner`.
+  See [ADR 0003](../adr/0003-sha-pin-github-actions.md).
+- **CodeQL baseline ratchet** — pre-existing CodeQL findings on
+  main don't block new PRs; only genuinely-new fingerprints do.
+  Fingerprint format is the SARIF `partialFingerprints` hash, so
+  unrelated line shifts no longer trip the ratchet. See
+  [ADR 0002](../adr/0002-baseline-ratchet-for-codeql.md) and
+  [ADR 0008](../adr/0008-ratchet-fingerprint-strategy.md).
+- **Release pipeline** — pushing a `v*.*.*` tag now runs an
+  end-to-end release: tests on 3.10/3.11/3.12, PyPI publish via
+  OIDC trusted publishing (no long-lived token), Snap publish to
+  `stable`, packed GNOME extension bundle attached, and a GitHub
+  Release with the matching CHANGELOG section as the body. See
+  [ADR 0004](../adr/0004-pypi-trusted-publishing-oidc.md) and
+  [`docs/releases/README.md`](README.md).
+- **Weekly snap rebuilds** — `snap-refresh.yml` rebuilds and
+  publishes to `edge` on a weekly cron so the snap stays patched
+  against Ubuntu archive USNs without coupling to a code release.
+  See [ADR 0009](../adr/0009-snap-rebuild-cadence.md).
+- **Solo-friendly branch protection** on `main` (required status
+  checks, linear history, no force-push, no required reviewers).
+  See [ADR 0006](../adr/0006-solo-friendly-branch-protection.md).
+- **Repo hygiene** — Contributor Covenant 2.1
+  (`CODE_OF_CONDUCT.md`), `docs/development.md` build/test/debug
+  guide, `docs/release-checklist.md` runbook, README architecture
+  diagram, and 9 MADR-format ADRs.
+
+## Known caveats
+
+- The first release exercising the publish pipeline end-to-end. If
+  PyPI / Snap publish fails, the GH Release is still created and
+  the artifacts are downloadable from the workflow run; the bug-fix
+  path is to push a `v1.0.6` tag once the pipeline issue is fixed.
+- Snap manual review may flag this release (D-Bus slot declaration
+  + new `network` plug for the opt-in update check). The publish
+  step uploads successfully; the new revision sits in review until
+  a Snap Store human approves. Edge channel is unaffected.
+
+## Thanks
+
+[#5](https://github.com/MohammedEl-sayedAhmed/clipman/pull/5) added
+dnf detection from a community contributor. Everything else in this
+release is on the maintainer.


### PR DESCRIPTION
Adds a polished Highlights / Install / Compatibility block to the existing `[1.0.5]` section in `CHANGELOG.md`, plus a verbose mirror at `docs/releases/v1.0.5.md` that links to the ADRs explaining the under-the-hood work.

`release.yml` extracts the `[1.0.5]` CHANGELOG section as the GitHub Release body, so this is the content that will land on the release page once `v1.0.5` is tagged.

## Type of change

- [x] Documentation

## Why this is needed before the tag push

The bullet-only `[1.0.5]` block from PR #25 would produce a flat list on the release page. This PR layers a narrative summary + install matrix + compatibility table + under-the-hood section above the existing bullets. Once merged, `release.yml` picks up the polished content automatically.

## After merge

`git tag v1.0.5` from the new `main` HEAD and `git push --tags` will trigger the full release pipeline.