### PR TITLE
site(mobile v2): hamburger nav, fixed lightbox X, responsive design pages

### DIFF
--- a/docs/design/index.html
+++ b/docs/design/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="../logo.svg">
     <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — design mockups</title>

--- a/docs/design/main-window.html
+++ b/docs/design/main-window.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="../logo.svg">
     <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — main window mockup</title>
@@ -431,6 +432,30 @@
         }
         .footer .text-btn.danger:hover {
             color: var(--error);
+        }
+
+        /* ------------------------------------------------------------
+           Mobile: drop the vertical centering, shrink the popup to fit
+           a phone viewport, let the page scroll naturally instead of
+           forcing a 100vh layout that pushes content off-screen.
+           ------------------------------------------------------------ */
+        @media (max-width: 640px) {
+            body {
+                min-height: auto;
+                align-items: flex-start;
+                padding: 16px;
+                overflow-x: hidden;
+            }
+            .theme-toggle {
+                position: static;
+                margin: 0 auto 12px;
+            }
+            .window {
+                width: 100%;
+                max-width: 360px;
+                height: auto;
+                min-height: 580px;
+            }
         }
     </style>
 <script src="theme.js" defer></script>

--- a/docs/design/preferences.html
+++ b/docs/design/preferences.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="../logo.svg">
     <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — Preferences mockup</title>
@@ -458,6 +459,56 @@
             color: var(--fg-muted);
             text-transform: uppercase;
             letter-spacing: 0.06em;
+        }
+
+        /* ------------------------------------------------------------
+           Mobile: 820px window is too wide for any phone. Collapse the
+           sidebar into a horizontal scrollable pill row above the
+           content; let the whole window be 100% of the viewport with a
+           reasonable max-width; drop the vertical centering and let the
+           page scroll.
+           ------------------------------------------------------------ */
+        @media (max-width: 640px) {
+            body {
+                min-height: auto;
+                align-items: flex-start;
+                padding: 16px;
+                overflow-x: hidden;
+            }
+            .theme-toggle {
+                position: static;
+                margin: 0 auto 12px;
+            }
+            .prefs-window {
+                width: 100%;
+                max-width: 100%;
+                height: auto;
+                min-height: 540px;
+                grid-template-columns: 1fr;
+                grid-template-areas:
+                    "headerbar"
+                    "sidebar"
+                    "content";
+            }
+            .prefs-sidebar {
+                grid-area: sidebar;
+                flex-direction: row;
+                overflow-x: auto;
+                border-right: none;
+                border-bottom: 1px solid var(--divider);
+                padding: 8px 12px;
+                gap: 4px;
+                scrollbar-width: none;
+            }
+            .prefs-sidebar::-webkit-scrollbar { display: none; }
+            .nav-item {
+                white-space: nowrap;
+                flex-shrink: 0;
+                padding: 6px 12px;
+            }
+            .prefs-content {
+                padding: 16px;
+            }
         }
     </style>
 <script src="theme.js" defer></script>

--- a/docs/design/snippets.html
+++ b/docs/design/snippets.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="../logo.svg">
     <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — Snippets editor mockup</title>
@@ -558,6 +559,31 @@
             box-shadow: 0 1px 0 var(--border-strong);
         }
         .status-kbd { margin-top: var(--space-4); font-size: var(--size-caption); color: var(--fg-muted); display: flex; gap: 6px; align-items: center; justify-content: center; }
+
+        /* ------------------------------------------------------------
+           Mobile: collapse the 280px+1fr master-detail into a single
+           column so neither pane is cramped. Snippet list above, edit
+           form below. Let the page scroll naturally.
+           ------------------------------------------------------------ */
+        @media (max-width: 640px) {
+            body {
+                min-height: auto;
+                align-items: flex-start;
+                padding: 16px;
+                overflow-x: hidden;
+            }
+            .theme-toggle {
+                position: static;
+                margin: 0 auto 12px;
+            }
+            .snip-window {
+                width: 100%;
+                max-width: 100%;
+                height: auto;
+                min-height: 560px;
+                grid-template-columns: 1fr;
+            }
+        }
     </style>
 <script src="theme.js" defer></script>
 </head>

