### PR TITLE
docs(readme): correct po/clipman.pot string count 71 -> 70

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ clipman/
 │   └── clipman.service            # Systemd user service
 ├── po/
 │   ├── POTFILES.in                # Files with translatable strings
-│   └── clipman.pot                # Translation template (71 strings)
+│   └── clipman.pot                # Translation template (70 strings)
 ├── tests/
 │   ├── test_database.py           # Database unit tests (93 tests)
 │   ├── test_clipboard_monitor.py  # Monitor unit tests (105 tests)


### PR DESCRIPTION
## Summary

- One-line fix: README's project-structure block listed `clipman.pot` as a "Translation template (71 strings)". The POT actually contains 70 translatable strings (`grep '^msgid \"' po/clipman.pot | grep -v '^msgid \"\"$' | wc -l` = 70). The "71" was counting the empty header `msgid`. CONTRIBUTING.md was already correct at 70; this aligns README with reality.

## Linked issues

(none)

## Type of change

- [x] Documentation

## Testing

- [x] `python -m unittest discover -s tests` not affected (docs-only)
- [x] Verified count via grep on po/clipman.pot