### PR TITLE
docs: add CITATION.cff (machine-readable repo citation)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use Clipman in academic work, blog posts, or downstream packages, please cite it using the metadata below."
+title: Clipman
+type: software
+authors:
+  - given-names: Mohammed
+    family-names: El-sayed Ahmed
+abstract: "Clipman is a clipboard history manager for Wayland (GNOME, KDE, Sway, Hyprland). Press Super+V to view your clipboard history, search entries, pin favorites, and instantly paste previous copies — like Windows Win+V, but for Linux."
+version: 1.0.6
+date-released: 2026-02-22
+url: "https://mohammedel-sayedahmed.github.io/clipman/"
+repository-code: "https://github.com/MohammedEl-sayedAhmed/clipman"
+license: Apache-2.0
+keywords:
+  - clipboard
+  - wayland
+  - gnome
+  - linux
+  - gtk


### PR DESCRIPTION
## What

Adds a `CITATION.cff` file at the repository root following the [Citation File Format 1.2.0](https://citation-file-format.github.io) specification.

## Why

`CITATION.cff` gives Clipman a canonical, machine-readable citation entry that downstream consumers can rely on:

- **GitHub** automatically detects the file and renders a **"Cite this repository"** button on the repo landing page, exposing both APA and BibTeX exports with one click.
- **Academic and blog citations** get a stable source of truth for author, version, date, and URL — no more guessing or copy-pasting from `pyproject.toml`.
- **Package indices, archival services (Zenodo, Software Heritage), and reference managers (Zotero, Mendeley)** can ingest the metadata directly.

No README edit is needed — GitHub adds the citation button automatically once the file is on the default branch.

## What's in the file

| Field             | Value                                                                                 |
|-------------------|---------------------------------------------------------------------------------------|
| `cff-version`     | `1.2.0`                                                                               |
| `title`           | Clipman                                                                               |
| `type`            | software                                                                              |
| `authors`         | Mohammed El-sayed Ahmed                                                               |
| `abstract`        | One-paragraph summary derived from the AppStream metainfo                             |
| `version`         | `1.0.6` (current `project.version` in `pyproject.toml`)                               |
| `date-released`   | `2026-02-22` (initial public release per `data/com.clipman.Clipman.metainfo.xml`)     |
| `url`             | https://mohammedel-sayedahmed.github.io/clipman/                                      |
| `repository-code` | https://github.com/MohammedEl-sayedAhmed/clipman                                      |
| `license`         | `Apache-2.0`                                                                          |
| `keywords`        | clipboard, wayland, gnome, linux, gtk                                                 |

## Scope

Single-file, docs-only change. No code, build, or runtime behavior touched.