### PR TITLE
fix(ci): drop [skip ci] from refresh-numbers so PR checks run

### DIFF
--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -132,7 +132,12 @@ jobs:
           git config user.email "$GH_COMMIT_EMAIL"
           git checkout -b "$branch"
           git add docs/_data/numbers.json
-          git commit -m "chore(numbers): refresh marketing counters [skip ci]"
+          # NOTE: no ``[skip ci]`` here. Branch protection on main requires
+          # the status checks to run+pass before the PR can merge; a
+          # ``[skip ci]`` commit message suppresses all workflow runs, so
+          # the required checks would never start and ``--auto`` merge
+          # would block forever. The checks must run on this PR.
+          git commit -m "chore(numbers): refresh marketing counters"
           git push origin "$branch"
           gh pr create \
             --base main \


### PR DESCRIPTION
## Problem
PR #94 (the daily numbers refresh) is stuck: **0 checks, `mergeStateStatus=BLOCKED`, auto-merge never completes.**

Root cause: the workflow commits with `[skip ci]` in the message. That suppresses **all** workflow runs for the commit — but `main`'s branch protection requires 9 status checks to pass before merge. The checks never start → the PR can never satisfy protection → auto-merge blocks forever.

`[skip ci]` was fine when the workflow pushed directly to `main`; it became a deadlock once the flow moved to a protected-branch PR.

## Fix
Remove `[skip ci]` from the commit message so CI runs on the numbers PR and auto-merge can land it.

## Follow-up
- After this merges, close the stuck #94 and re-trigger the workflow (or wait for tomorrow's cron) — the fresh PR will run checks and auto-merge cleanly.

## Test plan
- [ ] CI green on this PR
- [ ] Manually dispatch "Refresh marketing numbers" → new PR gets checks → auto-merges