### PR TITLE
ci(release): use libfuse2t64 on ubuntu-24.04 for AppImage build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,7 +447,9 @@ jobs:
       - name: Install python-appimage + FUSE2
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfuse2
+          # Ubuntu 24.04 (noble) renamed libfuse2 -> libfuse2t64 (time_t transition).
+          # Prefer the t64 package; fall back to libfuse2 for older runners.
+          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
           pip install python-appimage==1.4
 
       - name: Stage app recipe


### PR DESCRIPTION
## Summary

The v1.0.6 release pipeline's AppImage build job failed because Ubuntu 24.04 (noble) renamed `libfuse2` to `libfuse2t64` as part of the time_t transition. `apt-get install -y libfuse2` hard-errors on noble runners.

Fix: try `libfuse2t64` first, fall back to `libfuse2` so the step still works if we ever pin back to ubuntu-22.04 or earlier.

## Context

- v1.0.6 release run: https://github.com/MohammedEl-sayedAhmed/clipman/actions/runs/26184235282
- Failed job: `Build AppImage` → step `Install python-appimage + FUSE2`
- Non-blocking for v1.0.6 itself (PR #29 set \`fail_on_unmatched_files: false\` on the GH Release step), so the v1.0.6 release page shipped without the AppImage attached. This PR fixes the next release.

## Test plan

- [ ] After merge, manually trigger a tag-less release.yml smoke (or wait for the next tag) to confirm the AppImage builds. Alternatively re-run the failed AppImage job on the v1.0.6 run to validate the new step.