### PR TITLE
site(mobile v4): stack design pages vertically and restore states picker

### DIFF
--- a/docs/design/index.html
+++ b/docs/design/index.html
@@ -170,6 +170,12 @@
            ------------------------------------------------------------ */
         @media (max-width: 640px) {
             body {
+                /* Desktop body is display:flex; justify-content:center, which
+                   keeps the .page block centered. On mobile we want
+                   vertical stacking — the theme-toggle pill sits above
+                   the content, not next to it. */
+                flex-direction: column;
+                align-items: stretch;
                 padding: 16px;
                 overflow-x: hidden;
             }

--- a/docs/design/main-window.html
+++ b/docs/design/main-window.html
@@ -442,7 +442,8 @@
         @media (max-width: 640px) {
             body {
                 min-height: auto;
-                align-items: flex-start;
+                flex-direction: column;
+                align-items: stretch;
                 padding: 16px;
                 overflow-x: hidden;
             }

--- a/docs/design/preferences.html
+++ b/docs/design/preferences.html
@@ -471,7 +471,8 @@
         @media (max-width: 640px) {
             body {
                 min-height: auto;
-                align-items: flex-start;
+                flex-direction: column;
+                align-items: stretch;
                 padding: 16px;
                 overflow-x: hidden;
             }

--- a/docs/design/states.html
+++ b/docs/design/states.html
@@ -524,12 +524,19 @@
         @media (max-width: 640px) {
             body {
                 min-height: auto;
+                flex-direction: column;
+                align-items: stretch;
                 padding: 16px;
                 overflow-x: hidden;
             }
             /* Embedded (iframe) mode owns its own layout; don't let the
-               page-level mobile rule retake its padding. */
-            body.embed { padding: 12px; }
+               page-level mobile rule retake its padding or stack
+               direction. */
+            body.embed {
+                padding: 12px;
+                flex-direction: row;
+                align-items: center;
+            }
             .theme-toggle {
                 position: static;
                 margin: 0 auto 12px;
@@ -544,7 +551,16 @@
                 gap: var(--space-4);
                 max-width: 100%;
             }
-            .picker { display: none; }
+            /* The picker (state list) stays VISIBLE on mobile — users still
+               need to switch between the 15 mockup states. Re-layout as
+               a compact pane stacked below the popup. The desktop fixed
+               280px column would have forced horizontal overflow, but
+               with grid-template-columns: 1fr it now spans the row. */
+            .picker {
+                width: 100%;
+                max-height: 320px;       /* don't dominate the viewport */
+                overflow-y: auto;
+            }
             .window {
                 width: 100%;
                 max-width: 360px;


### PR DESCRIPTION
## Summary
Verified each mockup at 375px via headless Chrome screenshots. Two classes of mobile bug surfaced after #82 / #85:

1. **Horizontal stacking on three mockup pages** — main-window / preferences / snippets had ``body { display: flex }`` and the mobile rule only re-targeted ``align-items``, never ``flex-direction``. With the theme-toggle moved out of ``position: fixed`` (per #85), it became a flex child of the body and sat in a horizontal row next to the ``.window`` — half-off-screen. Fix: ``flex-direction: column; align-items: stretch`` on the mobile body.

2. **design/index.html same root cause** — its desktop body also uses ``display: flex``. The content was being pushed off-screen by the same mechanism. Same fix applied.

3. **states.html picker was hidden entirely on mobile** (``display: none`` from #85), so the 15-state list was unreachable — that's the whole point of the page. Switch to a 100%-wide scrollable pane stacked below the popup, so users can still pick states.

4. **states.html ``body.embed`` override** — the iframe-embedded mode (used by the marketing live-preview frame) gets an explicit ``flex-direction: row; align-items: center`` so the page-level mobile column rule doesn't break it.

## Verification
Screenshotted via ``google-chrome --headless --window-size=375,812`` for each page. All five mockup surfaces + the marketing page render cleanly: no horizontal scroll, no off-screen content, no orphaned theme toggle.

## Test plan
- [ ] CI green
- [ ] Open https://mohammedel-sayedahmed.github.io/clipman/design/ on iPhone — content stacks vertically, no left void
- [ ] Open .../design/main-window.html, /preferences.html, /snippets.html, /states.html — popup mockup centers, theme toggle sits above
- [ ] On states.html, the EDGE STATES picker is visible below the popup and lets you switch between the 15 states