### PR TITLE
chore: bump to 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,80 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-05-20
+
+### Highlights
+
+A follow-up release that lands everything 1.0.5 was meant to bring
+plus the UI polish and packaging breadth the maintainer requested
+after seeing the first cut.
+
+**For users**, 1.0.6 supersedes 1.0.5 wherever 1.0.5 actually reached
+(Snap Store stable). PyPI and the GitHub Release page reach this
+codebase here for the first time — the 1.0.5 publish pipeline failed
+mid-way and was retried as 1.0.6.
+
+**New on top of 1.0.5:**
+
+- Three additional release artifacts shipped to the GitHub Release:
+  `.deb` (Debian / Ubuntu), `.rpm` (Fedora / RHEL / openSUSE), and an
+  AppImage (best-effort, Linux-portable). PyPI wheel + sdist, Snap
+  stable, and the GNOME Shell extension zip are unchanged from 1.0.5.
+- Settings panel restructured into five clearly-labelled sections
+  (**APPEARANCE / HISTORY / SHORTCUTS / UPDATES / DATA**). The Updates
+  row no longer crams its switch + status + button onto one line.
+- Comprehensive visual overhaul of the popup CSS — accent-coloured
+  slider thumbs on slim tracks, refined buttons with bigger touch
+  targets, theme as a proper segmented control, larger colour
+  swatches, custom switch styling, more breathing room everywhere.
+- Chrome font sizes raised across the board so labels, section
+  headers, and buttons are legible on standard-DPI displays (the
+  earlier overhaul had drifted to 8-11 px; now 10-14 px depending
+  on the role).
+- A subtle but important fix: clicking certain settings widgets on
+  some Wayland compositors used to silently swallow the click. The
+  `focus-out-event` handler now distinguishes between losing focus
+  to another window (still hides) and losing focus to a child of
+  the popup itself (no-op). Affected the Switch, the combo box, and
+  the shortcut-capture dialog.
+
+### Compatibility
+
+Unchanged from 1.0.5: GNOME Shell 45 – 48, Python 3.10 – 3.12,
+extension `metadata.json` version 5.
+
+### Install / upgrade
+
+| Channel | Command |
+|---------|---------|
+| **PyPI** | `pip install --upgrade clipman-clipboard` |
+| **Snap** | auto-refresh, or `snap refresh clipman` |
+| **AUR** | `yay -S clipman` (or `paru -S clipman`) |
+| **Source** | `git pull && ./install.sh` |
+| **`.deb` (Debian / Ubuntu)** | grab `clipman_1.0.6_all.deb` from the GitHub Release → `sudo apt install ./clipman_1.0.6_all.deb` |
+| **`.rpm` (Fedora / RHEL)** | grab `clipman-1.0.6-1.noarch.rpm` from the GitHub Release → `sudo dnf install ./clipman-1.0.6-1.noarch.rpm` |
+| **AppImage** | grab `clipman-1.0.6-x86_64.AppImage` → `chmod +x` → run. Still needs system `python3-gi` and `gir1.2-gtk-3.0`. |
+| **GNOME Extension** | re-run `install.sh`, or upload the attached `clipman-extension-v1.0.6.zip` at <https://extensions.gnome.org/upload/> |
+
+### Changed
+- Release pipeline: `pypa/gh-action-pypi-publish` now pinned to the
+  *commit* SHA rather than the annotated-tag-object SHA. The previous
+  pin caused the v1.0.5 PyPI publish to fail with "Unable to find
+  image" because Docker-based actions resolve the image tag from the
+  ref. `snapcore/action-{build,publish}` fixed for consistency.
+- `softprops/action-gh-release` no longer fails when the AppImage
+  glob doesn't match (`fail_on_unmatched_files: false`). AppImage
+  packaging for a Python+GTK app is intentionally best-effort.
+- CodeQL workflow: per-SHA concurrency group on `push` events so
+  rapid back-to-back merges to `main` no longer drop the queued
+  `update-baseline` job. `workflow_dispatch` added as a manual
+  escape hatch.
+
 ### Internal / CI
-- **More release artifacts.** The tag-triggered release pipeline now
-  also builds `.deb`, `.rpm`, and an AppImage (best-effort) and
-  attaches them to the GitHub Release alongside the existing PyPI
-  wheel + sdist, snap, and GNOME extension zip. Release body gains a
-  templated "Assets" table documenting each artifact's use case and
-  install caveats. See [docs/releases/README.md](docs/releases/README.md).
+- `.github/workflows/release.yml`: new `build-distpkgs` job (fpm-based
+  .deb + .rpm) and new `build-appimage` job (python-appimage-based).
+  Release body now carries a templated **Assets** table with use
+  case + channel + install caveats per artifact.
 
 ## [1.0.5] - 2026-05-20
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mohammed El-sayed Ahmed <MohammedEl-sayedAhmed@users.noreply.github.com>
 pkgname=clipman-clipboard
