### PR TITLE
fix(ci): pass head-commit message through env to avoid shell tokenisation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -286,6 +286,13 @@ jobs:
         env:
           GH_COMMIT_AUTHOR: github-actions[bot]
           GH_COMMIT_EMAIL: github-actions[bot]@users.noreply.github.com
+          # Pass head-commit message through env, NEVER interpolate it
+          # directly into the shell script. The squash-merge body can
+          # contain arbitrary text (CSS snippets, backticks, `$(...)`,
+          # quotes); direct ${{ }} expansion would tokenise it as shell
+          # commands — broken job AND a classic Actions script-injection
+          # vector. Read it as $HEAD_COMMIT_SUBJECT below instead.
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           if git diff --quiet .github/security-baseline.json; then
             echo "Baseline unchanged; nothing to push."
@@ -294,9 +301,10 @@ jobs:
           git config user.name "$GH_COMMIT_AUTHOR"
           git config user.email "$GH_COMMIT_EMAIL"
           git add .github/security-baseline.json
-          git commit -m "chore(baseline): refresh from main @ ${GITHUB_SHA::7}
-
-          Auto-updated by codeql.yml update-baseline job after the
-          merge of ${{ github.event.head_commit.message }}.
-          "
+          # Take only the subject (first line) of the triggering commit
+          # so the trailer stays one line and never re-introduces multi-
+          # paragraph bodies into this commit message.
+          head_subject="${HEAD_COMMIT_MESSAGE%%$'\n'*}"
+          git commit -m "chore(baseline): refresh from main @ ${GITHUB_SHA::7}" \
+                     -m "Auto-updated by codeql.yml update-baseline job after the merge of: ${head_subject}"
           git push origin HEAD:security-baseline


### PR DESCRIPTION
## Summary
- Post-merge ``update-baseline`` job on codeql.yml is broken on main: the squash body of #72 contained CSS (``body.embed { ... }``) and the unquoted template expansion ``${{ github.event.head_commit.message }}`` tokenised it as shell, throwing ``.embed: command not found`` and ``pathspec 'Paste forever.' did not match any file(s) known to git``.
- Fix moves the message into ``HEAD_COMMIT_MESSAGE`` via the step ``env:`` block and reads it as a regular shell variable, taking only the first line so the trailer stays one line. Closes the classic Actions script-injection vector at the same time as fixing the immediate failure.

## Why this matters
Even though we control the squash messages, ``${{ }}`` expansion of any ``github.event.*`` field that originates outside the workflow file is a documented Actions security anti-pattern — a maintainer merging a PR with a crafted body could execute arbitrary commands in the runner.

## Repro of the failure
The failing run is [actions/runs/28143625605/job/83346107289](https://github.com/MohammedEl-sayedAhmed/clipman/actions/runs/28143625605/job/83346107289).

Errors:
\`\`\`
.embed: command not found
message: command not found
error: pathspec 'once.' did not match any file(s) known to git
error: pathspec 'Paste' did not match any file(s) known to git
\`\`\`

## Test plan
- [ ] CI green
- [ ] After merge, the next push to main triggers ``update-baseline`` and the job either commits cleanly to ``security-baseline`` or skips with "Baseline unchanged"
- [ ] No further shell-tokenisation errors in the logs