--- a/docs/design/states.html
+++ b/docs/design/states.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="../logo.svg">
     <link rel="apple-touch-icon" href="../logo.svg">
     <title>Clipman — edge states</title>
@@ -513,6 +514,38 @@
         .picker-item .dot.t-warn { background: var(--warning); }
         .picker-item .dot.t-err  { background: var(--error); }
         .picker-item .dot.t-neu  { background: var(--fg-muted); }
+
+        /* ------------------------------------------------------------
+           Mobile: drop the side-by-side popup+picker grid, hide the
+           picker (the 15 states are still browsable by editing the
+           URL or using the iframe-embedded version on the marketing
+           page), and let the popup fill the row.
+           ------------------------------------------------------------ */
+        @media (max-width: 640px) {
+            body {
+                min-height: auto;
+                padding: 16px;
+                overflow-x: hidden;
+            }
+            .theme-toggle {
+                position: static;
+                margin: 0 auto 12px;
+                display: inline-flex;
+            }
+            .layout {
+                grid-template-columns: 1fr;
+                gap: var(--space-4);
+                max-width: 100%;
+            }
+            .picker { display: none; }
+            .window {
+                width: 100%;
+                max-width: 360px;
+                margin: 0 auto;
+                height: auto;
+                min-height: 580px;
+            }
+        }
     </style>
 <script src="theme.js" defer></script>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -244,6 +244,23 @@ header.site nav {
     align-items: center;
     gap: 22px;
 }
+/* Hamburger button — visible only at mobile widths. */
+.hamburger {
+    display: none;
+    width: 44px;
+    height: 44px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border-strong);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-left: 8px;
+}
+.hamburger:hover { border-color: var(--accent); }
+.hamburger svg { width: 22px; height: 22px; }
 header.site nav a {
     color: var(--text);
     font-size: 0.95rem;
@@ -811,7 +828,10 @@ footer.site .legal .mono { font-size: 0.78rem; }
     display: none;
     align-items: center;
     justify-content: center;
-    padding: 24px;
+    /* Reserve a 64px band at the top so the close button (pinned to
+       the modal viewport, NOT the image) has its own breathing room
+       and never overlaps the screenshot. */
+    padding: 64px 24px 24px;
     z-index: 1000;
     -webkit-tap-highlight-color: transparent;
 }
@@ -819,7 +839,6 @@ footer.site .legal .mono { font-size: 0.78rem; }
     display: flex;
 }
 .img-modal-inner {
-    position: relative;
     max-width: min(1100px, 100%);
     max-height: 100%;
     display: flex;
@@ -828,7 +847,9 @@ footer.site .legal .mono { font-size: 0.78rem; }
 }
 .img-modal img {
     max-width: 100%;
-    max-height: 88vh;
+    /* Subtract the close-button band so the image vertically centers
+       inside the remaining 88vh-ish without ever ducking under the X. */
+    max-height: calc(100vh - 96px);
     width: auto;
     height: auto;
     object-fit: contain;
@@ -837,9 +858,10 @@ footer.site .legal .mono { font-size: 0.78rem; }
     background: var(--bg);
 }
 .img-modal-close {
+    /* Pinned to the modal viewport corner, not the image. */
     position: absolute;
-    top: -12px;
-    right: -12px;
+    top: 16px;
+    right: 16px;
     width: 44px;
     height: 44px;
     border-radius: 50%;
@@ -853,11 +875,13 @@ footer.site .legal .mono { font-size: 0.78rem; }
     justify-content: center;
     cursor: pointer;
     box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.4);
