### PR TITLE
ci(release): fix annotated-tag SHAs + tolerate missing AppImage glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI (OIDC trusted publishing)
-        uses: pypa/gh-action-pypi-publish@ecb4c3dfd4790f14e30aaeac04855c7413ee9368 # v1.12.2
+        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
 
   build-snap:
     name: Build snap
@@ -229,7 +229,7 @@ jobs:
 
       - name: Build snap
         id: build
-        uses: snapcore/action-build@d12445ae70c52b1ead8b8a0ac6635f0432af5c80 # v1.3.0
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
 
       - name: Upload snap artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -283,7 +283,7 @@ jobs:
 
       - name: Publish to Snap Store (stable channel)
         if: steps.creds.outputs.enabled == 'true'
-        uses: snapcore/action-publish@d383e5c99f47316f8c8d74be837f6a77455ec5a6 # v1.2.0
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
@@ -631,7 +631,13 @@ jobs:
             Download `clipman-extension-${{ needs.pre-flight.outputs.tag }}.zip` and upload it at <https://extensions.gnome.org/upload/>. Existing source installs pick up the new extension automatically via `install.sh`.
           draft: false
           prerelease: false
-          fail_on_unmatched_files: true
+          # Tolerate missing patterns: the AppImage build is best-effort
+          # (Python+GTK packaging is brittle). We'd rather ship a release
+          # without the AppImage than fail the whole pipeline on that one
+          # glob. .deb / .rpm / snap / extension / wheel / sdist are all
+          # produced by required-success jobs, so a missing one of those
+          # would already have failed an upstream job before we got here.
+          fail_on_unmatched_files: false
           files: |
             release-assets/clipman-extension-${{ needs.pre-flight.outputs.tag }}.zip
             release-assets/clipman_*.snap

--- a/.github/workflows/snap-refresh.yml
+++ b/.github/workflows/snap-refresh.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build snap
         id: build
-        uses: snapcore/action-build@d12445ae70c52b1ead8b8a0ac6635f0432af5c80 # v1.3.0
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
 
       - name: Upload snap artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -127,7 +127,7 @@ jobs:
 
       - name: Publish to Snap Store
         if: steps.creds.outputs.enabled == 'true'
-        uses: snapcore/action-publish@d383e5c99f47316f8c8d74be837f6a77455ec5a6 # v1.2.0
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:


### PR DESCRIPTION
## Why this exists

The v1.0.5 release attempt ran the pipeline today and surfaced two real bugs (no GitHub Release was created so there's no irreversible fallout — but the snap *was* published to stable, and PyPI was *not*).

### Bug 1 — Tag-object SHA pinned for Docker-based action

`pypa/gh-action-pypi-publish` runs as a Docker action via `ghcr.io/pypa/gh-action-pypi-publish:<sha>`. We had it pinned to the **annotated-tag-object** SHA (`ecb4c3dfd...`), not the underlying commit, so the image pull failed with `Unable to find image`. Same shape as the Scorecard imposter-commit bug we hit earlier today.

`snapcore/action-{build,publish}` had the same tag-object-pin problem but still worked because they're JS actions that just need a tree, not an image tag. Fixed here for consistency and so we're not silently relying on undocumented GitHub Actions behaviour.

| Action | Old SHA (tag object) | New SHA (commit) |
|--------|----------------------|------------------|
| `pypa/gh-action-pypi-publish` v1.12.2 | `ecb4c3dfd...` | `15c56dba361d8335944d31a2ecd17d700fc7bcbc` |
| `snapcore/action-build` v1.3.0 | `d12445ae70c5...` | `3bdaa03e1ba6bf59a65f84a751d943d549a54e79` |
| `snapcore/action-publish` v1.2.0 | `d383e5c99f47...` | `214b86e5ca036ead1668c79afb81e550e6c54d40` |

`snap-refresh.yml` uses the same two snapcore actions; updated identically.

### Bug 2 — Hard fail on missing AppImage glob

`softprops/action-gh-release` was failing the github-release job with `Pattern release-assets/clipman-*-x86_64.AppImage does not match any files` because `fail_on_unmatched_files: true` treats an empty glob as a hard error.

The AppImage build step is deliberately `continue-on-error` because Python+GTK AppImage packaging is fragile. Every *required* artifact (.deb / .rpm / snap / wheel / sdist / extension) comes from a job that must succeed before `github-release` runs, so a missing one of those would already have failed an upstream job. Switched the release-step flag to `false` so an empty AppImage glob is benign.

## Audit table

I also audited every action pin across all workflows; only the three above (and `snap-refresh.yml`'s reuse of snapcore) were wrong-form. Eight other action pins (`actions/*`, `step-security/harden-runner`, etc.) were already correctly commit-SHA-pinned and untouched.

## Verification path

This PR can't fully validate the new SHAs on its own — the failure modes only appear at tag push time. The plan once this lands:

1. Cut **v1.0.6** (skip v1.0.5 since the snap is already on it and PyPI's still empty; PyPI accepts a fresh number cleanly). Bump versions via `scripts/bump-version.sh 1.0.6` and rotate CHANGELOG.
2. Push the `v1.0.6` tag → re-fire `release.yml` → PyPI publish should now work; github-release should now create the release.

The maintainer asked to defer tagging entirely for now; this PR just makes the next tag attempt safe to run.

## Type of change

- [x] Bug fix
- [x] Build / CI / packaging