### PR TITLE
perf(window): decode image thumbnails at scale (crisper + lighter)

### DIFF
--- a/clipman/window.py
+++ b/clipman/window.py
@@ -34,7 +34,7 @@ try:
     gi.require_version("Gtk", "4.0")
     gi.require_version("Adw", "1")
     gi.require_version("Gdk", "4.0")
-    from gi.repository import Adw, Gdk, GLib, Gtk
+    from gi.repository import Adw, Gdk, GdkPixbuf, GLib, Gtk
 except (AttributeError, ValueError, ImportError) as e:
     raise RuntimeError(
         "GTK 4 + libadwaita not available: %s" % e
@@ -719,6 +719,49 @@ class ClipmanWindow(Adw.ApplicationWindow):
         except OSError:
             logger.debug("xdg-open failed for %s", url, exc_info=True)
 
+    def _scaled_thumbnail(self, image_path, size=48):
+        """Build a small, HiDPI-crisp thumbnail for an image entry.
+
+        Decodes-and-scales the stored PNG at load time via
+        ``GdkPixbuf.new_from_file_at_scale`` instead of decoding the
+        full-resolution screenshot into a GPU texture and then shrinking
+        it. A history refresh re-runs this for every image row, so paying
+        the full-res decode cost per refresh was a major source of the
+        popup feeling heavy.
+
+        The decode target is oversized by the widget scale factor (for
+        HiDPI sharpness) and by 2x (COVER-crop headroom so a non-square
+        image still fills a crisp ``size``x``size`` slot). Returns a
+        configured ``Gtk.Picture`` or ``None`` when the path is unsafe,
+        missing, or undecodable.
+        """
+        from clipman.database import _safe_image_path
+
+        if not image_path or not _safe_image_path(image_path):
+            return None
+
+        # Oversample: logical px * device scale * COVER-crop headroom.
+        scale = max(1, self.get_scale_factor())
+        box = size * scale * 2
+        try:
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                image_path, box, box, True
+            )
+            texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+        except Exception:
+            # Corrupt file or unsupported format — fall back to the bare
+            # ``[Image]`` label rather than crashing.
+            logger.debug("thumbnail failed for %r", image_path, exc_info=True)
+            return None
+
+        thumb = Gtk.Picture.new_for_paintable(texture)
+        thumb.set_can_shrink(True)
+        thumb.set_content_fit(Gtk.ContentFit.COVER)
+        thumb.set_size_request(size, size)
+        thumb.set_valign(Gtk.Align.CENTER)
+        thumb.add_css_class("clip-thumb")
+        return thumb
+
     def _make_entry_row(self, entry):
         ctype = entry.get("content_type") or "text"
         text = entry.get("content_text") or ""
@@ -753,28 +796,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
         bar.set_valign(Gtk.Align.FILL)
         row.add_prefix(bar)
 
-        # Image entries get a 32x32 thumbnail so users can scan the list
+        # Image entries get a 48x48 thumbnail so users can scan the list
         # visually instead of relying on the literal ``[Image]`` title.
         if ctype == "image":
-            image_path = entry.get("image_path")
-            from clipman.database import _safe_image_path
-
-            if image_path and _safe_image_path(image_path):
-                try:
-                    texture = Gdk.Texture.new_from_filename(image_path)
-                    thumb = Gtk.Picture.new_for_paintable(texture)
-                    thumb.set_can_shrink(True)
-                    thumb.set_content_fit(Gtk.ContentFit.COVER)
-                    thumb.set_size_request(32, 32)
-                    thumb.set_valign(Gtk.Align.CENTER)
-                    thumb.add_css_class("clip-thumb")
-                    row.add_prefix(thumb)
-                except Exception:
-                    # Corrupt file or unsupported format — fall back to
-                    # the bare ``[Image]`` label rather than crashing.
-                    logger.debug(
-                        "thumbnail failed for %r", image_path, exc_info=True
-                    )
+            thumb = self._scaled_thumbnail(entry.get("image_path"))
+            if thumb is not None:
+                row.add_prefix(thumb)
 
         pin_btn = Gtk.Button.new_from_icon_name(
             "starred-symbolic" if entry["pinned"]

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -377,6 +377,56 @@ class TestWindowConstruction(unittest.TestCase):
             "definitely-not-an-action", warning_messages[0]
         )
 
