### PR TITLE
fix: apply incognito-on-launch and surface the incognito banner

### DIFF
--- a/clipman/app.py
+++ b/clipman/app.py
@@ -52,6 +52,13 @@ class ClipmanApp(Adw.Application):
             application=self, db=self.db, monitor=self.monitor
         )
 
+        # Apply the persisted start-in-incognito preference. Driven through
+        # the window so the header toggle, tooltip and privacy banner all
+        # reflect it — previously this setting was saved but never read, so
+        # "start in incognito" silently did nothing and clips were recorded.
+        if self.db.get_setting("incognito_on_launch", "false") == "true":
+            self.window.set_incognito(True)
+
         # Register the D-Bus service BEFORE calling hold() — if another
         # Clipman daemon is already on the bus, we want to log + quit
         # cleanly rather than have a held-but-unreachable second daemon

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -1090,12 +1090,45 @@ class ClipmanWindow(Adw.ApplicationWindow):
     def _on_incognito_toggled(self, button):
         if self.monitor is None:
             return
-        self.monitor.set_incognito(button.get_active())
+        active = button.get_active()
+        self.monitor.set_incognito(active)
         button.set_tooltip_text(
             _("Incognito mode: ON — clipboard not recorded")
-            if button.get_active()
+            if active
             else _("Incognito mode: OFF")
         )
+        # Surface (or clear) the privacy banner so the state is visible and
+        # the "Resume recording" action is reachable. Without this the
+        # incognito-on banner and its resume action were dead code.
+        if active:
+            self._show_edge_state("incognito-on")
+        else:
+            self._dismiss_edge_banner("incognito-on")
+
+    def set_incognito(self, active):
+        """Public entry point to set incognito state (used at launch).
+
+        Drives the header toggle button so the monitor, tooltip and
+        privacy banner all stay in sync through the one handler.
+        """
+        self._incognito_btn.set_active(bool(active))
+
+    def _dismiss_edge_banner(self, state_id=None):
+        """Remove the mounted edge banner.
+
+        When ``state_id`` is given, only dismiss if the current banner is
+        that state — so turning incognito off doesn't wipe an unrelated
+        banner (e.g. ``paused``).
+        """
+        banner = self._current_edge_banner
+        if banner is None:
+            return
+        if state_id is not None:
+            spec = getattr(banner, "state_spec", None)
+            if spec is not None and spec.id != state_id:
+                return
+        self._edge_banner_slot.remove(banner)
+        self._current_edge_banner = None
 
     def _on_prefs_clicked(self, _button):
         from clipman.preferences import ClipmanPreferences

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -704,10 +704,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # The handler exists so the dispatcher table stays exhaustive.
         pass
 
-    def _dismiss_edge_banner(self):
-        if self._current_edge_banner is not None:
-            self._edge_banner_slot.remove(self._current_edge_banner)
-            self._current_edge_banner = None
+    def _dismiss_edge_banner(self, state_id=None):
+        """Remove the mounted edge banner.
+
+        When ``state_id`` is given, only dismiss if the current banner is
+        that state — so turning incognito off doesn't wipe an unrelated
+        banner (e.g. ``paused``).
+        """
+        banner = self._current_edge_banner
+        if banner is None:
+            return
+        if state_id is not None:
+            spec = getattr(banner, "state_spec", None)
+            if spec is not None and spec.id != state_id:
+                return
+        self._edge_banner_slot.remove(banner)
+        self._current_edge_banner = None
 
     def _open_url(self, url):
         try:
@@ -1112,23 +1124,6 @@ class ClipmanWindow(Adw.ApplicationWindow):
         privacy banner all stay in sync through the one handler.
         """
         self._incognito_btn.set_active(bool(active))
-
-    def _dismiss_edge_banner(self, state_id=None):
-        """Remove the mounted edge banner.
-
-        When ``state_id`` is given, only dismiss if the current banner is
-        that state — so turning incognito off doesn't wipe an unrelated
-        banner (e.g. ``paused``).
-        """
-        banner = self._current_edge_banner
-        if banner is None:
-            return
-        if state_id is not None:
-            spec = getattr(banner, "state_spec", None)
-            if spec is not None and spec.id != state_id:
-                return
-        self._edge_banner_slot.remove(banner)
-        self._current_edge_banner = None
 
     def _on_prefs_clicked(self, _button):
         from clipman.preferences import ClipmanPreferences

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -222,6 +222,33 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertTrue(hasattr(window, "refresh"))
         self.assertTrue(hasattr(window, "refresh_update_banner"))
 
+    def test_incognito_toggle_syncs_monitor_and_banner(self):
+        """set_incognito drives the monitor, button and privacy banner.
+
+        Regression for two bugs: the incognito-on banner (and its
+        "Resume recording" action) was never surfaced by the toggle, and
+        set_incognito is the launch-time entry point for the previously
+        ignored incognito_on_launch setting.
+        """
+        from unittest.mock import MagicMock
+
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestIncognito")
+        monitor = MagicMock()
+        window = ClipmanWindow(application=app, db=db, monitor=monitor)
+
+        window.set_incognito(True)
+        self.assertTrue(window._incognito_btn.get_active())
+        monitor.set_incognito.assert_called_with(True)
+        self.assertIsNotNone(window._current_edge_banner)  # banner shown
+
+        window.set_incognito(False)
+        self.assertFalse(window._incognito_btn.get_active())
+        monitor.set_incognito.assert_called_with(False)
+        self.assertIsNone(window._current_edge_banner)  # banner dismissed
+
     def test_preferences_window_constructs(self):
         from clipman.preferences import ClipmanPreferences
         from clipman.window import ClipmanWindow


### PR DESCRIPTION
Part of #132 (C4 + C5).

**C4 — `incognito_on_launch` never applied.** The setting was saved by preferences but `do_activate` never read it, so *start in incognito* silently did nothing and clipboard contents were recorded anyway. Now applied at launch via the window.

**C5 — incognito banner was dead code.** Toggling incognito flipped the monitor flag but never surfaced the `incognito-on` banner, so its "Resume recording" action was unreachable. The toggle now shows/dismisses the banner.

Adds `ClipmanWindow.set_incognito()` (shared entry point for launch + toggle) and `_dismiss_edge_banner(state_id)` (only clears the matching banner, so an unrelated one like `paused` survives).

Verified: new `test_incognito_toggle_syncs_monitor_and_banner` + full suite (298 passing).