-pkgver=1.0.5
+pkgver=1.0.6
 pkgrel=1
 pkgdesc="A clipboard history manager for Wayland (GNOME, KDE, Sway, Hyprland, etc.)"
 arch=('any')

--- a/clipman/__init__.py
+++ b/clipman/__init__.py
@@ -3,7 +3,7 @@ import os
 
 # Source of truth for the running daemon version.
 # scripts/bump-version.sh keeps this in sync with pyproject.toml.
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 LOCALE_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "locale"

--- a/docs/releases/v1.0.6.md
+++ b/docs/releases/v1.0.6.md
@@ -1,0 +1,104 @@
+# v1.0.6 — Polished UI + broader distribution
+
+**Released 2026-05-20.**
+Latest release page on GitHub:
+<https://github.com/MohammedEl-sayedAhmed/clipman/releases/tag/v1.0.6>
+
+This file mirrors the release notes auto-extracted from
+`CHANGELOG.md` by `release.yml`. The GitHub Release page is the
+canonical surface; this in-repo copy travels with the source and
+gets picked up by users reading the tarball.
+
+## Headlines
+
+- **Three new distribution artifacts** — `.deb`, `.rpm`, and an
+  AppImage (best-effort), built by the release pipeline and
+  attached to the GitHub Release alongside the existing PyPI
+  wheel + sdist, snap, and GNOME Shell extension zip.
+- **Settings panel restructured into named sections** —
+  **APPEARANCE / HISTORY / SHORTCUTS / UPDATES / DATA**. The
+  Updates row no longer crams its switch + status + button onto
+  one line.
+- **Comprehensive visual overhaul** — accent-coloured slider
+  thumbs on slim tracks, refined buttons with proper touch
+  targets, theme as a proper segmented control, larger colour
+  swatches, custom switch styling, generous breathing room.
+- **Legible chrome typography** — every hardcoded font size in
+  the stylesheet raised by ~2 px so labels, section headers, and
+  buttons read clearly at standard DPI.
+- **Subtle but important fix**: clicking certain settings widgets
+  on some Wayland compositors used to silently swallow the click
+  (the popup mis-interpreted a transient focus shift as
+  "window lost focus" and hid itself mid-click). The
+  `focus-out-event` handler now only hides on genuine cross-window
+  focus losses.
+
+## Compatibility
+
+Unchanged from 1.0.5:
+
+| Surface | Versions |
+|---------|----------|
+| GNOME Shell | 45, 46, 47, 48 |
+| Python | 3.10, 3.11, 3.12 |
+| Wayland compositor (without the extension) | KDE, Sway, Hyprland — any compositor with `wl-clipboard` |
+| Snap base | `core22` (Ubuntu 22.04) |
+| Extension `metadata.json` `version` | 5 (D-Bus `SimulatePaste(s mode)`) |
+
+## Install / upgrade
+
+| Channel | Command |
+|---------|---------|
+| PyPI | `pip install --upgrade clipman-clipboard` |
+| Snap | `snap refresh clipman` (or wait for auto-refresh) |
+| AUR | `yay -S clipman` |
+| Source | `git pull && ./install.sh` |
+| **`.deb`** (new) | `sudo apt install ./clipman_1.0.6_all.deb` |
+| **`.rpm`** (new) | `sudo dnf install ./clipman-1.0.6-1.noarch.rpm` |
+| **AppImage** (new, opt) | `chmod +x ./clipman-*.AppImage && ./clipman-*.AppImage` — still needs system `python3-gi` and `gir1.2-gtk-3.0` |
+| GNOME Extension | re-run `install.sh`, or upload `clipman-extension-v1.0.6.zip` at <https://extensions.gnome.org/upload/> |
+
+## Why 1.0.6 and not 1.0.5
+
+The 1.0.5 release pipeline attempted earlier today succeeded on
+Snap Store stable but failed on PyPI publish (wrong action SHA
+shape) and GitHub Release creation (`fail_on_unmatched_files`
+tripped on a missing AppImage). 1.0.6 fixes both root causes and
+ships the codebase end-to-end. The Snap Store revision for 1.0.5
+is superseded automatically when 1.0.6 publishes; nothing else
+needs to change.
+
+## Pipeline fixes shipping with 1.0.6 (no user-visible change)
+
+- `pypa/gh-action-pypi-publish` pinned to its commit SHA rather
+  than the annotated-tag-object SHA — fixes the Docker image-pull
+  failure that broke v1.0.5's PyPI publish. Same fix shape applied
+  to `snapcore/action-{build,publish}` for consistency. See ADR
+  0003 for the SHA-pin policy.
+- `softprops/action-gh-release` now tolerates missing artifact
+  globs (the AppImage soft-fails gracefully).
+- CodeQL workflow now uses a per-SHA concurrency group on `push`
+  events so rapid back-to-back merges to `main` don't drop the
+  queued `update-baseline` job — that bug stuck the security
+  baseline at an old commit during the 1.0.5 cut.
+
+## Known caveats
+
+- The AppImage doesn't bundle GTK or PyGObject — fully bundling
+  GTK is technically possible but historically fragile. For a
+  self-contained install the Snap and Flatpak builds remain the
+  better choices.
+- The `.deb` and `.rpm` install the system pieces only
+  (`/usr/bin/clipman`, Python module, `.desktop`, icon). They
+  don't install the per-user GNOME Shell extension or register
+  the `Super+V` keybinding. After installing the package, run
+  `install.sh` from a source checkout (or follow the per-user
+  setup in `docs/development.md`) to enable the extension +
+  keybinding.
+- The GNOME Extensions website (EGO) still has no public upload
+  API. The release pipeline builds the extension zip and attaches
+  it; the maintainer uploads it via the web UI.
+
+## Thanks
+
+Same contributor list as 1.0.5 — see that release's notes.

