### PR TITLE
docs: add modern Clipman logo SVG (Catppuccin Mocha)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/MohammedEl-sayedAhmed/clipman/main/docs/logo.svg" alt="Clipman logo" width="128" height="128">
+<img src="docs/logo.svg" alt="Clipman logo" width="128" height="128">
 
 # Clipman
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="https://raw.githubusercontent.com/MohammedEl-sayedAhmed/clipman/main/docs/logo.svg" alt="Clipman logo" width="128" height="128">
+
 # Clipman
 
 **A clipboard history manager for Ubuntu/GNOME on Wayland**

--- a/data/com.clipman.Clipman.svg
+++ b/data/com.clipman.Clipman.svg
@@ -1,15 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <!-- Clipboard board -->
-  <rect x="24" y="20" width="80" height="96" rx="8" fill="#585b70"/>
-  <rect x="28" y="36" width="72" height="76" rx="4" fill="#313244"/>
-  <!-- Clip at top -->
-  <rect x="44" y="12" width="40" height="20" rx="6" fill="#89b4fa"/>
-  <rect x="50" y="8" width="28" height="12" rx="4" fill="#89b4fa"/>
-  <!-- Text lines -->
-  <rect x="38" y="48" width="52" height="5" rx="2" fill="#a6adc8"/>
-  <rect x="38" y="60" width="40" height="5" rx="2" fill="#a6adc8"/>
-  <rect x="38" y="72" width="48" height="5" rx="2" fill="#a6adc8"/>
-  <rect x="38" y="84" width="32" height="5" rx="2" fill="#a6adc8"/>
-  <!-- History stack indicator -->
-  <rect x="20" y="24" width="80" height="96" rx="8" fill="none" stroke="#7f849c" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.5" transform="translate(-4,-4)"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Clipman</title>
+  <desc id="desc">Three stacked clipboard cards with a clip at the top, in Catppuccin Mocha colors. Visualises clipboard history with a paste cursor on the front card.</desc>
+
+  <defs>
+    <!-- Subtle stroke gradient for the front card so the edge catches
+         light at the top and recedes toward the bottom. -->
+    <linearGradient id="cardStroke" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#cba6f7" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#cba6f7" stop-opacity="0.25"/>
+    </linearGradient>
+
+    <!-- Catppuccin Mocha tokens used by reference below -->
+    <!-- base   #1e1e2e  surface0 #313244  surface1 #45475a  surface2 #585b70
+         text   #cdd6f4  subtext0 #a6adc8  subtext1 #bac2de
+         mauve  #cba6f7  pink     #f5c2e7  blue     #89b4fa  lavender #b4befe -->
+  </defs>
+
+  <!-- Back card (oldest in the history stack) -->
+  <g transform="translate(82, 18)">
+    <rect width="140" height="196" rx="16"
+          fill="#313244" stroke="#45475a" stroke-width="1.5"/>
+  </g>
+
+  <!-- Middle card -->
+  <g transform="translate(64, 32)">
+    <rect width="140" height="196" rx="16"
+          fill="#45475a" stroke="#585b70" stroke-width="1.5"/>
+  </g>
+
+  <!-- Front card (the active clip) -->
+  <g transform="translate(46, 46)">
+    <rect width="156" height="204" rx="16"
+          fill="#1e1e2e" stroke="url(#cardStroke)" stroke-width="2.5"/>
+
+    <!-- Clip at the top -->
+    <g transform="translate(78, -20)">
+      <!-- Outer clip band: Catppuccin mauve -->
+      <rect x="-28" y="2" width="56" height="28" rx="7"
+            fill="#cba6f7"/>
+      <!-- Inner top tab: Catppuccin lavender -->
+      <rect x="-19" y="-6" width="38" height="18" rx="5"
+            fill="#b4befe"/>
+      <!-- Pin highlight -->
+      <circle cx="0" cy="18" r="3.5" fill="#1e1e2e"/>
+    </g>
+
+    <!-- Content lines (the clipboard entry) -->
+    <rect x="22" y="44" width="112" height="10" rx="4" fill="#cdd6f4"/>
+    <rect x="22" y="66" width="88"  height="8"  rx="3" fill="#a6adc8"/>
+    <rect x="22" y="82" width="100" height="8"  rx="3" fill="#a6adc8"/>
+    <rect x="22" y="98" width="68"  height="8"  rx="3" fill="#a6adc8"/>
+
+    <!-- Selected row: the active clipboard entry — Catppuccin pink. -->
+    <rect x="16" y="124" width="124" height="28" rx="7"
+          fill="#f5c2e7" fill-opacity="0.15"
+          stroke="#f5c2e7" stroke-width="1.5" stroke-opacity="0.9"/>
+    <rect x="26" y="134" width="78" height="8" rx="3" fill="#f5c2e7"/>
+
+    <!-- Paste-cursor caret on the right side of the selected row -->
+    <path d="M 118 130 L 128 138 L 118 146 Z" fill="#f5c2e7"/>
+
+    <!-- Bottom hint lines for vertical weight -->
+    <rect x="22" y="166" width="56" height="8" rx="3" fill="#585b70"/>
+    <rect x="22" y="180" width="40" height="8" rx="3" fill="#45475a"/>
+  </g>
 </svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Clipman</title>
