### PR TITLE
fix(ci): refresh-numbers opens auto-merge PR instead of pushing to main

### DIFF
--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -28,7 +28,8 @@ on:
       - 'docs/_data/numbers.json'
 
 permissions:
-  contents: write   # commit the refreshed JSON back to main
+  contents: write       # push a refresh branch
+  pull-requests: write  # open the auto-merge PR
 
 concurrency:
   group: refresh-numbers
@@ -111,8 +112,9 @@ jobs:
           }))
           PY
 
-      - name: Commit and push if changed
+      - name: Open auto-merge PR if changed
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_COMMIT_AUTHOR: github-actions[bot]
           GH_COMMIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         run: |
@@ -120,8 +122,21 @@ jobs:
             echo "Numbers unchanged; nothing to push."
             exit 0
           fi
+          # Branch protection on main requires status checks to pass
+          # before any push lands. Direct ``git push origin HEAD:main``
+          # would fail with GH006 "Protected branch update failed". So
+          # we push a transient branch, open a PR, and ask GitHub to
+          # auto-merge it once the required checks pass.
+          branch="chore/numbers-$(date -u +%Y%m%d-%H%M%S)"
           git config user.name  "$GH_COMMIT_AUTHOR"
           git config user.email "$GH_COMMIT_EMAIL"
+          git checkout -b "$branch"
           git add docs/_data/numbers.json
           git commit -m "chore(numbers): refresh marketing counters [skip ci]"
-          git push origin HEAD:main
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(numbers): refresh marketing counters" \
+            --body "Automated daily refresh of \`docs/_data/numbers.json\` by the [refresh-numbers workflow](../actions/workflows/refresh-numbers.yml). Auto-merges once required checks pass."
+          gh pr merge "$branch" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary
- The nightly refresh-numbers job's "Commit and push if changed" step fails with ``GH006 Protected branch update failed`` every time the numbers actually change, because branch protection on ``main`` requires 9 status checks before any push lands.
- Switch the job to push a transient ``chore/numbers-YYYYMMDD-HHMMSS`` branch, open a PR via ``gh pr create``, then call ``gh pr merge --auto --squash --delete-branch`` so GitHub lands it once the required checks pass.

## Why this is the right shape
Same end state (one squash commit on main per genuine change) but it goes through the same gate every other merge does — no admin-bypass token, no need to grant the bot a special branch-protection exemption, and the PR shows up in the activity feed exactly like a human-authored change.

## Test plan
- [ ] After merge, manually dispatch the workflow (``gh workflow run "Refresh marketing numbers"``)
- [ ] If numbers haven't changed: "Numbers unchanged; nothing to push." and exit 0
- [ ] If numbers have changed: a ``chore/numbers-…`` PR opens, auto-merge enables, and once the 9 required checks pass it lands as a single squash commit on main