### PR TITLE
fix(window): wire Enter/Delete/P keyboard shortcuts

### DIFF
--- a/clipman/window.py
+++ b/clipman/window.py
@@ -1178,10 +1178,114 @@ class ClipmanWindow(Adw.ApplicationWindow):
             self._show_edge_state("restore-failed")
 
     def _on_key_pressed(self, _controller, keyval, _keycode, _state):
+        """Wire the shortcuts advertised in the footer hints.
+
+        The footer promises ``↵ Paste · ⌫ Delete · P Pin · Esc Close``.
+        Escape/Enter work regardless of focus; Delete and P are gated on
+        the search entry NOT having focus so they stay usable as literal
+        text editing while the user is typing a query.
+
+        Returns ``True`` when the key was handled (stops propagation),
+        ``False`` otherwise so gated/unhandled keys still reach the
+        search entry.
+        """
         if keyval == Gdk.KEY_Escape:
             self.set_visible(False)
             return True
+
+        if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter, Gdk.KEY_ISO_Enter):
+            self._activate_selected()
+            return True
+
+        search_focused = self.search_entry.has_focus()
+
+        # Down arrow from the search entry drops focus into the list so
+        # the user can start arrow-navigating rows. Up/Down within the
+        # list itself is native to Gtk.ListBox BROWSE mode.
+        if keyval == Gdk.KEY_Down and search_focused:
+            row = self._selected_or_first_row()
+            if row is not None:
+                self.listbox.select_row(row)
+                row.grab_focus()
+                return True
+            return False
+
+        # Delete and P are literal text editing while typing a query —
+        # only treat them as shortcuts when the search entry is unfocused.
+        if search_focused:
+            return False
+
+        if keyval == Gdk.KEY_Delete:
+            return self._delete_selected()
+
+        if keyval in (Gdk.KEY_p, Gdk.KEY_P):
+            return self._pin_selected()
+
         return False
