### PR TITLE
docs: drop 'Flathub submission pending' claim across README + ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ Or with paru: `paru -S clipman-clipboard`
 </details>
 
 <details>
-<summary><strong>Flatpak / Flathub</strong> (manifest in repo, submission pending)</summary>
+<summary><strong>Flatpak / Flathub</strong> (not currently published)</summary>
 
-A Flathub manifest is maintained at `flathub/io.github.MohammedEl_sayedAhmed.Clipman.json` for the upcoming Flathub submission. Once accepted, install with:
-
-```bash
-flatpak install flathub io.github.MohammedEl_sayedAhmed.Clipman
-```
+Clipman is **not** currently published on Flathub and there is no
+submission in flight. A reference manifest is kept at
+`flathub/io.github.MohammedEl_sayedAhmed.Clipman.json` so that a future
+submission has somewhere to start, but it should not be treated as a
+released channel.
 
 </details>
 

--- a/docs/adr/0007-in-app-update-notifications.md
+++ b/docs/adr/0007-in-app-update-notifications.md
@@ -9,12 +9,18 @@ deciders: MohammedEl-sayedAhmed
 ## Context
 
 Clipman ships through five channels: PyPI, source / `install.sh`,
-Snap, Flathub, AUR, and the GNOME Extensions website (extension
-only). Snap and Flathub auto-refresh installed apps; the other three
-require the user to manually pull updates. Today there is **no
-signal inside the running app** that a new release exists — users
-discover updates only by visiting GitHub, the AUR, or PyPI on their
-own initiative.
+Snap, AUR, `.deb`/`.rpm` artifacts on the GitHub Release page, plus
+the GNOME Extensions website (extension only). The Snap Store
+auto-refreshes installed snaps; the others require the user to pull
+updates manually. Today there is **no signal inside the running app**
+that a new release exists — users discover updates only by visiting
+GitHub, the AUR, or PyPI on their own initiative.
+
+(Flathub is *not* a current channel. There is no submission in flight;
+a reference manifest is kept under `flathub/` for possible future use.
+The per-install default for the update check still treats a hypothetical
+Flatpak install as auto-refreshing, since the technology itself
+refreshes when configured by a store.)
 
 We want a low-friction, privacy-respecting nudge: when a newer
 release is published, the running daemon should surface a small
@@ -24,9 +30,11 @@ in-app indicator the next time the user opens the popup. Concretely:
   cookies, or anything beyond what an anonymous web visitor would
   fetch.
 - *No auto-update.* We notify and link; we don't download or install.
-- *Opt-out friendly.* Snap and Flathub users in particular don't need
-  this — their package manager already refreshes — so it should
-  default off there.
+- *Opt-out friendly.* Snap users in particular don't need this — the
+  Snap Store already refreshes installed snaps — so it should default
+  off there. The same default applies if a Flatpak install ever exists
+  (`$FLATPAK_ID` set), since a Flatpak-hosting store would refresh on
+  its own.
 - *No new system dependency.* The daemon must do this with what's
   already installed (Python 3.10+, stdlib).
 

--- a/docs/adr/0010-versioning-policy.md
+++ b/docs/adr/0010-versioning-policy.md
@@ -8,12 +8,15 @@ deciders: MohammedEl-sayedAhmed
 
 ## Context
 
