### PR TITLE
ci(release): bump pypa/gh-action-pypi-publish v1.12.2 -> v1.14.0 (Metadata 2.4 support)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI (OIDC trusted publishing)
-        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   build-snap:
     name: Build snap


### PR DESCRIPTION
## Summary

The v1.0.6 PyPI publish failed twice. The first failure (`invalid-publisher`) was a missing trusted-publisher registration on the PyPI side, which has now been added. The re-run got further but tripped on a new twine pre-flight error:

\`\`\`
InvalidDistribution: Metadata is missing required fields: Name, Version.
...supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.
\`\`\`

## Root cause

The wheel is **actually valid** — confirmed by inspecting the artifact:

\`\`\`
$ unzip -p w.whl 'clipman_clipboard-1.0.6.dist-info/METADATA' | head -3
Metadata-Version: 2.4
Name: clipman-clipboard
Version: 1.0.6
\`\`\`

Modern setuptools emits **Metadata-Version: 2.4** (the PEP 639 license-expression format). The twine version bundled in \`pypa/gh-action-pypi-publish@v1.12.2\` (Nov 2024) only knows up to 2.3, so it bounces a perfectly valid wheel.

## Fix

Bump to **v1.14.0** (April 2026), which bundles a newer twine that recognises Metadata-Version 2.4.

\`cef221092ed1bacb1cc03d23a2d87d1d172e277b\` is the **commit SHA** for the v1.14.0 tag, not the annotated-tag-object SHA — same pattern ADR 0003 documents.

## Test plan

- [ ] After merge, re-run the v1.0.6 PyPI publish job on https://github.com/MohammedEl-sayedAhmed/clipman/actions/runs/26184235282 ("Re-run failed jobs"). The trusted publisher is already configured on the PyPI side, so the OIDC handshake will succeed; the twine pre-flight should now pass too.
- [ ] Confirm \`clipman-clipboard 1.0.6\` appears on https://pypi.org/project/clipman-clipboard/