### PR TITLE
site(numbers): refresh PyPI + GNOME counts server-side via daily workflow

### DIFF
--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -1,0 +1,127 @@
+name: Refresh marketing numbers
+
+# Fetches PyPI (via pypistats) and GNOME Extensions counts server-side
+# once a day and commits docs/_data/numbers.json if anything changed.
+#
+# Why this exists: the marketing page (docs/index.html) renders live
+# counts under "By the numbers". The GitHub-derived ones (stars, forks,
+# release downloads) come straight from api.github.com, which permits
+# cross-origin browser fetches. PyPI's stat endpoints either require an
+# API key (pepy.tech v2) or rate-limit, and extensions.gnome.org sends
+# no CORS header at all — so client-side fetches silently fail and
+# leave the tile showing "—". This workflow does the same fetches from
+# a runner (no CORS), writes the result to a same-origin JSON file,
+# and the page reads it on load.
+
+on:
+  schedule:
+    # Every day at 06:00 UTC. Snap analytics and PyPI stats update on a
+    # ~daily cadence so anything more frequent buys nothing.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+  # On push to main of either the workflow itself or the seed JSON, run
+  # immediately so changes to this job's plumbing are visible quickly.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/refresh-numbers.yml'
+      - 'docs/_data/numbers.json'
+
+permissions:
+  contents: write   # commit the refreshed JSON back to main
+
+concurrency:
+  group: refresh-numbers
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch upstream counters
+        id: fetch
+        run: |
+          python3 <<'PY'
+          import datetime, json, sys, urllib.request, urllib.error
+
+          NUMBERS_PATH = "docs/_data/numbers.json"
+          GNOME_EXTENSION_ID = 9407
+          PYPI_PACKAGE = "clipman-clipboard"
+          UA = "clipman-marketing-numbers/1.0 (+https://github.com/MohammedEl-sayedAhmed/clipman)"
+
+          def get_json(url, timeout=10):
+              req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/json"})
+              try:
+                  with urllib.request.urlopen(req, timeout=timeout) as r:
+                      return json.loads(r.read().decode("utf-8"))
+              except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError) as e:
+                  print(f"WARN: fetch {url} failed: {e}", file=sys.stderr)
+                  return None
+
+          with open(NUMBERS_PATH) as f:
+              prev = json.load(f)
+
+          pypi = get_json(f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/recent")
+          gnome = get_json(f"https://extensions.gnome.org/extension-info/?pk={GNOME_EXTENSION_ID}")
+
+          # Preserve prior values on partial failure so a transient outage
+          # never wipes the JSON down to zeros.
+          new = {
+              "_comment": prev.get("_comment"),
+              "updated_at": datetime.datetime.now(tz=datetime.timezone.utc)
+                              .replace(microsecond=0)
+                              .isoformat()
+                              .replace("+00:00", "Z"),
+              "pypi": dict(prev.get("pypi", {})),
+              "gnome": dict(prev.get("gnome", {})),
+          }
+          if pypi and isinstance(pypi.get("data"), dict):
+              d = pypi["data"]
+              new["pypi"].update({
+                  "package": PYPI_PACKAGE,
+                  "last_day":   int(d.get("last_day",   new["pypi"].get("last_day",   0))),
+                  "last_week":  int(d.get("last_week",  new["pypi"].get("last_week",  0))),
+                  "last_month": int(d.get("last_month", new["pypi"].get("last_month", 0))),
+                  "source": f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/recent",
+              })
+          if gnome and "downloads" in gnome:
+              new["gnome"].update({
+                  "extension_id": GNOME_EXTENSION_ID,
+                  "uuid": gnome.get("uuid", new["gnome"].get("uuid", "")),
+                  "downloads": int(gnome["downloads"]),
+                  "source": f"https://extensions.gnome.org/extension-info/?pk={GNOME_EXTENSION_ID}",
+              })
+
+          with open(NUMBERS_PATH, "w") as f:
+              json.dump(new, f, indent=2)
+              f.write("\n")
+
+          print("Refreshed:", json.dumps({
+              "pypi_last_month": new["pypi"].get("last_month"),
+              "gnome_downloads": new["gnome"].get("downloads"),
+          }))
+          PY
+
+      - name: Commit and push if changed
+        env:
+          GH_COMMIT_AUTHOR: github-actions[bot]
+          GH_COMMIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          if git diff --quiet docs/_data/numbers.json; then
+            echo "Numbers unchanged; nothing to push."
+            exit 0
+          fi
+          git config user.name  "$GH_COMMIT_AUTHOR"
+          git config user.email "$GH_COMMIT_EMAIL"
+          git add docs/_data/numbers.json
+          git commit -m "chore(numbers): refresh marketing counters [skip ci]"
+          git push origin HEAD:main

--- a/docs/_data/numbers.json
+++ b/docs/_data/numbers.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Refreshed daily by .github/workflows/refresh-numbers.yml. The marketing page (docs/index.html) fetches this file same-origin to bypass the CORS blocks on extensions.gnome.org and the auth requirement on api.pepy.tech/v2. Manual edits will be overwritten on the next scheduled run.",
+  "updated_at": "2026-06-25T03:00:00Z",
+  "pypi": {
+    "package": "clipman-clipboard",
+    "last_day": 33,
+    "last_week": 334,
+    "last_month": 887,
+    "source": "https://pypistats.org/api/packages/clipman-clipboard/recent"
+  },
+  "gnome": {
+    "extension_id": 9407,
+    "uuid": "clipman@clipman.com",
+    "downloads": 2888,
+    "source": "https://extensions.gnome.org/extension-info/?pk=9407"
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -941,16 +941,16 @@ footer.site .legal .mono { font-size: 0.78rem; }
             <span class="num-label">GNOME extension</span>
           </div>
           <div class="num-value" id="num-gnome" data-loading="true">—</div>
-          <div class="num-label">extension installs</div>
+          <div class="num-label">total installs</div>
         </div>
 
         <div class="num-card">
           <div class="num-head">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.6 2c-2.3 0-4.2 1.6-4.5 3.8-.1.6-.1 1.2 0 1.8h4.5v.7H5.4C3.5 8.3 2 9.9 2 12s1.5 3.7 3.4 3.7H7v-2.4c0-2 1.6-3.6 3.6-3.6h4.6c1.7 0 3.1-1.4 3.1-3.1V5.5c0-1.8-1.5-3.2-3.3-3.4-.4-.1-.9-.1-1.4-.1-.3 0-.6 0-1 0zM9.5 4c.6 0 1 .5 1 1s-.4 1-1 1-1-.5-1-1 .4-1 1-1zm6.5 4.3v2.4c0 2-1.6 3.6-3.6 3.6H7.8c-1.7 0-3.1 1.4-3.1 3.1v2.1c0 1.8 1.5 3.2 3.3 3.4 1.4.2 2.6.2 3.6 0 1.8-.1 3.4-1.5 3.4-3.4v-1.8h-4.5V17h6.8c1.9 0 3.4-1.6 3.4-3.7s-1.5-3.7-3.4-3.7H16zm-1.5 9.4c.6 0 1 .5 1 1s-.4 1-1 1-1-.5-1-1 .4-1 1-1z"/></svg>
-            <span class="num-label">PyPI downloads</span>
+            <span class="num-label">PyPI</span>
           </div>
           <div class="num-value" id="num-pypi" data-loading="true">—</div>
-          <div class="num-label">pip · pipx installs</div>
+          <div class="num-label">downloads · last 30 days</div>
         </div>
       </div>
     </div>
@@ -1274,24 +1274,25 @@ footer.site .legal .mono { font-size: 0.78rem; }
             } catch (_) { /* leave placeholder */ }
         })();
 
