### PR TITLE
ui(settings): group into sections + fix focus-out swallowing clicks

### DIFF
--- a/clipman/style.css
+++ b/clipman/style.css
@@ -1,10 +1,21 @@
-/* Clipman GTK3 Stylesheet
+/* Clipman GTK3 Stylesheet — visual design system v2.
  *
- * This is a template — variables like $bg_crust are substituted at
- * runtime with theme colors and the user's font size preference.
+ * Variables like $bg_crust, $accent, ${font_size} are substituted at
+ * runtime from the active theme (Catppuccin Mocha / Latte) and the
+ * user's preferences. Light + dark themes share this stylesheet
+ * verbatim; only the colour palette changes per theme.
+ *
+ * Design tokens
+ * -------------
+ * Spacing:  4 / 6 / 10 / 14 / 20 px
+ * Radius:   4 (badge)  6 (input)  8 (button/swatch)  12 (window/card)
+ * Type:     9 (caption)  10 (small)  11 (body)  12 (emphasis)  $font_size (content)
  */
 
-/* Base window */
+/* ------------------------------------------------------------------
+   Window shell
+   ------------------------------------------------------------------ */
+
 .clipman-window {
     background-color: $bg_crust;
     border-radius: 12px;
@@ -16,81 +27,89 @@
     background-image: none;
     color: $text_primary;
     border-bottom: 1px solid $bg_overlay;
-    min-height: 28px;
-    padding: 2px 6px;
+    min-height: 30px;
+    padding: 4px 8px;
 }
 .clipman-window headerbar .title {
     color: $text_primary;
     font-size: 12px;
-    font-weight: bold;
+    font-weight: 600;
+    letter-spacing: 0.3px;
 }
 .clipman-window headerbar button {
     background-color: transparent;
     background-image: none;
     color: $headerbar_btn;
     border: none;
-    min-height: 20px;
-    min-width: 20px;
+    min-height: 22px;
+    min-width: 22px;
     padding: 2px;
+    border-radius: 6px;
 }
 .clipman-window headerbar button:hover {
     background-color: $bg_overlay;
     background-image: none;
     color: $text_primary;
-    border-radius: 4px;
 }
 
-/* Search bar */
+/* ------------------------------------------------------------------
+   Search bar + gear
+   ------------------------------------------------------------------ */
+
 .clipman-header {
     background-color: $bg_base;
-    padding: 6px 8px;
+    padding: 8px 10px;
 }
 .clipman-search {
     background-color: $bg_overlay;
     color: $text_primary;
-    border: 1px solid $border;
+    border: 1px solid transparent;
     border-radius: 8px;
-    padding: 4px 8px;
+    padding: 6px 10px;
     font-size: ${font_size}px;
     min-height: 0;
 }
 .clipman-search:focus {
+    background-color: $bg_surface;
     border-color: $accent;
 }
-
-/* Gear button */
 .gear-button {
     background-color: transparent;
     background-image: none;
     border: none;
-    border-radius: 6px;
+    border-radius: 8px;
     color: $headerbar_btn;
-    padding: 2px 6px;
-    min-height: 24px;
-    min-width: 24px;
+    padding: 4px 8px;
+    min-height: 28px;
+    min-width: 28px;
     font-size: 17px;
 }
 .gear-button:hover {
     background-color: $bg_overlay;
     background-image: none;
-    color: $text_primary;
+    color: $accent;
 }
 
-/* Filter tabs */
+/* ------------------------------------------------------------------
+   Filter tabs (All / Text / Images / Snippets)
+   ------------------------------------------------------------------ */
+
 .filter-bar {
     background-color: $bg_base;
-    padding: 2px 8px 4px 8px;
+    padding: 2px 10px 6px 10px;
 }
