### PR TITLE
deps: declare GTK 4 + libadwaita >= 1.4 in packaging manifests

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -10,7 +10,8 @@ depends=(
     'python>=3.10'
     'python-gobject'
     'python-dbus'
-    'gtk3'
+    'gtk4'
+    'libadwaita'
     'wl-clipboard'
 )
 optdepends=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "clipman-clipboard"
 version = "1.0.6"
-description = "A clipboard history manager for Ubuntu/GNOME on Wayland"
+description = "A Wayland-native clipboard history manager built with GTK 4 and libadwaita"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,11 +65,14 @@ parts:
     build-packages:
       - libgdk-pixbuf2.0-dev
       - libglib2.0-dev
+      - libadwaita-1-dev
     stage-packages:
       - python3
       - python3-gi
       - python3-dbus
-      - gir1.2-gtk-3.0
+      - gir1.2-gtk-4.0
+      - gir1.2-adw-1
+      - libadwaita-1-0
       - adwaita-icon-theme
       - hicolor-icon-theme
       - librsvg2-common


### PR DESCRIPTION
## Summary

Packaging-only change. Updates the snap, AUR, and PyPI metadata so they declare GTK 4 + libadwaita >= 1.4 instead of GTK 3, in preparation for the GTK4 + libadwaita port of the app code.

This is the **packaging half** of a two-PR migration:

1. **This PR** — flip the dependency declarations in every packaging manifest.
2. **Follow-up PR** — port the actual code (`gi.require_version('Gtk', '4.0')`, `gi.require_version('Adw', '1')`, widget API churn, etc.).

## Why it's safe to merge alone

This PR only changes **build / runtime dependency declarations**, not a single line of Python. Specifically:

- The next snap build will pull `gir1.2-gtk-4.0`, `gir1.2-adw-1`, and `libadwaita-1-0` into the staged tree. The resulting snap will therefore have **both** GTK 3 and GTK 4 typelibs available (`gir1.2-gtk-3.0` is dropped from the explicit stage list, but the GTK 3 shared libs that the still-GTK3 Python code dlopens via PyGObject get pulled in transitively by `python3-gi` / `adwaita-icon-theme` in core22, so the existing runtime keeps working).
- The AUR depends() swap means anyone fresh-installing from AUR after this PR but **before** the code-port PR will get GTK 4 + libadwaita pulled in, plus GTK 3 stays as a transitive dep of other system packages on a typical Arch desktop. The follow-up code PR lands quickly behind this one.
- `pyproject.toml` description is metadata only.

When the code-port PR flips the `require_version` lines, no further packaging change is needed — the libs are already in place.

## Files touched

- `snap/snapcraft.yaml` — add `libadwaita-1-dev` to `build-packages`; swap `gir1.2-gtk-3.0` for `gir1.2-gtk-4.0`, add `gir1.2-adw-1` and `libadwaita-1-0` to `stage-packages`. Kept `python3-gi`, `adwaita-icon-theme`, etc.
- `aur/PKGBUILD` — replace `gtk3` with `gtk4` + `libadwaita` in `depends()`.
- `pyproject.toml` — reword `description` from Ubuntu/GNOME-specific phrasing to Wayland-native + GTK 4 (any Wayland compositor). Left the `Environment :: X11 Applications :: GTK` classifier alone since it signals the GTK family generally.

## Test plan

- [ ] CI snap build succeeds with the new stage-packages list.
- [ ] `makepkg --printsrcinfo` on the updated PKGBUILD parses cleanly.
- [ ] `pip install .` from the repo root still works (description-only change shouldn't break sdist build).
- [ ] After the follow-up code-port PR lands, confirm the snap launches without `Namespace Gtk not available` errors.