### PR TITLE
site(design): replace placeholder card glyphs with subject-matched SVGs

### DIFF
--- a/docs/design/index.html
+++ b/docs/design/index.html
@@ -170,7 +170,14 @@
     <div class="card-grid">
 
         <a class="card" href="main-window.html">
-            <div class="preview">▣</div>
+            <div class="preview">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="3" y="4" width="18" height="16" rx="2"/>
+                    <line x1="3" y1="8.5" x2="21" y2="8.5"/>
+                    <line x1="6.5" y1="12.5" x2="14.5" y2="12.5"/>
+                    <line x1="6.5" y1="16" x2="17.5" y2="16"/>
+                </svg>
+            </div>
             <div class="body">
                 <div class="title">Main window</div>
                 <div class="desc">Clipboard popup — search, filter, pinned, day-grouped rows, footer.</div>
@@ -179,7 +186,16 @@
         </a>
 
         <a class="card" href="preferences.html">
-            <div class="preview">⚙</div>
+            <div class="preview">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <line x1="3" y1="7" x2="21" y2="7"/>
+                    <line x1="3" y1="12" x2="21" y2="12"/>
+                    <line x1="3" y1="17" x2="21" y2="17"/>
+                    <circle cx="9" cy="7" r="2.2" fill="currentColor" stroke="none"/>
+                    <circle cx="16" cy="12" r="2.2" fill="currentColor" stroke="none"/>
+                    <circle cx="7.5" cy="17" r="2.2" fill="currentColor" stroke="none"/>
+                </svg>
+            </div>
             <div class="body">
                 <div class="title">Preferences</div>
                 <div class="desc">Settings extracted from the inline panel into AdwPreferencesWindow with groups: Appearance / Privacy / Shortcuts / Storage / Updates / About.</div>
@@ -188,7 +204,13 @@
         </a>
 
         <a class="card" href="snippets.html">
-            <div class="preview">✎</div>
+            <div class="preview">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="8 8 4 12 8 16"/>
+                    <polyline points="16 8 20 12 16 16"/>
+                    <line x1="13.5" y1="6.5" x2="10.5" y2="17.5"/>
+                </svg>
+            </div>
             <div class="body">
                 <div class="title">Snippets editor</div>
                 <div class="desc">Master-detail Adw.Dialog: searchable snippet list on the left, edit form on the right with monospace content, {{date}}/{{clipboard}} variables, use-count meta.</div>
@@ -197,7 +219,12 @@
         </a>
 
         <a class="card" href="states.html">
-            <div class="preview">∅</div>
+            <div class="preview">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="12" cy="12" r="8.5"/>
+                    <line x1="6" y1="18" x2="18" y2="6"/>
+                </svg>
+            </div>
             <div class="body">
                 <div class="title">Edge states</div>
                 <div class="desc">15 states across 4 rendering modes (full-takeover Adw.StatusPage, AdwBanner-above-content, Adw.AlertDialog overlay, populated baseline). Sidebar picker; both themes.</div>


### PR DESCRIPTION
## Summary

The design-index card grid (`docs/design/index.html`) used four single-character Unicode glyphs as previews — `▣`, `⚙`, `✎`, `∅`. They were placeholder-y and didn't read as "this card is about X" at a glance. Replaced each with an inline 48×48 SVG that depicts the card's subject directly.

All SVGs use `stroke="currentColor"` so they inherit the existing `var(--accent)` color from `.card .preview` — no CSS changes, no new assets. The `font-size: 32px` rule on `.preview` is now inert for these cards but kept in place since other cards may reuse the class.

## Icon choices

| Card | Old glyph | New icon |
|---|---|---|
| **Main window** | `▣` | Window frame with a header bar and two list rows — clipboard-popup metaphor, deliberately not a browser with traffic-light dots. |
| **Preferences** | `⚙` | Three horizontal sliders with offset handles. Avoided the gear because every settings page on the web is a gear. |
| **Snippets editor** | `✎` | Angle brackets `</>` with a slash through the middle — reads as "code snippet". |
| **Edge states** | `∅` | Circle with a slash through it — the "absence / empty" idea without leaning on a literal Unicode null symbol. |

## Test plan

- [ ] Open `docs/design/index.html` in dark theme — all four icons render in the accent color (mauve in Mocha).
- [ ] Toggle to light theme — icons re-tint via `currentColor` (no hard-coded fills).
- [ ] Confirm the card hover lift still works and the 160px preview height is visually balanced with the 48×48 icon.
- [ ] Click each card and confirm the link to the underlying mockup still works.