### PR TITLE
ci(numbers): supersede stale pending PRs on each daily run

### DIFF
--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -122,6 +122,15 @@ jobs:
             echo "Numbers unchanged; nothing to push."
             exit 0
           fi
+          # Supersede any earlier open numbers PR. Check runs on
+          # github-actions[bot] PRs need manual maintainer approval, so the
+          # maintainer approves only the latest pending PR. If they miss a
+          # day, stale auto-refresh PRs would otherwise pile up — close each
+          # prior one (and delete its branch) before opening today's.
+          mapfile -t stale < <(gh pr list --state open --search "chore(numbers) in:title" --json number --jq ".[].number") || stale=()
+          for n in "${stale[@]:-}"; do
+            [ -n "$n" ] && gh pr close "$n" --delete-branch --comment "Superseded by a newer daily numbers refresh ($(date -u +%F)). Approve the most recent chore(numbers) PR instead." || true
+          done
           # Branch protection on main requires status checks to pass
           # before any push lands. Direct ``git push origin HEAD:main``
           # would fail with GH006 "Protected branch update failed". So
@@ -143,5 +152,5 @@ jobs:
             --base main \
             --head "$branch" \
             --title "chore(numbers): refresh marketing counters" \
-            --body "Automated daily refresh of \`docs/_data/numbers.json\` by the [refresh-numbers workflow](../actions/workflows/refresh-numbers.yml). Auto-merges once required checks pass."
+            --body "Automated daily refresh of \`docs/_data/numbers.json\`. This run supersedes any earlier open numbers PR. Approve the workflow run to let checks run; it auto-merges once they pass."
           gh pr merge "$branch" --auto --squash --delete-branch


### PR DESCRIPTION
## What

The daily `refresh-numbers` job now **closes any already-open `chore(numbers)` PR (and deletes its branch) before opening the new one**, so each run supersedes the previous.

## Why

The auto-refresh PR is authored by `github-actions[bot]`. This repo requires **manual maintainer approval** before check runs execute on bot-authored PRs. The maintainer approves only the latest pending PR — so on any day they miss the approval, the prior auto-refresh PRs accumulate as stale, never-merging branches.

With this change, every daily run first tears down the earlier pending PR(s), leaving exactly one current PR for the maintainer to approve.

## How it works

```mermaid
flowchart TD
    A[Daily run: fetch counters] --> B{numbers.json changed?}
    B -- no --> Z[exit 0]
    B -- yes --> C[List open chore-numbers PRs]
    C --> D[Close each + delete branch<br/>comment: superseded]
    D --> E[Create today's branch + commit]
    E --> F[Open new PR]
    F --> G[gh pr merge --auto --squash]
    G --> H[Maintainer approves run<br/>checks pass -> auto-merge]
```

The supersede block sits right after the `git diff --quiet` no-change guard and before the new branch is created:

- Lists open PRs with `chore(numbers)` in the title.
- Closes each with `--delete-branch` and a "superseded" comment.
- Uses `mapfile` + `for "${stale[@]:-}"` so an empty list and individual close failures never abort the step.

## Unchanged

- Timestamped branch name, no-`[skip ci]` commit message, `--auto --squash --delete-branch` merge, and the Python fetch step are all left intact.
- PR body string updated to explain the approval-gate + supersede behavior.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` -> **YAML OK**
- `bash -n` on the embedded `run:` script -> **no syntax errors**
