### PR TITLE
ci(release): auto-publish to AUR on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -648,3 +648,91 @@ jobs:
             release-assets/clipman_*.deb
             release-assets/clipman-*.rpm
             release-assets/clipman-*-x86_64.AppImage
+
+  publish-aur:
+    # Refresh the AUR package after a successful GitHub Release.
+    #
+    # Requires the AUR_SSH_PRIVATE_KEY secret to be set (ed25519 private
+    # key whose public counterpart is registered on the AUR maintainer's
+    # account). Without the secret, this job logs a warning and exits
+    # cleanly - same pattern as publish-snap with SNAPCRAFT_STORE_CREDENTIALS.
+    name: Publish to AUR
+    needs: [pre-flight, github-release]
+    if: >-
+      always()
+      && needs.pre-flight.result == 'success'
+      && needs.github-release.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check credentials
+        id: creds
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "$AUR_SSH_KEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::AUR_SSH_PRIVATE_KEY secret not set; skipping AUR publish. Add the secret to enable automatic AUR refresh."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install SSH key
+        if: steps.creds.outputs.enabled == 'true'
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+
+      - name: Pin AUR host key
+        if: steps.creds.outputs.enabled == 'true'
+        run: |
+          # Pin the known AUR host keys so a MITM can't redirect the push.
+          # Fingerprints from https://aur.archlinux.org/ "SSH fingerprints" section.
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # SHA256 fingerprints (verified against https://aur.archlinux.org/):
+          #   ed25519: SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4
+          #   ecdsa:   SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI
+          #   rsa:     SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8
+          cat > ~/.ssh/known_hosts <<'EOF'
+          aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
+          aur.archlinux.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMiLrP8pVi5BFX2i3vepSUnpedeiewE5XptnUnau+ZoeUOPkpoCgZZuYfpaIQfhhJJI5qgnjJmr4hyJbe/zxow=
+          aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk=
+          EOF
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Refresh AUR metadata
+        if: steps.creds.outputs.enabled == 'true'
+        run: ./scripts/update-aur.sh
+
+      - name: Push to AUR
+        if: steps.creds.outputs.enabled == 'true'
+        env:
+          VERSION: ${{ needs.pre-flight.outputs.version }}
+        run: |
+          # Clone the AUR repo, replace the two files we manage, commit, push.
+          # No `.git` history from this repo leaks into the AUR repo.
+          aur_clone=$(mktemp -d)
+          git clone ssh://aur@aur.archlinux.org/clipman-clipboard.git "$aur_clone"
+          cp aur/PKGBUILD aur/.SRCINFO "$aur_clone/"
+          cd "$aur_clone"
+          if git diff --quiet PKGBUILD .SRCINFO; then
+            echo "AUR is already at $VERSION; nothing to push."
+            exit 0
+          fi
+          git -c user.email="57391064+MohammedEl-sayedAhmed@users.noreply.github.com" \
+              -c user.name="MohammedEl-sayedAhmed" \
+              commit -am "Update to $VERSION"
+          git push


### PR DESCRIPTION
## Summary

After a successful GitHub Release, automatically push the refreshed PKGBUILD + .SRCINFO to the AUR repo (`ssh://aur@aur.archlinux.org/clipman-clipboard.git`). Removes the last manual step from the release flow — no more cloning the AUR repo, copying two files, and pushing by hand after every tag.

## Design

New `publish-aur` job in `release.yml`:

- **Triggered**: only on tag push (`refs/tags/v*`), and only after `github-release` succeeds — so we don't push to AUR for a release that didn't actually ship.
- **Auth**: SSH key from `secrets.AUR_SSH_PRIVATE_KEY` loaded into `ssh-agent` via `webfactory/ssh-agent` (commit-SHA pinned `@e8387483...` = v0.10.0).
- **Host-key pinning**: full known_hosts block for AUR's ed25519/ecdsa/rsa keys pasted inline, with the SHA256 fingerprints in a leading comment so they can be cross-checked against AUR's published values:
  - ed25519: `SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4`
  - ecdsa:   `SHA256:uTa/0PndEgPZTf76e1DFqXKJEXKsn7m9ivhLQtzGOCI`
  - rsa:     `SHA256:5s5cIyReIfNNVGRFdDbe3hdYiI5OelHGpw2rOUud3Q8`
- **Metadata refresh**: runs the existing `scripts/update-aur.sh` (introduced in PR #38) to compute the fresh sha256 from the GitHub source tarball and regenerate `.SRCINFO`.
- **Push**: clones AUR, copies the two managed files, commits with the maintainer's noreply email, pushes. Skips the push if the diff is empty (idempotent — safe to re-run on the same tag).
- **Graceful skip**: if `AUR_SSH_PRIVATE_KEY` isn't set on the repo, the job logs a `::warning::` and exits cleanly — same pattern as `publish-snap` with `SNAPCRAFT_STORE_CREDENTIALS`.

## Secret setup

The repo now has the `AUR_SSH_PRIVATE_KEY` secret set with a dedicated ed25519 key (separate from the maintainer's GitHub-personal key, so the CI exposure has a smaller blast radius if it ever leaks). The corresponding public key is registered on the AUR maintainer profile.

## Test plan

- [ ] After merge, the next tagged release fires the new job. Verify the AUR package page (`https://aur.archlinux.org/packages/clipman-clipboard`) updates to the new version within a few minutes of the tag.
- [ ] Re-running the same tag (re-tagging or re-running the release pipeline) should hit the "AUR already up to date, nothing to push" branch and exit clean.