### PR TITLE
ux: declutter history rows (remove card-in-card; friendlier subtitle)

### DIFF
--- a/clipman/style.css
+++ b/clipman/style.css
@@ -79,12 +79,11 @@
     padding: 0 8px 8px 8px;
 }
 
+/* Rows live inside a single .boxed-list card (one container border +
+   hairline separators, the standard Adwaita grouped list). Do NOT give
+   each row its own border/background/radius/margin — that stacks a card
+   inside the card and reads as heavy, cluttered chips. Keep only sizing. */
 .clipman-list > row {
-    background-color: @card_bg_color;
-    color: @card_fg_color;
-    border: 1px solid alpha(@window_fg_color, 0.06);
-    border-radius: 8px;
-    margin: 3px 0;
     padding: 2px 4px;
     min-height: 44px;
 }

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -730,9 +730,16 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
         row = Adw.ActionRow()
         row.set_title(escape(title))
-        row.set_subtitle(
-            f"{ctype.upper()} · {self._format_time(entry['accessed_at'])}"
-        )
+        # Friendlier subtitle: the coloured type bar already conveys the
+        # type, so lead with the relative time instead of a shouty
+        # "TEXT ·" prefix, and add a char count for text entries.
+        ts = self._format_time(entry["accessed_at"])
+        if ctype == "text" and text:
+            n = len(text)
+            subtitle = f"{ts} · {n:,} char{'s' if n != 1 else ''}"
+        else:
+            subtitle = ts
+        row.set_subtitle(escape(subtitle))
         row.set_activatable(True)
         row.add_css_class("clip-row")
         row.entry_data = entry


### PR DESCRIPTION
Part of #132.

**Problem (see #132):** every history row had its own `border + background + border-radius + margin` *on top of* the `.boxed-list` container — a card inside a card. Combined with the `TEXT · just now` caps subtitle, the list read as heavy, cluttered chips.

**Change:**
- Drop the per-row card styling; let `.boxed-list` render the standard Adwaita grouped list (single container, hairline separators). Keeps the Catppuccin palette.
- Subtitle: `TEXT · just now` → `just now · 46 chars` (the coloured type bar already conveys type; char count is more useful).

**Before → after** (via `xvfb-run python3 scripts/screenshot.py`, added in #133):
- Before: bordered floating chips, redundant caps type prefix.
- After: clean flat grouped list, informative subtitle.

Verified: 297 tests pass; rendered headless screenshot confirms the lighter look. No behavior change beyond styling + subtitle text.