### PR TITLE
fix(ci): refresh-numbers cleanup uses REST list, not code search

### DIFF
--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -138,7 +138,15 @@ jobs:
           # maintainer approves only the latest pending PR. If they miss a
           # day, stale auto-refresh PRs would otherwise pile up — close each
           # prior one (and delete its branch) before opening today's.
-          mapfile -t stale < <(gh pr list --state open --search "chore(numbers) in:title" --json number --jq ".[].number") || stale=()
+          #
+          # NB: filter client-side, not with ``--search``. gh pr list
+          # --search hits the code-search index, which is eventually
+          # consistent and returned nothing under GITHUB_TOKEN in this
+          # runner, so no PR was ever closed and refreshes piled up. The
+          # plain REST list (--json) is immediately consistent; match the
+          # title prefix with jq instead.
+          mapfile -t stale < <(gh pr list --state open --limit 100 --json number,title \
+            --jq '.[] | select(.title | startswith("chore(numbers)")) | .number') || stale=()
           for n in "${stale[@]:-}"; do
             [ -n "$n" ] && gh pr close "$n" --delete-branch --comment "Superseded by a newer daily numbers refresh ($(date -u +%F)). Approve the most recent chore(numbers) PR instead." || true
           done


### PR DESCRIPTION
## Problem

The daily refresh's "supersede earlier open numbers PR" step used:

```bash
gh pr list --state open --search "chore(numbers) in:title" ...
```

`--search` hits GitHub's code-search index, which is **eventually consistent** and returned **empty** under `GITHUB_TOKEN` in the runner. So the close loop iterated over nothing, and every daily run stacked a fresh PR without closing the prior ones — four were open at once (#115, #120, #121, #127).

The 07-13 run log confirms it: execution jumps straight from `Refreshed:` to `Switched to a new branch` with **no** `Closed pull request` lines.

## Fix

Use the plain REST list (immediately consistent) and filter the title prefix client-side with jq:

```bash
gh pr list --state open --limit 100 --json number,title \
  --jq '.[] | select(.title | startswith("chore(numbers)")) | .number'
```

Verified this matches all four currently-open numbers PRs, whereas `--search` missed them in-runner.