### PR TITLE
docs: refresh CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,38 @@ clipman/
 python3 -m unittest discover -s tests
 ```
 
-All 226 tests should pass. Tests cover the database layer, clipboard monitor, URL detection, and time formatting — no GTK or D-Bus required.
+All 303 tests should pass. The suite is stdlib-only — no GTK or D-Bus required at test time. Tests cover the database layer, clipboard monitor, URL detection, and time formatting. See [docs/development.md](docs/development.md) for the fuller dev setup.
+
+### Lint
+
+```bash
+ruff check clipman tests
+shellcheck --severity=warning install.sh uninstall.sh launcher.sh
+```
+
+- Ruff config lives in `pyproject.toml`. The per-file `E402` ignores in `clipman/app.py` and `clipman/window.py` are intentional — `gi.require_version()` legitimately must precede the `from gi.repository import ...` calls.
+- Run shellcheck whenever you touch a shell script.
+- See [docs/development.md](docs/development.md) for the fuller setup.
+
+### D-Bus debugging
+
+The daemon owns `com.clipman.Daemon` on the session bus; the
+GNOME Shell extension owns `org.gnome.Shell.Extensions.clipman`.
+
+Confirm both services are live:
+
+    busctl --user list | grep -E 'com.clipman.Daemon|org.gnome.Shell.Extensions.clipman'
+
+Introspect or call them with `gdbus`:
+
+    gdbus introspect --session --dest com.clipman.Daemon \
+        --object-path /com/clipman/Daemon
+
+    gdbus call --session --dest com.clipman.Daemon \
+        --object-path /com/clipman/Daemon \
+        --method com.clipman.Daemon.Toggle
+
+`docs/development.md` covers the rest.
 
 ### Key Constraints
 
@@ -83,6 +114,7 @@ status.set_text(_("{count} items").format(count=total))
 - Use `.format()` for strings with variables — keep placeholders inside the translatable string
 - Translation template: `po/clipman.pot`
 - Source file list: `po/POTFILES.in`
+- Adding a new translation: see [docs/translating.md](docs/translating.md).
 
 ### CSS Theming
 
@@ -99,6 +131,7 @@ The UI stylesheet lives in `clipman/style.css` as a `string.Template` file:
 - Use `${variable}` when followed by letters/digits (e.g., `${font_size}px`)
 - Variables are substituted at runtime from the theme dictionary in `window.py`
 - Do **not** use CSS custom properties (`var(--name)`) — GTK3's CSS engine does not support them
+- Never commit `clipman/style.css` with `$variable` placeholders substituted — the runtime template substitution would then double-substitute and the daemon would fail to load the CSS.
 
 ## Submitting Changes
 
@@ -107,6 +140,20 @@ The UI stylesheet lives in `clipman/style.css` as a `string.Template` file:
 3. Run the test suite: `python3 -m unittest discover -s tests`
 4. Commit with a clear message describing what and why
 5. Push and open a Pull Request
+
+## How a PR gets reviewed
+
+- **Timeline.** A single maintainer reviews PRs (see GOVERNANCE.md). Typical first response within a week.
+- **What reviewers check.**
+  - Tests pass: `python3 -m unittest discover -s tests`.
+  - `ruff check clipman tests` clean.
+  - `shellcheck --severity=warning install.sh uninstall.sh launcher.sh` clean if any shell script was touched.
+  - User-visible change → `CHANGELOG.md` `[Unreleased]` entry.
+  - Substantive architectural decision → ADR added under `docs/adr/` per ADR 0001.
+  - D-Bus contract change (signature, new method, new arg) → `extension/metadata.json` `version` integer bumped per [ADR 0005](docs/adr/0005-paste-mode-as-dbus-arg.md).
+- **Auto-labeling.** Path-based `area:*` and `distribution:*` labels are applied automatically by `.github/workflows/labeler.yml`; type / priority / status labels are set manually.
+- **Dependabot PRs.** PRs labeled `dependencies` by Dependabot for `pip` and `github-actions` are still reviewed but typically merge quickly once CI is green.
+- **GitHub Advanced Security threads.** Resolve every `github-advanced-security` finding before merge — reply on the thread, resolve, and dismiss the alert if it's a false positive.
 
 ## Reporting Issues
 
@@ -124,6 +171,16 @@ When filing a bug report, please include:
 - JavaScript (extension): ES module syntax, GNOME Shell conventions
 - No unnecessary abstractions — keep it simple
 - Prefer specific exception types over bare `except`
+
+## Definition of Done
+
+- [ ] `python3 -m unittest discover -s tests` passes locally (303 tests)
+- [ ] `ruff check clipman tests` is clean
+- [ ] `shellcheck --severity=warning install.sh uninstall.sh launcher.sh` is clean if any shell script was touched
+- [ ] `CHANGELOG.md` `[Unreleased]` updated for user-visible changes
+- [ ] ADR added under `docs/adr/` for substantive architectural decisions
+- [ ] `extension/metadata.json` `version` integer bumped if the D-Bus contract changed (per [ADR 0005](docs/adr/0005-paste-mode-as-dbus-arg.md))
+- [ ] PR description fills the template (`.github/pull_request_template.md`)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Updates the test count (226 → 303) and clarifies the suite is stdlib-only.
- Adds: a brief Lint subsection (ruff + shellcheck), a D-Bus debugging subsection, a CSS theming gotcha (never commit substituted style.css), an i18n cross-reference to docs/translating.md, a `How a PR gets reviewed` section, and a `Definition of Done` checklist.
- Existing content preserved verbatim — this PR augments, it does not replace.

## Linked issues

(none)

## Type of change

- [x] Documentation

## Testing

- [x] `python -m unittest discover -s tests` not affected (docs-only)