-        // 4) GNOME Extensions registry → install count for ext #9407.
+        // 4 + 5) Same-origin JSON refreshed daily by the
+        // refresh-numbers.yml workflow. We can't read the GNOME
+        // Extensions API or PyPI download stats directly from the
+        // browser — the first sends no Access-Control-Allow-Origin
+        // header at all, the second requires an authenticated key on
+        // its v2 API — so a scheduled GitHub Action does the fetch
+        // server-side and commits the numbers into _data/numbers.json.
         (async () => {
             try {
-                const r = await fetch('https://extensions.gnome.org/extension-info/?pk=9407');
+                // Cache-bust on the day so a fresh deploy after the
+                // nightly refresh isn't served the stale CDN copy.
+                const day = new Date().toISOString().slice(0, 10);
+                const r = await fetch('_data/numbers.json?d=' + day);
                 if (!r.ok) return;
                 const j = await r.json();
-                if (typeof j.downloads === 'number') setNum('num-gnome', j.downloads);
-            } catch (_) { /* leave placeholder */ }
-        })();
-
-        // 5) pepy.tech → cumulative PyPI download count.
-        (async () => {
-            try {
-                const r = await fetch('https://api.pepy.tech/api/v2/projects/clipman-clipboard');
-                if (!r.ok) return;
-                const j = await r.json();
-                const n = j && (j.total_downloads ?? j.downloads);
-                if (typeof n === 'number') setNum('num-pypi', n);
+                const gnome = j && j.gnome && j.gnome.downloads;
+                const pypi  = j && j.pypi  && j.pypi.last_month;
+                if (typeof gnome === 'number') setNum('num-gnome', gnome);
+                if (typeof pypi  === 'number') setNum('num-pypi',  pypi);
             } catch (_) { /* leave placeholder */ }
         })();
     }


### PR DESCRIPTION
## Summary
- The "By the numbers" tiles for PyPI and GNOME extension always rendered ``—`` because the client-side fetches were CORS-blocked: ``extensions.gnome.org`` sends no ``Access-Control-Allow-Origin``, and ``api.pepy.tech/v2`` requires an API key.
- The README badges work for the same numbers because they're static SVGs (``img.shields.io`` / ``static.pepy.tech``) — the badge service fetches server-side and bakes the count into the image.
- Approach: a scheduled GitHub Action runs daily, fetches both endpoints from the runner (no CORS), commits ``docs/_data/numbers.json``. The marketing page fetches that file same-origin with a YYYY-MM-DD cache-buster.

## What changes
- ``.github/workflows/refresh-numbers.yml``: daily cron at 06:00 UTC + ``workflow_dispatch`` + on-push for the workflow file itself. Preserves prior values on partial fetch failure so a transient outage never wipes numbers to zero.
- ``docs/_data/numbers.json``: seeded from a live fetch (PyPI 887/month, GNOME 2,888 total installs).
- ``docs/index.html``: collapsed the two failing client-side fetches into one same-origin read; tightened the tile labels to match what's actually sourced ("total installs" + "downloads · last 30 days").

## Test plan
- [ ] CI green
- [ ] After merge, the workflow runs once (on the push-to-main path), the JSON gets bumped to fresh numbers if any drifted
- [ ] On the live marketing page, the PyPI and GNOME tiles render real counts within a couple of seconds of page load
- [ ] Manually trigger the workflow via ``gh workflow run "Refresh marketing numbers"`` and confirm the commit author is ``github-actions[bot]``