-Clipman has shipped through eight 1.0.x releases on PyPI, Snap, Flathub,
-AUR, and the GitHub Releases page, plus an out-of-band cadence for the
-GNOME Shell extension on extensions.gnome.org. Until now the meaning of
-each version bump has lived only in the maintainer's head and in the
-release-checklist prose. That worked while the public surface was
-small, but it has grown:
+Clipman has shipped through eight 1.0.x releases on PyPI, Snap, AUR,
+and the GitHub Releases page (`.deb` / `.rpm` / AppImage artifacts),
+plus an out-of-band cadence for the GNOME Shell extension on
+extensions.gnome.org. (Flathub is not a current channel — a manifest
+is kept under `flathub/` for possible future use, but there is no
+submission in flight.) Until now the meaning of each version bump has
+lived only in the maintainer's head and in the release-checklist
+prose. That worked while the public surface was small, but it has
+grown:
 
 - Two D-Bus interfaces with explicit contracts — `com.clipman.Daemon`
   at `/com/clipman/Daemon` (methods: `Toggle`, `Show`, `Hide`, `Quit`,
@@ -29,10 +32,10 @@ small, but it has grown:
   Ubuntu 22.04+.
 - A toolkit choice (GTK3) that downstream packagers depend on.
 
-Without a written policy, downstreams (AUR, Flathub, Snap, distro
-packagers) cannot tell from a tag alone whether a release will require
-a rebuild against new system libraries, a schema migration, or a new
-extension version. They also cannot tell whether the extension's
+Without a written policy, downstreams (AUR, Snap, distro packagers,
+plus any future Flathub submission) cannot tell from a tag alone
+whether a release will require a rebuild against new system libraries,
+a schema migration, or a new extension version. They also cannot tell whether the extension's
 `metadata.json` `version` integer — bumped 4→5 in ADR 0005 — is the
 same concept as the product's tag, which it is not.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -85,9 +85,10 @@ These steps aren't automatable today:
   upload API.
 - **AUR** — bump `aur/PKGBUILD` (the bump script already did this) and
   push to the AUR remote if you maintain a separate AUR repo.
-- **Flathub** — open a PR against the Flathub repo bumping the
-  manifest source URL / commit. The in-repo manifest under `flathub/`
-  is for reference only.
+- **Flathub** — not a current channel. The in-repo manifest under
+  `flathub/` is kept for reference only; if a Flathub submission
+  is ever made, this step becomes "open a PR against the Flathub
+  repo bumping the manifest source URL / commit".
 
 ## Verify the release publicly
 


### PR DESCRIPTION
## Summary

There is no Flathub submission in flight. Several places in the docs claimed otherwise — \"upcoming Flathub submission\", \"submission pending\", or listed Flathub among released channels. This PR corrects the factual claim without touching the in-repo manifest, the snap/flatpak update-default logic, the AppStream metadata, or any release-pipeline plumbing — those stay so a future submission has a starting point.

## Files touched

- **`README.md`** — the **Flatpak / Flathub** install block now says clearly that the channel is not currently published. The reference manifest is still mentioned.
- **`docs/adr/0007-in-app-update-notifications.md`** — channel list updated; the *Opt-out friendly* bullet rephrased to talk about Snap users, with a follow-on note that the `\$FLATPAK_ID` per-install default in code is intentionally unchanged for any hypothetical Flatpak install.
- **`docs/adr/0010-versioning-policy.md`** — \"Clipman has shipped through ... PyPI, Snap, Flathub, AUR\" corrected to remove Flathub; the downstreams list is also updated.
- **`docs/release-checklist.md`** — the Flathub step is now \"not a current channel\" with a one-liner about what the step *would* be if a submission ever lands.

## ADR-in-place note

The ADR README says accepted ADRs are not edited in place. These edits are **factual corrections** to a claim that was never accurate (no Flathub submission ever happened) — not changes to the decision itself. The privacy posture, per-install default, and migration story remain identical.

## What did **not** change

- `flathub/io.github.MohammedEl_sayedAhmed.Clipman.json` — kept as a reference for a possible future submission.
- `clipman/updates.py` `install_kind()` and \`\$FLATPAK_ID\` handling — defensive default for any future Flatpak install.
- `data/io.github.MohammedEl_sayedAhmed.Clipman.{desktop,metainfo.xml}` — Flatpak-namespaced AppStream metadata.
- `.github/labels.yml`, `.github/labeler.yml`, `scripts/bump-version.sh` — packaging tooling that would be needed by a future submission.

## Test plan

- [ ] Read each diff in *Files changed* and confirm the wording isn't promising anything
- [ ] Wait for CI (lint, tests, CodeQL, gitleaks) to pass
- [ ] Squash-merge on green