### PR TITLE
ci(codeql): per-SHA concurrency group on push + workflow_dispatch escape hatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,24 @@ on:
     branches: [main]
   schedule:
     - cron: "27 4 * * 1"
+  workflow_dispatch:
 
 permissions: {}
 
+# On push to main, each commit needs its own analyze + update-baseline
+# run so the security-baseline branch stays in sync with current main.
+# A ref-scoped concurrency group with cancel-in-progress: false caused
+# GitHub Actions to drop subsequent pushes whose queued slot would have
+# otherwise waited behind an in-progress run, leaving the baseline
+# pinned to an older commit. Splitting the group key by event:
+#   push       -> per-SHA group (every commit gets its own slot, never collides);
+#   pull_request -> per-PR group with cancel-in-progress true (saves runner minutes on re-pushes);
+#   schedule   -> per-workflow group (only one weekly run at a time is fine).
+# workflow_dispatch is enabled below as a manual escape hatch in case
+# a future push ever does get dropped — we can refresh the baseline
+# without waiting for the next push to main.
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Problem

Earlier today, PR #24 merged to `main` right after PR #23. The post-merge CodeQL workflow run for PR #24's commit (9571b04) **never scheduled** — the concurrency group `codeql-CodeQL-refs/heads/main` with `cancel-in-progress: false` had PR #23's run in progress, and GitHub Actions silently dropped #24's queued slot instead of queueing it sequentially. Because `update-baseline` lists `analyze` in `needs:`, the security-baseline branch stayed pinned at the pre-PR-24 SHA. PR #25 (the version bump) then inherited the same drift and failed its ratchet against a stale baseline.

## Fix

Split the group key by event:

```diff
- group: codeql-${{ github.workflow }}-${{ github.ref }}
+ group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
```

| Event | Group key | Effect |
|-------|-----------|--------|
| `push` (main) | `...-<sha>` | every commit gets its own slot; no drops |
| `pull_request` | `...-<pr-number>` + `cancel-in-progress: true` | force-pushes cancel old runs (saves runner minutes) |
| `schedule` / `workflow_dispatch` | `...-<workflow>-?` | low-volume, default behavior is fine |

Also enables `workflow_dispatch` as a manual escape hatch — if a push ever does get dropped, we can re-trigger `update-baseline` without waiting for the next push to main.

## Type of change

- [x] Build / CI / packaging
- [x] Bug fix

## Verification

The fix is in workflow YAML only — it'll first run when this PR is opened (PR-side group), then again on merge (push-side group with the merge SHA). The first post-merge run should refresh the baseline branch automatically.

After merge, sanity check:
```bash
gh run list --workflow CodeQL --branch main --limit 3
git log origin/security-baseline --oneline -1   # head should advance
```