+
+    # ------------------------------------------------------------------
+    # Keyboard / click shared action helpers
+    # ------------------------------------------------------------------
+
+    def _selected_or_first_row(self):
+        """Return the selected row, or the first row if none is selected.
+
+        Returns ``None`` when the list is empty.
+        """
+        row = self.listbox.get_selected_row()
+        if row is None:
+            row = self.listbox.get_row_at_index(0)
+        return row
+
+    def _activate_selected(self):
+        """Paste the selected row (or the first row if none selected).
+
+        Shared by the Enter shortcut. Returns ``True`` when a row was
+        acted on, ``False`` when the list is empty.
+        """
+        row = self._selected_or_first_row()
+        if row is None:
+            return False
+        kind = getattr(row, "row_kind", None)
+        if kind == "snippet":
+            self._paste_snippet(row.snippet_data)
+        elif kind == "entry":
+            self._paste_entry(row.entry_data)
+        else:
+            return False
+        return True
+
+    def _delete_selected(self):
+        """Delete the selected entry (mirrors its trash button).
+
+        Snippets have no inline delete here, so non-entry rows are
+        ignored. Returns ``True`` when an entry was deleted.
+        """
+        row = self._selected_or_first_row()
+        if row is None or getattr(row, "row_kind", None) != "entry":
+            return False
+        entry_id = row.entry_data.get("id")
+        if not entry_id:
+            return False
+        self.db.delete_entry(entry_id)
+        self.refresh()
+        return True
+
+    def _pin_selected(self):
+        """Toggle pin on the selected entry (mirrors its star button).
+
+        Snippets have no pin, so non-entry rows are ignored. Returns
+        ``True`` when an entry's pin state was toggled.
+        """
+        row = self._selected_or_first_row()
+        if row is None or getattr(row, "row_kind", None) != "entry":
+            return False
+        entry_id = row.entry_data.get("id")
+        if not entry_id:
+            return False
+        self.db.toggle_pin(entry_id)
+        self.refresh()
+        return True
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -501,6 +501,166 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertLess(ih, 1200)
 
 
+@unittest.skipUnless(_HAS_GTK and _ADW_INIT_OK,
+                     "GTK 4 + libadwaita not available")
+class TestKeyboardShortcuts(unittest.TestCase):
+    """The footer advertises ↵ Paste · ⌫ Delete · P Pin · Esc Close.
+
+    Exercises the action helpers directly (far more robust headless than
+    synthesizing real key events): select a row, call the helper, assert
+    the DB / selection state changed.
+    """
+
+    def _make_db(self):
+        from clipman import database
+
+        tmp = tempfile.mkdtemp(prefix="clipman-test-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        data_dir = Path(tmp) / "clipman"
+        images_dir = data_dir / "images"
+        db_path = data_dir / "clipman.db"
+        for target, value in (
+            ("clipman.database.DATA_DIR", data_dir),
+            ("clipman.database.IMAGES_DIR", images_dir),
+            ("clipman.database.DB_PATH", db_path),
+        ):
+            p = patch(target, value)
+            p.start()
+            self.addCleanup(p.stop)
+        db = database.ClipboardDB()
+        self.addCleanup(db.close)
+        return db
+
+    def _seeded_window(self, texts=("old", "mid", "new")):
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        for text in texts:
+            db.add_entry("text", content_text=text)
+        app = Adw.Application(application_id="com.clipman.TestKeys")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window.refresh()
+        return db, window
+
+    def test_selected_or_first_row_falls_back_to_first(self):
+        _db, window = self._seeded_window()
+        window.listbox.unselect_all()
+        self.assertIsNone(window.listbox.get_selected_row())
+        row = window._selected_or_first_row()
+        self.assertIsNotNone(row)
+        # Falls back to index 0 (most-recent entry) when nothing selected.
+        self.assertIs(row, window.listbox.get_row_at_index(0))
+
+    def test_selected_or_first_row_prefers_selection(self):
+        _db, window = self._seeded_window()
+        target = window.listbox.get_row_at_index(1)
+        window.listbox.select_row(target)
+        self.assertIs(window._selected_or_first_row(), target)
+
+    def test_delete_selected_removes_entry(self):
+        db, window = self._seeded_window()
+        target = window.listbox.get_row_at_index(0)
+        window.listbox.select_row(target)
+        target_id = target.entry_data["id"]
+
+        self.assertTrue(window._delete_selected())
+
+        remaining = {e["id"] for e in db.get_entries(limit=200)}
+        self.assertNotIn(target_id, remaining)
+        self.assertEqual(len(remaining), 2)
+
+    def test_delete_selected_empty_list_is_noop(self):
+        db, window = self._seeded_window(texts=())
+        # Nothing to delete -> returns False, doesn't raise.
+        self.assertFalse(window._delete_selected())
+        self.assertEqual(len(db.get_entries(limit=200)), 0)
+
+    def test_pin_selected_toggles_pin(self):
+        db, window = self._seeded_window()
+        target = window.listbox.get_row_at_index(0)
+        window.listbox.select_row(target)
+        target_id = target.entry_data["id"]
+        self.assertFalse(target.entry_data["pinned"])
+
+        self.assertTrue(window._pin_selected())
+
+        pinned = {e["id"] for e in db.get_entries(limit=200) if e["pinned"]}
+        self.assertIn(target_id, pinned)
+
+        # Toggling again unpins. After refresh the row objects are rebuilt,
+        # and pinned entries sort first, so re-select index 0.
+        again = window.listbox.get_row_at_index(0)
+        window.listbox.select_row(again)
+        self.assertTrue(window._pin_selected())
+        still_pinned = {
+            e["id"] for e in db.get_entries(limit=200) if e["pinned"]
+        }
+        self.assertNotIn(target_id, still_pinned)
+
+    def test_pin_selected_ignores_snippet_rows(self):
+        db, window = self._seeded_window(texts=())
+        db.add_snippet("greeting", "hello ${date}")
+        window._active_filter = "snippets"
+        window.refresh()
+
+        row = window.listbox.get_row_at_index(0)
+        self.assertEqual(row.row_kind, "snippet")
+        window.listbox.select_row(row)
+        # Snippets have no pin — helper must decline, not crash.
+        self.assertFalse(window._pin_selected())
+
+    def test_delete_selected_ignores_snippet_rows(self):
+        db, window = self._seeded_window(texts=())
+        db.add_snippet("greeting", "hello")
+        window._active_filter = "snippets"
+        window.refresh()
+
+        row = window.listbox.get_row_at_index(0)
+        self.assertEqual(row.row_kind, "snippet")
+        window.listbox.select_row(row)
+        self.assertFalse(window._delete_selected())
+        self.assertEqual(len(db.get_snippets()), 1)
+
+    def test_activate_selected_pastes_entry(self):
+        _db, window = self._seeded_window()
+        target = window.listbox.get_row_at_index(1)
+        window.listbox.select_row(target)
+
+        pasted = []
+        window._paste_entry = lambda entry: pasted.append(entry)
+        self.assertTrue(window._activate_selected())
+        self.assertEqual(len(pasted), 1)
+        self.assertEqual(pasted[0]["content_text"], "mid")
+
+    def test_activate_selected_falls_back_to_first_when_none_selected(self):
+        _db, window = self._seeded_window()
+        window.listbox.unselect_all()
+
+        pasted = []
+        window._paste_entry = lambda entry: pasted.append(entry)
+        self.assertTrue(window._activate_selected())
+        # Index 0 is the most-recent entry ("new").
+        self.assertEqual(pasted[0]["content_text"], "new")
+
+    def test_activate_selected_pastes_snippet(self):
+        db, window = self._seeded_window(texts=())
+        db.add_snippet("sig", "regards")
+        window._active_filter = "snippets"
+        window.refresh()
+        row = window.listbox.get_row_at_index(0)
+        window.listbox.select_row(row)
+
+        pasted = []
+        window._paste_snippet = lambda snip: pasted.append(snip)
+        self.assertTrue(window._activate_selected())
+        self.assertEqual(pasted[0]["name"], "sig")
+
+    def test_activate_selected_empty_list_is_noop(self):
+        _db, window = self._seeded_window(texts=())
+        window._paste_entry = lambda entry: self.fail("should not paste")
+        self.assertFalse(window._activate_selected())
+
+
 class TestEdgeStateDeclaration(unittest.TestCase):
     """Module-level invariants of edge_states.py that don't need GTK.
 


### PR DESCRIPTION
Part of #132 (C3).

The popup footer advertises `↵ Paste · ⌫ Delete · P Pin · Esc Close`, but `_on_key_pressed` only handled Escape — Enter/Delete/P did nothing.

**Now wired** (with focus-gating):
- **Enter/KP_Enter** → paste the selected row (or first if none). Works from search or list.
- **Delete** → delete selected entry — only when the search entry is **not** focused (else it's normal text editing).
- **p/P** → toggle pin on selected entry — only when search is not focused.
- **Down** from search → move focus into the list to start arrow-navigating.
- **Escape** → unchanged.

Shared helpers `_selected_or_first_row` / `_activate_selected` / `_delete_selected` / `_pin_selected` back both keys and buttons. 11 new tests drive the helpers + DB/selection state. Suite green (310); ruff clean.