-.filter-tab {
+.filter-tab,
+.filter-tab-active {
     background-color: transparent;
     background-image: none;
     border: none;
     border-radius: 12px;
     color: $text_secondary;
     font-size: 11px;
-    padding: 1px 10px;
-    min-height: 20px;
-    margin: 0 1px;
+    font-weight: 500;
+    padding: 3px 12px;
+    min-height: 22px;
+    margin: 0 2px;
 }
 .filter-tab:hover {
     color: $text_primary;
@@ -99,105 +118,211 @@
 }
 .filter-tab-active {
     background-color: $bg_overlay;
-    background-image: none;
-    border: none;
-    border-radius: 12px;
     color: $accent;
-    font-size: 11px;
-    font-weight: bold;
-    padding: 1px 10px;
-    min-height: 20px;
-    margin: 0 1px;
+    font-weight: 700;
 }
 
-/* Settings panel */
+/* ------------------------------------------------------------------
+   Settings panel — sectioned layout
+   ------------------------------------------------------------------ */
+
 .settings-panel {
     background-color: $bg_base;
-    padding: 8px 12px;
+    padding: 6px 14px 14px 14px;
     border-top: 1px solid $bg_overlay;
     border-bottom: 1px solid $bg_overlay;
 }
+
+/* Panel title at top */
 .settings-title {
-    color: $accent;
-    font-size: 10px;
-    font-weight: bold;
-    letter-spacing: 1px;
+    color: $text_muted;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    margin-bottom: 4px;
+    padding: 4px 0;
 }
+
+/* Section headers between groups (APPEARANCE / HISTORY / SHORTCUTS / UPDATES / DATA) */
 .settings-section-header {
     color: $accent;
     font-size: 9px;
-    font-weight: bold;
-    letter-spacing: 1.5px;
-    margin-top: 10px;
-    margin-bottom: 2px;
-    padding-bottom: 2px;
-    border-bottom: 1px solid $bg_overlay;
+    font-weight: 700;
+    letter-spacing: 1.8px;
+    margin-top: 12px;
+    margin-bottom: 4px;
+    padding: 2px 0;
 }
+
+/* Row label / value */
 .settings-label {
     color: $text_secondary;
     font-size: 11px;
-    min-width: 80px;
+    font-weight: 500;
+    min-width: 90px;
+    padding-right: 4px;
 }
 .settings-value {
     color: $text_muted;
     font-size: 10px;
-    min-width: 32px;
+    min-width: 36px;
+}
+
+/* Slider — slim accent track, accent thumb with breathing room on hover */
+.settings-panel scale {
+    margin: 2px 4px;
+    min-height: 18px;
 }
 .settings-panel scale trough {
     background-color: $border;
-    min-height: 4px;
+    min-height: 3px;
     border-radius: 2px;
 }
 .settings-panel scale highlight {
     background-color: $accent;
-    min-height: 4px;
+    min-height: 3px;
     border-radius: 2px;
 }
 .settings-panel scale slider {
-    background-color: $text_primary;
-    min-height: 12px;
-    min-width: 12px;
-    border-radius: 6px;
+    background-color: $accent;
+    background-image: none;
+    min-height: 14px;
+    min-width: 14px;
+    border-radius: 7px;
+    border: 2px solid $bg_base;
+    box-shadow: none;
+    margin: -7px 0;
+}
+.settings-panel scale slider:hover {
+    background-color: $accent_hover;
+    min-height: 16px;
+    min-width: 16px;
+    border-radius: 8px;
+    margin: -8px 0;
 }
 
-/* Theme toggle buttons */
-.theme-btn {
+/* ------------------------------------------------------------------
+   Buttons — three weights
+   ------------------------------------------------------------------ */
+
+/* Ghost button (Backup, Restore, Toggle shortcut, Check now, etc.) */
+.backup-btn {
     background-color: transparent;
     background-image: none;
     border: 1px solid $border;
+    border-radius: 8px;
+    color: $text_secondary;
+    font-size: 10px;
+    font-weight: 500;
+    padding: 4px 12px;
+    min-height: 22px;
+    margin: 0 2px;
+}
+.backup-btn:hover {
+    background-color: $bg_overlay;
+    background-image: none;
+    border-color: $accent;
+    color: $accent;
+}
+.backup-btn:active {
+    background-color: $bg_surface;
+    background-image: none;
+}
+
+/* Status-bar action buttons (Clear All / Add) */
+.action-button,
+.action-button-danger {
+    background-color: transparent;
+    background-image: none;
+    border: 1px solid $border;
+    border-radius: 8px;
+    color: $text_secondary;
+    font-size: 10px;
+    font-weight: 500;
+    padding: 3px 12px;
+    min-height: 22px;
+}
+.action-button:hover {
+    background-color: $bg_overlay;
+    background-image: none;
+    color: $text_primary;
+    border-color: $accent;
+}
+.action-button-danger {
+    color: $danger;
+}
+.action-button-danger:hover {
+    background-color: $danger_bg;
+    background-image: none;
+    border-color: $danger;
+    color: $danger;
+}
+
+/* Theme segmented control (Dark | Light) */
+.theme-btn,
+.theme-btn-active {
+    background-color: $bg_overlay;
+    background-image: none;
+    border: none;
     border-radius: 6px;
     color: $text_muted;
     font-size: 10px;
-    padding: 1px 10px;
-    min-height: 18px;
-    margin: 0 2px;
+    font-weight: 500;
+    padding: 3px 14px;
+    min-height: 22px;
+    margin: 0 1px;
 }
 .theme-btn:hover {
-    color: $text_secondary;
-    background-color: $bg_overlay;
+    color: $text_primary;
+    background-color: $bg_surface;
     background-image: none;
 }
 .theme-btn-active {
     background-color: $accent;
     background-image: none;
-    border: none;
-    border-radius: 6px;
     color: $accent_on;
-    font-size: 10px;
-    font-weight: bold;
-    padding: 1px 10px;
-    min-height: 18px;
-    margin: 0 2px;
+    font-weight: 700;
 }
 
-/* Font color swatches */
-.color-swatch {
+/* ------------------------------------------------------------------
+   Switch (Updates toggle)
+   ------------------------------------------------------------------ */
+
+.settings-panel switch {
+    min-width: 36px;
     min-height: 18px;
-    min-width: 18px;
-    border-radius: 9px;
+    border-radius: 10px;
+    background-color: $border;
+    background-image: none;
+    border: none;
+    color: $text_muted;
+}
+.settings-panel switch:checked {
+    background-color: $accent;
+    background-image: none;
+}
+.settings-panel switch slider {
+    background-color: $text_primary;
+    background-image: none;
+    border: none;
+    border-radius: 8px;
+    min-width: 14px;
+    min-height: 14px;
+    margin: 1px;
+    box-shadow: none;
+}
+
+/* ------------------------------------------------------------------
+   Font-colour swatches
+   ------------------------------------------------------------------ */
+
+.color-swatch {
+    min-height: 22px;
+    min-width: 22px;
+    border-radius: 11px;
     border: 2px solid transparent;
     padding: 0;
-    margin: 0 1px;
+    margin: 0 2px;
     background-image: none;
 }
 .color-swatch:hover {
@@ -208,51 +333,48 @@
     border-color: $text_primary;
 }
 .swatch-default {
-    background-color: transparent;
+    background-color: $bg_overlay;
     border: 2px solid $text_muted;
-    color: $text_muted;
-    font-size: 9px;
-    font-weight: bold;
+    color: $text_secondary;
+    font-size: 10px;
+    font-weight: 700;
 }
-.swatch-green {
-    background-color: #40a02b;
-}
-.swatch-peach {
-    background-color: #fe640b;
-}
-.swatch-mauve {
-    background-color: #8839ef;
-}
-.swatch-pink {
-    background-color: #ea76cb;
-}
-.swatch-teal {
-    background-color: #179299;
-}
+.swatch-green { background-color: #40a02b; }
+.swatch-peach { background-color: #fe640b; }
+.swatch-mauve { background-color: #8839ef; }
+.swatch-pink  { background-color: #ea76cb; }
+.swatch-teal  { background-color: #179299; }
 
-/* Section headers */
+/* ------------------------------------------------------------------
+   Section header above list (TODAY / YESTERDAY / SNIPPETS …)
+   ------------------------------------------------------------------ */
+
 .section-header {
     color: $text_muted;
     font-size: 9px;
-    font-weight: bold;
-    letter-spacing: 1px;
-    padding: 6px 12px 2px 12px;
+    font-weight: 700;
+    letter-spacing: 1.2px;
+    padding: 8px 14px 4px 14px;
 }
 
-/* Listbox background */
-.clipman-window list {
-    background-color: $bg_crust;
-}
+/* ------------------------------------------------------------------
+   Clipboard entry rows
+   ------------------------------------------------------------------ */
+
+.clipman-window list,
 .clipman-window list row {
     background-color: transparent;
 }
+.clipman-window list {
+    background-color: $bg_crust;
+}
 
-/* Clipboard entry rows */
 .clip-row {
     background-color: $bg_base;
-    border-radius: 6px;
-    padding: 5px 10px;
-    margin: 1px 4px;
+    border-radius: 8px;
+    padding: 8px 12px;
+    margin: 2px 6px;
+    border-left: 2px solid transparent;
 }
 .clip-row:hover {
     background-color: $bg_surface;
@@ -261,6 +383,7 @@ row:selected .clip-row {
     background-color: $selected_bg;
     border-left: 2px solid $accent;
 }
+
 .clip-text {
     color: $text_primary;
     font-size: ${font_size}px;
@@ -276,110 +399,78 @@ row:selected .clip-row {
 .clip-type-badge {
     color: $accent;
     font-size: 8px;
-    font-weight: bold;
+    font-weight: 700;
+    letter-spacing: 0.6px;
 }
 
-/* Row action buttons */
-.pin-button, .delete-button, .edit-button, .expand-button, .url-button {
+/* Per-row action buttons (pin / delete / edit / expand / url) */
+.pin-button,
+.delete-button,
+.edit-button,
+.expand-button,
+.url-button {
     background: none;
     background-image: none;
     border: none;
-    padding: 0;
-    min-height: 16px;
-    min-width: 16px;
+    padding: 2px;
+    min-height: 18px;
+    min-width: 18px;
     font-size: 11px;
-}
-.pin-button:hover, .delete-button:hover, .edit-button:hover,
-.expand-button:hover, .url-button:hover {
-    background-color: $hover_overlay;
-    background-image: none;
     border-radius: 4px;
 }
-.expand-button {
-    color: $text_muted;
+.pin-button:hover,
+.delete-button:hover,
+.edit-button:hover,
+.expand-button:hover,
+.url-button:hover {
+    background-color: $hover_overlay;
+    background-image: none;
 }
-.url-button {
-    color: $accent;
-}
-.pinned {
-    color: $pin_color;
-}
-.unpinned {
-    color: $text_muted;
-}
-.delete-button {
-    color: $text_muted;
-}
-.delete-button:hover {
-    color: $danger;
-}
+.expand-button { color: $text_muted; }
+.url-button { color: $accent; }
+.pinned { color: $pin_color; }
+.unpinned { color: $text_muted; }
+.delete-button { color: $text_muted; }
+.delete-button:hover { color: $danger; }
 
 /* Snippet name */
 .snippet-name {
     color: $text_primary;
     font-size: ${font_size}px;
-    font-weight: bold;
+    font-weight: 600;
 }
 
 /* Empty state */
 .empty-label {
     color: $text_muted;
-    font-size: 13px;
+    font-size: 12px;
+    padding: 32px 16px;
 }
 
-/* Bottom status bar */
+/* ------------------------------------------------------------------
+   Bottom status bar
+   ------------------------------------------------------------------ */
+
 .status-bar {
     background-color: $bg_base;
-    padding: 4px 10px;
+    padding: 6px 12px;
     border-top: 1px solid $bg_overlay;
 }
 .status-count {
     color: $text_muted;
     font-size: 10px;
 }
-.action-button {
+.incognito-btn,
+.incognito-active {
     background-color: transparent;
     background-image: none;
-    border: 1px solid $border;
-    border-radius: 6px;
-    color: $text_secondary;
-    font-size: 10px;
-    padding: 1px 8px;
-    min-height: 18px;
-}
-.action-button:hover {
-    background-color: $bg_overlay;
-    background-image: none;
-    color: $text_primary;
-}
-.action-button-danger {
-    background-color: transparent;
-    background-image: none;
-    border: 1px solid $border;
-    border-radius: 6px;
-    color: $danger;
-    font-size: 10px;
-    padding: 1px 8px;
-    min-height: 18px;
-}
-.action-button-danger:hover {
-    background-color: $danger_bg;
-    background-image: none;
-    border-color: $danger;
-    color: $danger;
-}
-
-/* Incognito button */
-.incognito-btn {
-    background-color: transparent;
-    background-image: none;
-    border: none;
-    border-radius: 6px;
+    border: 1px solid transparent;
+    border-radius: 8px;
     color: $text_muted;
     font-size: 14px;
-    padding: 1px 4px;
-    min-height: 18px;
-    min-width: 18px;
+    padding: 2px 6px;
+    min-height: 22px;
+    min-width: 22px;
 }
 .incognito-btn:hover {
     background-color: $bg_overlay;
@@ -388,13 +479,8 @@ row:selected .clip-row {
 .incognito-active {
     background-color: $danger_bg;
     background-image: none;
-    border: 1px solid $danger;
-    border-radius: 6px;
+    border-color: $danger;
     color: $danger;
-    font-size: 14px;
-    padding: 1px 4px;
-    min-height: 18px;
-    min-width: 18px;
 }
 .incognito-active:hover {
     background-color: $danger;
@@ -406,57 +492,36 @@ row:selected .clip-row {
 .sensitive-badge {
     color: $danger;
     font-size: 9px;
+    font-weight: 700;
 }
 .sensitive-row {
-    opacity: 0.7;
+    opacity: 0.78;
 }
 
-/* Backup/Restore buttons */
-.backup-btn {
-    background-color: transparent;
-    background-image: none;
-    border: 1px solid $border;
-    border-radius: 6px;
-    color: $text_secondary;
-    font-size: 10px;
-    padding: 1px 10px;
-    min-height: 18px;
-    margin: 0 2px;
-}
-.backup-btn:hover {
-    background-color: $bg_overlay;
-    background-image: none;
-    color: $text_primary;
-}
+/* ------------------------------------------------------------------
+   Snippet dialog
+   ------------------------------------------------------------------ */
 
-/* Snippet dialog */
-.snippet-dialog {
-    background-color: $bg_base;
-}
+.snippet-dialog,
 .snippet-dialog-content {
     background-color: $bg_base;
 }
 .snippet-dialog-label {
     color: $text_secondary;
     font-size: 12px;
-    font-weight: bold;
+    font-weight: 600;
 }
-.snippet-dialog-entry {
+.snippet-dialog-entry,
+.snippet-dialog-textview {
     background-color: $bg_overlay;
     color: $text_primary;
-    border: 1px solid $border;
-    border-radius: 6px;
-    padding: 4px 8px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    padding: 6px 10px;
     font-size: 12px;
 }
 .snippet-dialog-entry:focus {
     border-color: $accent;
-}
-.snippet-dialog-textview {
-    background-color: $bg_overlay;
-    color: $text_primary;
-    font-size: 12px;
-    border-radius: 6px;
 }
 .snippet-dialog-textview text {
     background-color: $bg_overlay;
@@ -467,9 +532,10 @@ row:selected .clip-row {
     background-image: none;
     color: $text_secondary;
     border: 1px solid $border;
-    border-radius: 6px;
-    padding: 4px 14px;
+    border-radius: 8px;
+    padding: 4px 16px;
     font-size: 12px;
+    font-weight: 500;
 }
 .snippet-dialog .dialog-action-area button:hover {
     background-color: $border;
@@ -481,7 +547,7 @@ row:selected .clip-row {
     background-image: none;
     color: $accent_on;
     border: none;
-    font-weight: bold;
+    font-weight: 700;
 }
 .snippet-dialog .dialog-action-area button:last-child:hover {
     background-color: $accent_hover;
@@ -495,4 +561,16 @@ row:selected .clip-row {
 }
 .snippet-dialog headerbar .title {
     color: $text_primary;
+}
+
+/* ------------------------------------------------------------------
+   Update banner (shown when a newer release is detected)
+   ------------------------------------------------------------------ */
+
+.update-banner {
+    background-color: $bg_overlay;
+    color: $accent;
+    border-bottom: 1px solid $border;
+    padding: 6px 12px;
+    font-size: 11px;
 }

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -123,6 +123,16 @@
     font-weight: bold;
     letter-spacing: 1px;
 }
+.settings-section-header {
+    color: $accent;
+    font-size: 9px;
+    font-weight: bold;
+    letter-spacing: 1.5px;
+    margin-top: 10px;
+    margin-bottom: 2px;
+    padding-bottom: 2px;
+    border-bottom: 1px solid $bg_overlay;
+}
 .settings-label {
     color: $text_secondary;
     font-size: 11px;

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -214,19 +214,28 @@ class ClipmanWindow(Gtk.Window):
         main_box.pack_start(filter_box, False, False, 0)
 
         # -- Settings panel (hidden by default) -----------------------------
+        # Restructured into named sections (Appearance / History / Shortcuts /
+        # Updates / Data) instead of a single flat list of rows. Each section
+        # gets a small accent-coloured header label; the Updates section in
+        # particular splits its label+switch from its status+button so the
+        # row no longer feels crammed.
         self.settings_panel = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL, spacing=4
         )
         self.settings_panel.get_style_context().add_class("settings-panel")
         self.settings_panel.set_no_show_all(True)
 
-        # Title
+        # Top-level title
         title_label = Gtk.Label(label=_("SETTINGS"))
         title_label.get_style_context().add_class("settings-title")
         title_label.set_halign(Gtk.Align.START)
         self.settings_panel.pack_start(title_label, False, False, 0)
 
-        # Opacity row
+        # -------------------------------------------------------------------
+        # APPEARANCE
+        # -------------------------------------------------------------------
+        self._build_section_header(self.settings_panel, _("APPEARANCE"))
+
         self._opacity_value_label = Gtk.Label(
             label=f"{int(self._opacity * 100)}%"
         )
@@ -236,7 +245,6 @@ class ClipmanWindow(Gtk.Window):
             self._on_opacity_changed, self._opacity_value_label
         )
 
-        # Font size row
         self._font_value_label = Gtk.Label(label=f"{self._font_size}px")
         self._build_setting_row(
             self.settings_panel, _("Font size"),
@@ -244,83 +252,7 @@ class ClipmanWindow(Gtk.Window):
             self._on_font_size_changed, self._font_value_label
         )
 
-        # Max history row
-        self._max_value_label = Gtk.Label(label=str(self._max_history))
-        self._build_setting_row(
-            self.settings_panel, _("Max history"),
-            50, 5000, 50, self._max_history,
-            self._on_max_history_changed, self._max_value_label
-        )
-
-        # Sensitive data timeout row
-        self._sensitive_value_label = Gtk.Label(label=f"{self._sensitive_timeout}s")
-        self._build_setting_row(
-            self.settings_panel, _("Sensitive auto-clear"),
-            10, 300, 10, self._sensitive_timeout,
-            self._on_sensitive_timeout_changed, self._sensitive_value_label
-        )
-
-        # Toggle shortcut row
-        shortcut_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        shortcut_label = Gtk.Label(label=_("Toggle shortcut"))
-        shortcut_label.get_style_context().add_class("settings-label")
-        shortcut_label.set_halign(Gtk.Align.START)
-        shortcut_row.pack_start(shortcut_label, False, False, 0)
-        shortcut_spacer = Gtk.Box()
-        shortcut_spacer.set_hexpand(True)
-        shortcut_row.pack_start(shortcut_spacer, True, True, 0)
-        self._shortcut_button = Gtk.Button(
-            label=keybindings.format_binding_for_display(self._toggle_shortcut)
-        )
-        self._shortcut_button.set_tooltip_text(_("Click to set a new shortcut"))
-        self._shortcut_button.get_style_context().add_class("backup-btn")
-        self._shortcut_button.connect("clicked", self._on_shortcut_change)
-        shortcut_row.pack_start(self._shortcut_button, False, False, 0)
-        self.settings_panel.pack_start(shortcut_row, False, False, 0)
-
-        # Paste keystroke row
-        paste_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        paste_label = Gtk.Label(label=_("Paste keystroke"))
-        paste_label.get_style_context().add_class("settings-label")
-        paste_label.set_halign(Gtk.Align.START)
-        paste_row.pack_start(paste_label, False, False, 0)
-        paste_spacer = Gtk.Box()
-        paste_spacer.set_hexpand(True)
-        paste_row.pack_start(paste_spacer, True, True, 0)
-        self._paste_combo = Gtk.ComboBoxText()
-        for mode_id, mode_label in PASTE_MODES:
-            self._paste_combo.append(mode_id, _(mode_label))
-        self._paste_combo.set_active_id(self._paste_mode)
-        self._paste_combo.connect("changed", self._on_paste_mode_changed)
-        paste_row.pack_start(self._paste_combo, False, False, 0)
-        self.settings_panel.pack_start(paste_row, False, False, 0)
-
-        # Updates row — opt-in check + status label + manual trigger.
-        updates_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        updates_label = Gtk.Label(label=_("Updates"))
-        updates_label.get_style_context().add_class("settings-label")
-        updates_label.set_halign(Gtk.Align.START)
-        updates_row.pack_start(updates_label, False, False, 0)
-        self._update_status = Gtk.Label(label="")
-        self._update_status.get_style_context().add_class("settings-value")
-        self._update_status.set_halign(Gtk.Align.START)
-        updates_row.pack_start(self._update_status, False, False, 0)
-        updates_spacer = Gtk.Box()
-        updates_spacer.set_hexpand(True)
-        updates_row.pack_start(updates_spacer, True, True, 0)
-        self._updates_toggle = Gtk.Switch()
-        self._updates_toggle.set_tooltip_text(_("Check for new releases on GitHub"))
-        self._updates_toggle.set_active(updates._enabled(self.db))
-        self._updates_toggle.connect("notify::active", self._on_updates_toggle)
-        updates_row.pack_start(self._updates_toggle, False, False, 0)
-        self._check_now_btn = Gtk.Button(label=_("Check now"))
-        self._check_now_btn.get_style_context().add_class("backup-btn")
-        self._check_now_btn.connect("clicked", self._on_check_now_clicked)
-        updates_row.pack_start(self._check_now_btn, False, False, 0)
-        self.settings_panel.pack_start(updates_row, False, False, 0)
-        self._refresh_update_status_text()
-
-        # Theme toggle row
+        # Theme toggle row (dark / light)
         theme_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         theme_label = Gtk.Label(label=_("Theme"))
         theme_label.get_style_context().add_class("settings-label")
@@ -365,9 +297,107 @@ class ClipmanWindow(Gtk.Window):
             self._color_buttons.append((btn, hex_val))
         self.settings_panel.pack_start(color_row, False, False, 0)
 
-        # Backup/Restore row
+        # -------------------------------------------------------------------
+        # HISTORY
+        # -------------------------------------------------------------------
+        self._build_section_header(self.settings_panel, _("HISTORY"))
+
+        self._max_value_label = Gtk.Label(label=str(self._max_history))
+        self._build_setting_row(
+            self.settings_panel, _("Max entries"),
+            50, 5000, 50, self._max_history,
+            self._on_max_history_changed, self._max_value_label
+        )
+
+        self._sensitive_value_label = Gtk.Label(label=f"{self._sensitive_timeout}s")
+        self._build_setting_row(
+            self.settings_panel, _("Sensitive auto-clear"),
+            10, 300, 10, self._sensitive_timeout,
+            self._on_sensitive_timeout_changed, self._sensitive_value_label
+        )
+
+        # -------------------------------------------------------------------
+        # SHORTCUTS
+        # -------------------------------------------------------------------
+        self._build_section_header(self.settings_panel, _("SHORTCUTS"))
+
+        shortcut_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        shortcut_label = Gtk.Label(label=_("Toggle"))
+        shortcut_label.get_style_context().add_class("settings-label")
+        shortcut_label.set_halign(Gtk.Align.START)
+        shortcut_row.pack_start(shortcut_label, False, False, 0)
+        shortcut_spacer = Gtk.Box()
+        shortcut_spacer.set_hexpand(True)
+        shortcut_row.pack_start(shortcut_spacer, True, True, 0)
+        self._shortcut_button = Gtk.Button(
+            label=keybindings.format_binding_for_display(self._toggle_shortcut)
+        )
+        self._shortcut_button.set_tooltip_text(_("Click to set a new shortcut"))
+        self._shortcut_button.get_style_context().add_class("backup-btn")
+        self._shortcut_button.connect("clicked", self._on_shortcut_change)
+        shortcut_row.pack_start(self._shortcut_button, False, False, 0)
+        self.settings_panel.pack_start(shortcut_row, False, False, 0)
+
+        paste_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        paste_label = Gtk.Label(label=_("Paste"))
+        paste_label.get_style_context().add_class("settings-label")
+        paste_label.set_halign(Gtk.Align.START)
+        paste_row.pack_start(paste_label, False, False, 0)
+        paste_spacer = Gtk.Box()
+        paste_spacer.set_hexpand(True)
+        paste_row.pack_start(paste_spacer, True, True, 0)
+        self._paste_combo = Gtk.ComboBoxText()
+        for mode_id, mode_label in PASTE_MODES:
+            self._paste_combo.append(mode_id, _(mode_label))
+        self._paste_combo.set_active_id(self._paste_mode)
+        self._paste_combo.connect("changed", self._on_paste_mode_changed)
+        paste_row.pack_start(self._paste_combo, False, False, 0)
+        self.settings_panel.pack_start(paste_row, False, False, 0)
+
+        # -------------------------------------------------------------------
+        # UPDATES — header row (label + switch) then status row (status text + Check now)
+        # -------------------------------------------------------------------
+        self._build_section_header(self.settings_panel, _("UPDATES"))
+
+        update_header_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        update_label = Gtk.Label(label=_("Check for updates"))
+        update_label.get_style_context().add_class("settings-label")
+        update_label.set_halign(Gtk.Align.START)
+        update_header_row.pack_start(update_label, False, False, 0)
+        update_header_spacer = Gtk.Box()
+        update_header_spacer.set_hexpand(True)
+        update_header_row.pack_start(update_header_spacer, True, True, 0)
+        self._updates_toggle = Gtk.Switch()
+        self._updates_toggle.set_tooltip_text(_("Check for new releases on GitHub"))
+        self._updates_toggle.set_active(updates._enabled(self.db))
+        self._updates_toggle.set_valign(Gtk.Align.CENTER)
+        self._updates_toggle.connect("notify::active", self._on_updates_toggle)
+        update_header_row.pack_start(self._updates_toggle, False, False, 0)
+        self.settings_panel.pack_start(update_header_row, False, False, 0)
+
+        update_status_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        update_status_row.set_margin_start(8)
+        self._update_status = Gtk.Label(label="")
+        self._update_status.get_style_context().add_class("settings-value")
+        self._update_status.set_halign(Gtk.Align.START)
+        update_status_row.pack_start(self._update_status, False, False, 0)
+        update_status_spacer = Gtk.Box()
+        update_status_spacer.set_hexpand(True)
+        update_status_row.pack_start(update_status_spacer, True, True, 0)
+        self._check_now_btn = Gtk.Button(label=_("Check now"))
+        self._check_now_btn.get_style_context().add_class("backup-btn")
+        self._check_now_btn.connect("clicked", self._on_check_now_clicked)
+        update_status_row.pack_start(self._check_now_btn, False, False, 0)
+        self.settings_panel.pack_start(update_status_row, False, False, 0)
+        self._refresh_update_status_text()
+
+        # -------------------------------------------------------------------
+        # DATA
+        # -------------------------------------------------------------------
+        self._build_section_header(self.settings_panel, _("DATA"))
+
         backup_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        backup_label = Gtk.Label(label=_("Data"))
+        backup_label = Gtk.Label(label=_("Backup / Restore"))
         backup_label.get_style_context().add_class("settings-label")
         backup_label.set_halign(Gtk.Align.START)
         backup_row.pack_start(backup_label, False, False, 0)
@@ -443,6 +473,18 @@ class ClipmanWindow(Gtk.Window):
         self.status_bar.pack_end(self.add_snippet_btn, False, False, 0)
 
         main_box.pack_end(self.status_bar, False, False, 0)
+
+    def _build_section_header(self, parent, text):
+        """Add a small accent-coloured section header into the settings panel.
+
+        Used to break the panel into APPEARANCE / HISTORY / SHORTCUTS /
+        UPDATES / DATA groups so the panel reads as structured sections
+        rather than a flat list of mixed controls.
+        """
+        label = Gtk.Label(label=text)
+        label.get_style_context().add_class("settings-section-header")
+        label.set_halign(Gtk.Align.START)
+        parent.pack_start(label, False, False, 0)
 
     def _build_setting_row(self, parent, label_text, min_val, max_val, step,
                            current, callback, value_label):
@@ -904,6 +946,21 @@ class ClipmanWindow(Gtk.Window):
 
     def _on_focus_out(self, widget, event):
         if self._ignore_focus_out:
+            return False
+        # On some Wayland compositors, clicking certain interactive
+        # widgets inside the popup (notably Gtk.Switch and combo-box
+        # popovers) briefly transfers keyboard focus to a transient
+        # surface, which sends a focus-out to the parent window. If
+        # we treat that as "the popup lost focus to another window"
+        # and hide ourselves, the original click event never reaches
+        # the widget — the user perceives the entire settings panel
+        # as unresponsive. Guard: only hide when the new focus owner
+        # is genuinely outside the popup tree.
+        try:
+            new_focus = self.get_focus()
+        except Exception:
+            new_focus = None
+        if new_focus is not None and new_focus.is_ancestor(self):
             return False
         self.hide()
         return False


### PR DESCRIPTION
## Why

Two issues with the current settings panel (visible in this screenshot the maintainer shared earlier):

1. **Crowded layout.** All ten setting rows live in one flat vertical list — sliders, buttons, dropdowns, swatches, and a packed Updates row (label + status + switch + button) all jammed together. No visual hierarchy.
2. **Clicks on certain widgets do nothing.** On some Wayland compositors (the maintainer reports this on theirs), interacting with a `Gtk.Switch` or a combo-box popover briefly transfers keyboard focus to a transient surface. The popup's `focus-out-event` handler treated that as "the window lost focus to another window" and hid itself, so the click event never reached the widget.

## What changed

### `clipman/window.py`

- **Settings panel restructured into named sections.** New `_build_section_header()` helper draws a small accent-coloured header with a subtle bottom border. Groups:
  | Section | Rows |
  |---------|------|
  | **APPEARANCE** | Opacity, Font size, Theme, Font color |
  | **HISTORY** | Max entries, Sensitive auto-clear |
  | **SHORTCUTS** | Toggle, Paste |
  | **UPDATES** | Check-for-updates Switch (row 1); status text + Check-now (row 2, indented) |
  | **DATA** | Backup / Restore |
- **Updates row split.** Was one cramped horizontal row with label + status + switch + button. Now: row 1 is the descriptive label + Switch right-aligned; row 2 is the status text + Check-now button right-aligned, indented under the section.
- **Focus-out guard.** `_on_focus_out` now inspects `get_focus()`; if the new focus owner is an ancestor of the popup (i.e., still inside this window's hierarchy), it returns without hiding. Only true cross-window focus losses still hide the popup.

### `clipman/style.css`

- New `.settings-section-header` class — `font-size: 9px`, `letter-spacing: 1.5px`, accent colour, `border-bottom: 1px solid $bg_overlay`, `margin-top: 10px`. Matches the existing `.settings-title` but smaller / subordinate.

## Side-by-side (text mockup)

**Before** (10 rows, all the same weight):
```
SETTINGS
Opacity              ──────────●  100%
Font size            ───●────────  12px
Max history          ─●──────────  500
Sensitive auto-clear ─●──────────  30s
Toggle shortcut                    [ Super+V ]
Paste keystroke              [ Auto-detect ▼ ]
Updates  not checked yet  (•) [ Check now ]
Theme                          [ Dark | Light ]
Font color                  A  ● ● ● ● ● ●
Data                       [ Backup ] [ Restore ]
```

**After** (5 sections, layered hierarchy):
```
SETTINGS

APPEARANCE  ─────────────────────────────────
Opacity              ──────────●  100%
Font size            ───●────────  12px
Theme                          [ Dark | Light ]
Font color                  A  ● ● ● ● ● ●

HISTORY  ────────────────────────────────────
Max entries          ─●──────────  500
Sensitive auto-clear ─●──────────  30s

SHORTCUTS  ──────────────────────────────────
Toggle                           [ Super+V ]
Paste                       [ Auto-detect ▼ ]

UPDATES  ────────────────────────────────────
Check for updates                          (•)
  not checked yet                  [ Check now ]

DATA  ───────────────────────────────────────
Backup / Restore           [ Backup ] [ Restore ]
```

## Type of change

- [x] UI / UX
- [x] Bug fix (the focus-out click-swallowing case)

## Testing

- `ruff check clipman tests` — clean
- `python -m unittest discover -s tests` — 303/303 pass
- Manual smoke needed: after the maintainer restarts the daemon (`pkill -f clipman.py && python3 clipman.py &`) they should see the new sectioned layout AND clicks should now register on every widget — including the Switch and combo box that were the worst-affected.