### PR TITLE
docs(readme): add star-history chart + source-install star prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ systemctl --user start clipman.service
 
 The systemd service auto-restarts on crash and starts automatically on login.
 
+> If you cloned the repo and Clipman is useful to you, please [star it on GitHub](https://github.com/MohammedEl-sayedAhmed/clipman/stargazers) — source installs aren't counted anywhere else, and stars are how the project gets visibility.
+
 ### Alternative Installation
 
 <details>
@@ -369,6 +371,16 @@ Licensed under the **Apache License, Version 2.0**. You may use, modify, and dis
 - State any changes you made
 
 See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for full details.
+
+## Star History
+
+<a href="https://star-history.com/#MohammedEl-sayedAhmed/clipman&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=MohammedEl-sayedAhmed/clipman&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=MohammedEl-sayedAhmed/clipman&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MohammedEl-sayedAhmed/clipman&type=Date" />
+  </picture>
+</a>
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary

Source installs (\`git clone\` + \`./install.sh\`) are invisible to every public counter on the README — GH Release Downloads, PyPI Downloads, EGO Downloads, and AUR all only track their own channel. The one public signal a source installer can leave is a ⭐.

Two complementary additions:

1. **One-line star prompt** under the Quick Start install commands. Explains *why* (source installs aren't counted anywhere) and invites a star.
2. **Star History chart** at the bottom of the README, just before Acknowledgements. Rendered by [star-history.com](https://star-history.com), supports light/dark via \`<picture>\` and \`prefers-color-scheme\`.

## What was deliberately *not* added

A static "14-day clones: N" snapshot from \`gh api .../traffic/clones\`. The current 14-day window is dominated by CI traffic (~375 clones in a single day from release pipeline runs), so the number would mislead readers. The Star History chart gives an honest growth signal without that distortion.

## Test plan

- [x] README renders correctly on GitHub (preview)
- [x] Star History image loads (\`star-history.com\` is public, no auth)
- [ ] Verify dark-mode swap works in browser (\`prefers-color-scheme\`)