### PR TITLE
site(design): wire favicon on all design mockup pages

### DIFF
--- a/docs/design/index.html
+++ b/docs/design/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <link rel="icon" href="../logo.svg">
+    <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — design mockups</title>
     <link rel="stylesheet" href="tokens.css">
     <style>

--- a/docs/design/main-window.html
+++ b/docs/design/main-window.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <link rel="icon" href="../logo.svg">
+    <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — main window mockup</title>
     <link rel="stylesheet" href="tokens.css">
     <style>

--- a/docs/design/preferences.html
+++ b/docs/design/preferences.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <link rel="icon" href="../logo.svg">
+    <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — Preferences mockup</title>
     <link rel="stylesheet" href="tokens.css">
     <style>

--- a/docs/design/snippets.html
+++ b/docs/design/snippets.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <link rel="icon" href="../logo.svg">
+    <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — Snippets editor mockup</title>
     <link rel="stylesheet" href="tokens.css">
     <style>

--- a/docs/design/states.html
+++ b/docs/design/states.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <link rel="icon" href="../logo.svg">
+    <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — edge states</title>
     <link rel="stylesheet" href="tokens.css">
     <style>


### PR DESCRIPTION
## Summary
- Only ``docs/index.html`` carried the favicon links. The five mockup pages under ``docs/design/`` (``states.html``, ``main-window.html``, ``preferences.html``, ``snippets.html``, ``index.html``) rendered with the default browser globe icon when opened directly.
- ``states.html`` is also the target of the live-preview iframe on the marketing page, so the missing favicon shows up in tab labels and in any deep-link from the marketing page.
- Add the same ``rel="icon"`` and ``rel="apple-touch-icon"`` pointing at ``../logo.svg`` to all five.

## Test plan
- [ ] Open https://mohammedel-sayedahmed.github.io/clipman/design/states.html after deploy — tab shows the Clipman logo, not the globe
- [ ] Same for the other four design pages