+    z-index: 1;
 }
 .img-modal-close:hover { background: #292524; }
 @media (max-width: 640px) {
-    .img-modal { padding: 16px; }
-    .img-modal-close { top: 4px; right: 4px; }
+    .img-modal { padding: 56px 12px 12px; }
+    .img-modal-close { top: 8px; right: 8px; }
+    .img-modal img { max-height: calc(100vh - 80px); }
 }
 
 /* ================================================================
@@ -872,13 +896,47 @@ footer.site .legal .mono { font-size: 0.78rem; }
     /* Tighten the page gutter so 327px content -> 343px content. */
     .wrap { padding: 0 16px; }
 
-    /* The in-page anchor links push the header off-screen on iPhone SE.
-       Hide them on mobile — the page is short enough to scroll, and the
-       theme toggle stays accessible. "source" lives in the footer too. */
-    header.site nav a { display: none; }
+    /* Header gets a hamburger menu instead of inline links. The header
+       row still shows the brand on the left + hamburger + theme toggle
+       on the right. The full nav opens as a dropdown panel from the
+       hamburger; links and the theme toggle live inside it. */
+    header.site .wrap { position: relative; }
+    .hamburger { display: inline-flex; }
+
+    header.site nav {
+        display: none;
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 16px;
+        left: 16px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--r-lg);
+        padding: 16px 18px;
+        box-shadow: 0 12px 32px -12px rgba(0, 0, 0, 0.30),
+                    0 4px  10px  -4px rgba(0, 0, 0, 0.12);
+        flex-direction: column;
+        align-items: stretch;
+        gap: 4px;
+        z-index: 50;
+    }
+    header.site nav.is-open { display: flex; }
+    header.site nav a {
+        font-size: 1.05rem;
+        padding: 10px 4px;
+        opacity: 1;
+        font-family: var(--mono);
+        border-bottom: 1px solid var(--border);
+    }
+    header.site nav a:last-of-type { border-bottom: none; }
+
     .theme-toggle {
-        width: 44px;
-        height: 44px;     /* WCAG-AA touch target */
+        /* Bigger inside the hamburger panel; aligned to the row. */
+        width: 100%;
+        height: 44px;
+        border-radius: var(--r-md);
+        margin-top: 4px;
+        gap: 8px;
     }
 
     /* Hero CTA buttons: meet the 44px touch-target minimum. */
@@ -913,6 +971,29 @@ footer.site .legal .mono { font-size: 0.78rem; }
         padding: 14px 16px;
         font-size: 0.82rem;
     }
+
+    /* Live demo on mobile: the existing rule at 540px shrinks padding
+       but the iframe still tries to hold 460px of width. Let it use the
+       full row, drop the fixed height in favor of the aspect ratio, and
+       fall back to an explicit min-height for the popup content. */
+    .demo-stage iframe {
+        max-width: 100%;
+        height: auto;
+        min-height: 600px;
+        aspect-ratio: auto;
+    }
+    /* Demo bar (label + desc + state pills) stacks on mobile so the
+       state picker doesn't get pushed off-screen. */
+    .demo-bar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    .demo-states {
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+    .demo-states::-webkit-scrollbar { display: none; }
 }
 
 </style>
@@ -927,7 +1008,16 @@ footer.site .legal .mono { font-size: 0.78rem; }
       <img src="logo.svg" alt="" width="28" height="28">
       Clipman
     </a>
-    <nav aria-label="Primary">
+    <button class="hamburger" id="nav-toggle" type="button"
+            aria-label="Open navigation menu" aria-expanded="false" aria-controls="primary-nav">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="4" y1="7"  x2="20" y2="7"/>
+        <line x1="4" y1="12" x2="20" y2="12"/>
+        <line x1="4" y1="17" x2="20" y2="17"/>
+      </svg>
+    </button>
+    <nav id="primary-nav" aria-label="Primary">
       <a href="#demo">demo</a>
       <a href="#features">features</a>
       <a href="#design">design</a>
@@ -1421,6 +1511,29 @@ footer.site .legal .mono { font-size: 0.78rem; }
         loadNumbers();
     }
 
