### PR TITLE
fix(snippets): load new snippet into the editor form

### DIFF
--- a/clipman/snippets_dialog.py
+++ b/clipman/snippets_dialog.py
@@ -261,6 +261,17 @@ class SnippetsDialog(Adw.Dialog):
         row.snippet_id = snippet["id"]
         return row
 
+    def _find_row_by_id(self, snippet_id):
+        """Return the listbox row whose snippet id matches, or None."""
+        index = 0
+        while True:
+            row = self._listbox.get_row_at_index(index)
+            if row is None:
+                return None
+            if getattr(row, "snippet_id", None) == snippet_id:
+                return row
+            index += 1
+
     def _on_row_selected(self, _listbox, row):
         if row is None:
             self._load_into_form(None)
@@ -326,10 +337,22 @@ class SnippetsDialog(Adw.Dialog):
 
     def _on_new_clicked(self, _btn):
         sid = self.db.add_snippet(_("New snippet"), "")
-        self._selected_id = sid
+        # Do NOT pre-set self._selected_id here: _reload_list() would
+        # select the matching row, but _on_row_selected early-returns
+        # when snippet_id == self._selected_id, so _load_into_form would
+        # never run and the editor form would stay blank. Reload first
+        # (with _selected_id still pointing at the previous snippet, or
+        # None) so selecting the new row is a genuine change, then load
+        # the new snippet into the form explicitly.
         self._reload_list()
-        # The new snippet is loaded automatically by _reload_list's
-        # row_selected handler when the matching row reappears.
+        snippet = next(
+            (s for s in self._snippets if s["id"] == sid), None
+        )
+        if snippet is not None:
+            row = self._find_row_by_id(sid)
+            if row is not None:
+                self._listbox.select_row(row)
+            self._load_into_form(snippet)
 
     def _on_save_clicked(self, _btn):
         name = self._name_row.get_text().strip()

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -266,6 +266,52 @@ class TestWindowConstruction(unittest.TestCase):
         dialog = SnippetsDialog(db)
         self.assertIsNotNone(dialog)
 
+    def test_new_snippet_loads_into_editor_form(self):
+        """Creating a new snippet must populate the editor, not blank it.
+
+        Regression: _on_new_clicked used to set self._selected_id
+        BEFORE _reload_list(), so when the reload re-selected the row,
+        _on_row_selected early-returned (snippet_id == _selected_id) and
+        _load_into_form never ran — the form stayed blank. Assert the
+        selection AND the observable form state (name entry + content
+        buffer + title) reflect the freshly created snippet.
+        """
+        from clipman.snippets_dialog import SnippetsDialog
+
+        db = self._make_db()
+        dialog = SnippetsDialog(db)
+
+        # Sanity: nothing selected, form blank before the new action.
+        self.assertIsNone(dialog._selected_id)
+        self.assertEqual(dialog._name_row.get_text(), "")
+
+        dialog._on_new_clicked(None)
+
+        # The new row's id is now the selection target.
+        self.assertIsNotNone(dialog._selected_id)
+        new_id = dialog._selected_id
+
+        # The DB persisted exactly the snippet we expect.
+        snippet = next(
+            (s for s in db.get_snippets() if s["id"] == new_id), None
+        )
+        self.assertIsNotNone(snippet)
+
+        # Observable editor state must mirror the new snippet, not be blank.
+        self.assertEqual(dialog._name_row.get_text(), snippet["name"])
+        buf = dialog._textview.get_buffer()
+        buffer_text = buf.get_text(
+            buf.get_start_iter(), buf.get_end_iter(), True
+        )
+        self.assertEqual(buffer_text, snippet.get("content_text") or "")
+        self.assertEqual(dialog._title_label.get_text(), snippet["name"])
+        self.assertTrue(dialog._delete_btn.get_sensitive())
+
+        # And the sidebar row for the new snippet is the selected one.
+        selected = dialog._listbox.get_selected_row()
+        self.assertIsNotNone(selected)
+        self.assertEqual(getattr(selected, "snippet_id", None), new_id)
+
     def test_refresh_with_seeded_entries(self):
         """Three seeded entries -> three ActionRows with their titles."""
         from clipman.window import ClipmanWindow


### PR DESCRIPTION
Part of #132 (C6).

**Bug:** creating a new snippet auto-selected it but the editor stayed **blank**. `_on_new_clicked` set `self._selected_id = sid` *before* `_reload_list()`; when the reload re-selected the row, `_on_row_selected`'s guard (`snippet_id == self._selected_id → return`) early-returned, so `_load_into_form` never ran.

**Fix:** reload first, then explicitly select the row and load the form (new `_find_row_by_id` helper). The redundant-reload guard is untouched for the normal path.

**Test:** `test_new_snippet_loads_into_editor_form` drives `_on_new_clicked` and asserts the name/content/title/delete-sensitivity/selection all reflect the new snippet. Verified it fails on the old code and passes on the fix. Full suite green; ruff clean.