--- a/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
+++ b/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
@@ -41,7 +41,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.0.5.tar.gz",
+                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.0.6.tar.gz",
                     "sha256": "bb5f2ccfb41eea1bf92bfe76fb1b786bb14f782782f155b2575f72d7859cc116"
                 },
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clipman-clipboard"
-version = "1.0.5"
+version = "1.0.6"
 description = "A clipboard history manager for Ubuntu/GNOME on Wayland"
 readme = "README.md"
 license = "Apache-2.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: clipman
-version: '1.0.5'
+version: '1.0.6'
 summary: Clipboard history manager for Wayland
 description: |
   A fast, native clipboard manager for Wayland (GNOME, KDE, Sway,


### PR DESCRIPTION
## Summary

Version bump to 1.0.6, the consolidated release that ships:

- **PR #29** — release.yml SHA fixes (`pypa/gh-action-pypi-publish` commit SHA, `fail_on_unmatched_files: false`, snap action SHA pins)
- **PR #27** — CodeQL per-SHA concurrency on push (prevents queued ratchet drops)
- **PR #30** — settings panel redesign + Wayland focus-out fix + visual overhaul
- **PR #31** — chrome font sizes bumped +2px for legibility

All ingredients are already on \`main\`; this PR rolls them into the version manifest and finalises the changelog.

## Files bumped to \`1.0.6\` via \`scripts/bump-version.sh\`

- \`pyproject.toml\`
- \`clipman/__init__.py\` (\`__version__\`)
- \`snap/snapcraft.yaml\`
- \`flathub/io.github.MohammedEl_sayedAhmed.Clipman.json\`
- \`aur/PKGBUILD\`

## Changelog

\`[Unreleased]\` rotated to \`[1.0.6] - 2026-05-20\` with the polished Highlights / Compatibility / Install matrix / "Why 1.0.6 and not 1.0.5" callout. Verbose mirror committed at \`docs/releases/v1.0.6.md\`.

## Why 1.0.6 and not 1.0.5

The 1.0.5 tag fired the release pipeline; Snap publish succeeded but **PyPI publish failed** (wrong action SHA shape) and **GH Release creation failed** (\`fail_on_unmatched_files\` tripped on a missing AppImage glob). Both root causes are fixed on main (PR #29). 1.0.6 ships the codebase end-to-end. The Snap Store revision for 1.0.5 is automatically superseded once 1.0.6 publishes.

## Test plan

- [x] \`ruff check clipman tests\` — clean
- [x] \`python -m unittest discover -s tests\` — 303/303 pass
- [ ] CI green on this PR
- [ ] After merge: tag \`v1.0.6\` + push to trigger release.yml end-to-end
- [ ] Verify PyPI / Snap Store / GH Release artifacts after the tag fires