### PR TITLE
ci(refresh-numbers): only bump updated_at when a counter changes

### DIFF
--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -75,13 +75,15 @@ jobs:
           gnome = get_json(f"https://extensions.gnome.org/extension-info/?pk={GNOME_EXTENSION_ID}")
 
           # Preserve prior values on partial failure so a transient outage
-          # never wipes the JSON down to zeros.
+          # never wipes the JSON down to zeros. updated_at is carried over
+          # unchanged here and only bumped below when a counter actually
+          # moved: setting it to now() on every run made the file always
+          # differ, so each run opened a no-op PR — and merging one
+          # re-triggered this workflow via the push path filter, chaining
+          # junk PRs.
           new = {
               "_comment": prev.get("_comment"),
-              "updated_at": datetime.datetime.now(tz=datetime.timezone.utc)
-                              .replace(microsecond=0)
-                              .isoformat()
-                              .replace("+00:00", "Z"),
+              "updated_at": prev.get("updated_at"),
               "pypi": dict(prev.get("pypi", {})),
               "gnome": dict(prev.get("gnome", {})),
           }
@@ -101,6 +103,15 @@ jobs:
                   "downloads": int(gnome["downloads"]),
                   "source": f"https://extensions.gnome.org/extension-info/?pk={GNOME_EXTENSION_ID}",
               })
+
+          # Stamp a fresh timestamp only when a counter changed. If the
+          # fetched data matches what's already committed, the file stays
+          # byte-identical and ``git diff --quiet`` below skips the PR.
+          if new["pypi"] != prev.get("pypi", {}) or new["gnome"] != prev.get("gnome", {}):
+              new["updated_at"] = (datetime.datetime.now(tz=datetime.timezone.utc)
+                                   .replace(microsecond=0)
+                                   .isoformat()
+                                   .replace("+00:00", "Z"))
 
           with open(NUMBERS_PATH, "w") as f:
               json.dump(new, f, indent=2)


### PR DESCRIPTION
## Problem

The refresh job set `updated_at` to `now()` on **every** run, before comparing against the committed file. So `docs/_data/numbers.json` always differed by at least the timestamp, `git diff --quiet` never short-circuited, and every run opened a PR — even when no counter moved.

That's benign on its own (one no-op PR/day). But the workflow also fires on **push to `main`** touching `docs/_data/numbers.json`. When such a PR is merged with a real-user token, the push re-triggers the job, which opens *another* timestamp-only PR, and so on. Today that produced the `#108 → #109` churn: `#109`'s entire diff was one line —

```diff
-  "updated_at": "2026-07-04T19:23:02Z",
+  "updated_at": "2026-07-04T20:03:42Z",
```

every PyPI/GNOME counter identical. (`#109` has been closed as pure churn.)

```mermaid
flowchart LR
  R[refresh run] --> S["updated_at = now()<br/>(always)"]
  S --> D{"git diff --quiet?"}
  D -- "never quiet" --> PR[open no-op PR]
  PR -- "merge (real-user token)" --> P["push to main<br/>touches numbers.json"]
  P -- "push path filter" --> R
```

## Fix

Carry `updated_at` over unchanged, and re-stamp it **only when a PyPI or GNOME counter actually changed**:

- Data unchanged → file stays byte-identical → `git diff --quiet` passes → **no PR**.
- A counter moved → timestamp bumps alongside it → PR opens as intended.
- Fetch failure → prior values preserved, no bump (unchanged behavior).

This also breaks the re-trigger loop at the source: a merge whose data already matches upstream produces no follow-up PR.

Net effect: `updated_at` now means *"last time the numbers changed"* rather than *"last time the job ran"* — which matches the field name and what the marketing page implies.

## Verification

Local logic test over the current JSON shape:

| Scenario | Result |
|---|---|
| Fetched data identical to committed | no-op — `updated_at` kept, **no PR** |
| PyPI counter moved | timestamp bumped → PR |
| GNOME counter moved | timestamp bumped → PR |
| Both fetches fail (`None`) | prior values preserved, no bump |

YAML parses; Python block compiles.
