### PR TITLE
ci(release): pin python-appimage to 1.4.5 (1.4 doesn't exist)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,7 +450,7 @@ jobs:
           # Ubuntu 24.04 (noble) renamed libfuse2 -> libfuse2t64 (time_t transition).
           # Prefer the t64 package; fall back to libfuse2 for older runners.
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
-          pip install python-appimage==1.4
+          pip install python-appimage==1.4.5
 
       - name: Stage app recipe
         env:


### PR DESCRIPTION
## Summary

The v1.0.6 re-tagged release pipeline got past the libfuse2t64 step that PR #33 fixed, then tripped on the next line:

\`\`\`
pip install python-appimage==1.4
ERROR: Could not find a version that satisfies the requirement
python-appimage==1.4 (from versions: ..., 1.3.0, 1.3.1, 1.4.3, 1.4.4, 1.4.5)
\`\`\`

\`python-appimage\` doesn't publish a bare \`1.4\` on PyPI — only point releases \`1.4.3\`, \`1.4.4\`, \`1.4.5\`. The pin was wrong from the start of the AppImage job.

## Fix

Pin to \`1.4.5\` (latest in the 1.4 line).

## Non-blocking

\`fail_on_unmatched_files: false\` (from PR #29) means the missing AppImage doesn't break the rest of the release. v1.0.6 shipped fine without it. This fix only matters for the **next** tagged release.

## Test plan

- [ ] After merge, the next tagged release should produce an AppImage attached to the GitHub Release.