+  <desc id="desc">Three stacked clipboard cards with a clip at the top, in Catppuccin Mocha colors. Visualises clipboard history with a paste cursor on the front card.</desc>
+
+  <defs>
+    <!-- Subtle stroke gradient for the front card so the edge catches
+         light at the top and recedes toward the bottom. -->
+    <linearGradient id="cardStroke" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#cba6f7" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#cba6f7" stop-opacity="0.25"/>
+    </linearGradient>
+
+    <!-- Catppuccin Mocha tokens used by reference below -->
+    <!-- base   #1e1e2e  surface0 #313244  surface1 #45475a  surface2 #585b70
+         text   #cdd6f4  subtext0 #a6adc8  subtext1 #bac2de
+         mauve  #cba6f7  pink     #f5c2e7  blue     #89b4fa  lavender #b4befe -->
+  </defs>
+
+  <!-- Back card (oldest in the history stack) -->
+  <g transform="translate(82, 18)">
+    <rect width="140" height="196" rx="16"
+          fill="#313244" stroke="#45475a" stroke-width="1.5"/>
+  </g>
+
+  <!-- Middle card -->
+  <g transform="translate(64, 32)">
+    <rect width="140" height="196" rx="16"
+          fill="#45475a" stroke="#585b70" stroke-width="1.5"/>
+  </g>
+
+  <!-- Front card (the active clip) -->
+  <g transform="translate(46, 46)">
+    <rect width="156" height="204" rx="16"
+          fill="#1e1e2e" stroke="url(#cardStroke)" stroke-width="2.5"/>
+
+    <!-- Clip at the top -->
+    <g transform="translate(78, -20)">
+      <!-- Outer clip band: Catppuccin mauve -->
+      <rect x="-28" y="2" width="56" height="28" rx="7"
+            fill="#cba6f7"/>
+      <!-- Inner top tab: Catppuccin lavender -->
+      <rect x="-19" y="-6" width="38" height="18" rx="5"
+            fill="#b4befe"/>
+      <!-- Pin highlight -->
+      <circle cx="0" cy="18" r="3.5" fill="#1e1e2e"/>
+    </g>
+
+    <!-- Content lines (the clipboard entry) -->
+    <rect x="22" y="44" width="112" height="10" rx="4" fill="#cdd6f4"/>
+    <rect x="22" y="66" width="88"  height="8"  rx="3" fill="#a6adc8"/>
+    <rect x="22" y="82" width="100" height="8"  rx="3" fill="#a6adc8"/>
+    <rect x="22" y="98" width="68"  height="8"  rx="3" fill="#a6adc8"/>
+
+    <!-- Selected row: the active clipboard entry — Catppuccin pink. -->
+    <rect x="16" y="124" width="124" height="28" rx="7"
+          fill="#f5c2e7" fill-opacity="0.15"
+          stroke="#f5c2e7" stroke-width="1.5" stroke-opacity="0.9"/>
+    <rect x="26" y="134" width="78" height="8" rx="3" fill="#f5c2e7"/>
+
+    <!-- Paste-cursor caret on the right side of the selected row -->
+    <path d="M 118 130 L 128 138 L 118 146 Z" fill="#f5c2e7"/>
+
+    <!-- Bottom hint lines for vertical weight -->
+    <rect x="22" y="166" width="56" height="8" rx="3" fill="#585b70"/>
+    <rect x="22" y="180" width="40" height="8" rx="3" fill="#45475a"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds `docs/logo.svg` — a hand-designed modern SVG logo for the project. The existing app icon at `data/com.clipman.Clipman.svg` is unchanged; this is a new asset intended for the README header, social cards, and any other surface that wants a vector mark.

## Design

- **Three stacked cards** visualise clipboard history. The front card is the active clip; back/middle peek out behind to suggest depth (older entries).
- **Mauve clip** at the top of the front card.
- **Pink-accented selected row** with a paste-cursor caret on the right, evoking the Super+V paste flow.
- **Catppuccin Mocha palette** — same family the app's GTK theme already uses:
  - mauve `#cba6f7` clip outer
  - lavender `#b4befe` clip inner
  - pink `#f5c2e7` active row
  - text `#cdd6f4` / subtext0 `#a6adc8` content lines
  - base `#1e1e2e` front card; surface0/surface1 for back/middle stack
- **No background rectangle** — the SVG composites cleanly on light, dark, or transparent surfaces.
- viewBox `256x256` works as either an inline mark or an app-icon-sized render.

## Light vs dark preview

The asset reads well both contexts:
- On a light README header: dark cards stand out, mauve stroke gives the front card a soft glow.
- On a dark surface: same composition, just with darker surrounding chrome.

## Test plan

- [ ] CI green
- [ ] Squash-merge
- [ ] Future PR can wire it into the README header if/when desired