+    def test_scaled_thumbnail_decodes_at_scale_not_full_res(self):
+        """A large stored image yields a bounded-size thumbnail texture.
+
+        Regression for the perf bug where the image-row thumbnail decoded
+        the FULL-resolution stored screenshot into a GPU texture on every
+        history refresh, then shrank it. The fix decodes-and-scales at
+        load, so the resulting texture must be far smaller than the
+        1600x1200 source — bounded by the requested oversampled box, not
+        the source dimensions.
+        """
+        from gi.repository import GdkPixbuf
+
+        from clipman.window import ClipmanWindow
+
+        # Build a real 1600x1200 PNG in memory (no alpha needed).
+        big = GdkPixbuf.Pixbuf.new(
+            GdkPixbuf.Colorspace.RGB, False, 8, 1600, 1200
+        )
+        big.fill(0x3366FFFF)  # solid blue; RGBA packed
+        ok, png_bytes = big.save_to_bufferv("png", [], [])
+        self.assertTrue(ok, "failed to encode source PNG")
+
+        db = self._make_db()
+        entry_id = db.add_entry("image", image_data=bytes(png_bytes))
+        self.assertIsNotNone(entry_id)
+
+        app = Adw.Application(application_id="com.clipman.TestThumb")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+
+        # Grab the stored path the same way _make_entry_row does.
+        entry = db.get_entries(limit=1)[0]
+        size = 48
+        thumb = window._scaled_thumbnail(entry["image_path"], size=size)
+        self.assertIsNotNone(thumb, "expected a Gtk.Picture thumbnail")
+
+        paintable = thumb.get_paintable()
+        self.assertIsNotNone(paintable)
+        iw = paintable.get_intrinsic_width()
+        ih = paintable.get_intrinsic_height()
+
+        # The oversampled decode box: size * scale_factor * 2 (COVER
+        # headroom). Even at a large HiDPI scale this stays well under
+        # the 1600x1200 source — proving we no longer decode full-res.
+        scale = max(1, window.get_scale_factor())
+        box = size * scale * 2
+        self.assertLessEqual(iw, box)
+        self.assertLessEqual(ih, box)
+        self.assertLess(iw, 1600)
+        self.assertLess(ih, 1200)
+
 
 class TestEdgeStateDeclaration(unittest.TestCase):
     """Module-level invariants of edge_states.py that don't need GTK.


### PR DESCRIPTION
Part of #132 (P1) — and addresses the maintainer's ask to *increase the app's resolution*.

**Problem:** the list decoded each stored image at **full resolution** (`Gdk.Texture.new_from_filename`) then shrank it to a 32×32 `Gtk.Picture` — re-run for every image on every refresh. A history with screenshots re-uploaded multi-megapixel textures to VRAM on the main thread each time the popup opened or the search changed. A top cause of the app feeling *very heavy*.

**Fix:** decode-and-scale at load via `GdkPixbuf.new_from_file_at_scale` → `Gdk.Texture.new_for_pixbuf` in a new testable `_scaled_thumbnail()` helper. Thumbnails also bumped **32 → 48 px, HiDPI-aware** (`× scale_factor`) so they're crisper/higher-res, not tiny. `_safe_image_path` check kept; corrupt-image fallback logs (no empty except).

`_copy_image_to_clipboard` is **unchanged** — the actual clipboard copy still uses the full-resolution image.

**Verified:** new `test_scaled_thumbnail_decodes_at_scale_not_full_res` (1600×1200 PNG → asserts decoded paintable ≤ box, ≪ full res); full suite 298 passing; ruff clean; headless screenshot confirms the thumbnail renders crisply.