### PR TITLE
site(mobile v3): wrap demo state pills instead of horizontal scroll

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -989,11 +989,22 @@ footer.site .legal .mono { font-size: 0.78rem; }
         align-items: stretch;
         gap: 12px;
     }
+    /* User-reported (v2): the state-picker pill was horizontally
+       scrollable, which felt broken because the pills inside don't
+       hint that they slide. Switch to flex-wrap so the four pills
+       wrap onto a second row when they don't fit. */
     .demo-states {
-        overflow-x: auto;
-        scrollbar-width: none;
+        flex-wrap: wrap;
+        justify-content: center;
+        overflow: visible;
+        padding: 6px;
+        border-radius: var(--r-md);
     }
-    .demo-states::-webkit-scrollbar { display: none; }
+    .demo-states button {
+        padding: 8px 14px;
+        font-size: 0.8rem;
+        min-height: 36px;
+    }
 }
 
 </style>


### PR DESCRIPTION
## Summary
- v2 (in #82) collapsed the four state-picker pills into a horizontally scrollable strip on mobile.
- User feedback: the scroll felt broken — pills inside a pill-shaped row give no visual cue that they slide.
- Switch to ``flex-wrap: wrap`` so the pills wrap onto a second row when they don't fit, with ``justify-content: center``. Pill min-height bumped to 36px so the taps stay comfortable.
- Drops the ``overflow-x: auto`` and scrollbar-hide rules.

## Test plan
- [ ] On iPhone SE / 375px, the four pills wrap into a tidy two-row stack
- [ ] On tablet (601–880px), pills sit in one row
- [ ] Desktop layout unchanged