### PR TITLE
site(mobile): theme toggle stays visible in header, hamburger holds links only

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -243,6 +243,7 @@ header.site nav {
     display: flex;
     align-items: center;
     gap: 22px;
+    margin-left: auto;   /* push nav + theme toggle to the right of the brand */
 }
 /* Hamburger button — visible only at mobile widths. */
 .hamburger {
@@ -896,12 +897,19 @@ footer.site .legal .mono { font-size: 0.78rem; }
     /* Tighten the page gutter so 327px content -> 343px content. */
     .wrap { padding: 0 16px; }
 
-    /* Header gets a hamburger menu instead of inline links. The header
-       row still shows the brand on the left + hamburger + theme toggle
-       on the right. The full nav opens as a dropdown panel from the
-       hamburger; links and the theme toggle live inside it. */
+    /* Header row on mobile: brand on the left, theme toggle + hamburger
+       on the right. The theme toggle stays VISIBLE in the header (most
+       used control); the hamburger holds the secondary anchor links
+       which drop down on tap. Keeping the toggle out of the dropdown
+       means switching themes never costs an extra tap to open the menu
+       first. */
     header.site .wrap { position: relative; }
     .hamburger { display: inline-flex; }
+
+    /* Move-to-right grouping: theme toggle nudges flush right; the
+       hamburger sits next to it. The nav slot (the dropdown) becomes
+       an absolute-positioned panel anchored below the header row. */
+    .theme-toggle { margin-left: auto; }
 
     header.site nav {
         display: none;
@@ -912,7 +920,7 @@ footer.site .legal .mono { font-size: 0.78rem; }
         background: var(--surface);
         border: 1px solid var(--border);
         border-radius: var(--r-lg);
-        padding: 16px 18px;
+        padding: 12px 16px;
         box-shadow: 0 12px 32px -12px rgba(0, 0, 0, 0.30),
                     0 4px  10px  -4px rgba(0, 0, 0, 0.12);
         flex-direction: column;
@@ -930,13 +938,10 @@ footer.site .legal .mono { font-size: 0.78rem; }
     }
     header.site nav a:last-of-type { border-bottom: none; }
 
+    /* Touch-target on the always-visible theme toggle. */
     .theme-toggle {
-        /* Bigger inside the hamburger panel; aligned to the row. */
-        width: 100%;
+        width: 44px;
         height: 44px;
-        border-radius: var(--r-md);
-        margin-top: 4px;
-        gap: 8px;
     }
 
     /* Hero CTA buttons: meet the 44px touch-target minimum. */
@@ -1019,6 +1024,18 @@ footer.site .legal .mono { font-size: 0.78rem; }
       <img src="logo.svg" alt="" width="28" height="28">
       Clipman
     </a>
+    <nav id="primary-nav" aria-label="Primary">
+      <a href="#demo">demo</a>
+      <a href="#features">features</a>
+      <a href="#design">design</a>
+      <a href="#install">install</a>
+      <a href="#faq">faq</a>
+      <a href="https://github.com/MohammedEl-sayedAhmed/clipman">source</a>
+    </nav>
+    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch between dark and light theme">
+      <svg class="ico-dark" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+      <svg class="ico-light" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="4.2"/><path d="M12 2v2.5M12 19.5V22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M2 12h2.5M19.5 12H22M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8"/></svg>
+    </button>
     <button class="hamburger" id="nav-toggle" type="button"
             aria-label="Open navigation menu" aria-expanded="false" aria-controls="primary-nav">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -1028,18 +1045,6 @@ footer.site .legal .mono { font-size: 0.78rem; }
         <line x1="4" y1="17" x2="20" y2="17"/>
       </svg>
     </button>
-    <nav id="primary-nav" aria-label="Primary">
-      <a href="#demo">demo</a>
-      <a href="#features">features</a>
-      <a href="#design">design</a>
-      <a href="#install">install</a>
-      <a href="#faq">faq</a>
-      <a href="https://github.com/MohammedEl-sayedAhmed/clipman">source</a>
-      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch between dark and light theme">
-        <svg class="ico-dark" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
-        <svg class="ico-light" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="4.2"/><path d="M12 2v2.5M12 19.5V22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M2 12h2.5M19.5 12H22M4.9 19.1l1.8-1.8M17.3 6.7l1.8-1.8"/></svg>
-      </button>
-    </nav>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
v2 put the theme toggle inside the hamburger dropdown. Switching themes therefore cost two taps (open menu → tap toggle). Reorder the header markup so the toggle is a sibling of the nav, not a child; the hamburger dropdown now contains only the anchor links.

## Layout
- **Desktop**: brand → nav → theme toggle. ``margin-left: auto`` on nav groups nav + toggle flush right of the brand.
- **Mobile (≤640px)**: brand → theme toggle → hamburger. Nav opens as a dropdown anchored below the header. Theme toggle is 44x44 to meet the touch-target rule.

## No behavior change
JS still binds to ``#nav-toggle`` (hamburger) for the menu dropdown and ``#theme-toggle`` for the theme switcher. Both IDs are unchanged.

## Test plan
- [ ] On 375px mobile, the theme toggle sits next to the hamburger; tapping it switches theme without opening the menu
- [ ] Tapping the hamburger opens the dropdown with only six anchor links (no theme toggle inside)
- [ ] Desktop layout: brand on the left, nav + theme toggle grouped on the right