+    // ---- Mobile nav (hamburger toggle) ------------------------------
+    (function () {
+        const toggle = document.getElementById('nav-toggle');
+        const nav    = document.getElementById('primary-nav');
+        if (!toggle || !nav) return;
+        function setOpen(open) {
+            nav.classList.toggle('is-open', open);
+            toggle.setAttribute('aria-expanded', String(open));
+        }
+        toggle.addEventListener('click', () => setOpen(!nav.classList.contains('is-open')));
+        // Close on link tap so the page navigates to the section.
+        nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => setOpen(false)));
+        // Esc closes; outside-click closes.
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && nav.classList.contains('is-open')) setOpen(false);
+        });
+        document.addEventListener('click', (e) => {
+            if (!nav.classList.contains('is-open')) return;
+            if (nav.contains(e.target) || toggle.contains(e.target)) return;
+            setOpen(false);
+        });
+    })();
+
     // ---- Image lightbox ---------------------------------------------
     // Click any hero / feature screenshot to open it full-size in a
     // modal. Close on backdrop click, X button, or Escape.
@@ -1483,9 +1596,12 @@ footer.site .legal .mono { font-size: 0.78rem; }
 <!-- Image lightbox modal — populated by initLightbox() above. -->
 <div id="img-modal" class="img-modal" role="dialog" aria-modal="true"
      aria-label="Full-size screenshot" aria-hidden="true">
+  <!-- Close button sits at the modal viewport corner so it never
+       overlaps the screenshot itself. The CSS reserves a 64px top band
+       (56px on mobile) for it. -->
+  <button type="button" id="img-modal-close" class="img-modal-close"
+          aria-label="Close screenshot">&times;</button>
   <div class="img-modal-inner">
-    <button type="button" id="img-modal-close" class="img-modal-close"
-            aria-label="Close screenshot">&times;</button>
     <img id="img-modal-img" alt="">
   </div>
 </div>


### PR DESCRIPTION
## Summary
Three mobile issues from the previous round + fresh feedback:

1. **"I can't see a navbar on mobile."** v1 hid the nav links entirely. v2 adds a hamburger menu — the mobile header shows brand + hamburger + (theme toggle inside the dropdown), tapping it reveals all six anchor links + theme toggle as a drop-down panel. Esc / outside-click / link-tap closes.
2. **"X button overlays part of the image."** The close button was pinned to ``.img-modal-inner`` at ``top:-12px right:-12px``, so it sat half-on / half-off the image corner. Moved out to ``.img-modal`` itself with a reserved 64px top band (56px on mobile) so the X never overlaps the screenshot.
3. **"The local preview is broken on mobile"** + **"Subpages look zoomed out too much."**
   - Marketing demo iframe: drop the 460px max-width and 700px fixed height; flex to the row with ``min-height: 600px`` + aspect-ratio-auto.
   - All design pages were missing ``<meta name="viewport">``, so mobile browsers were rendering at a virtual 980px viewport then scaling down — the "zoomed out" appearance. Added to all five.
4. Mobile @media block on every design mockup:
   - ``main-window.html``: popup constrains to 360px max, flex-start vertical layout.
   - ``preferences.html``: 820x600 grid collapses to single column; sidebar becomes a horizontal scrollable pill row above content.
   - ``snippets.html``: master-detail collapses to single column.
   - ``states.html``: hides the right-rail picker; popup centers + fills to 360px.

## Test plan
- [ ] iPhone Safari 375px: hamburger visible, dropdown opens, every link inside dismisses the menu
- [ ] Lightbox: tap any screenshot — close X sits at the top-right of the **viewport**, not overlapping the image; works on rotate
- [ ] Live preview iframe scales properly, no horizontal scrollbar
- [ ] design/main-window, preferences, snippets, states all render at native scale (no zoom-out) and the chrome adapts (single column / horizontal sidebar)