### PR TITLE
perf(window): debounce search to coalesce list rebuilds

### DIFF
--- a/clipman/window.py
+++ b/clipman/window.py
@@ -136,6 +136,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self.db = db
         self.monitor = monitor
         self._search_query = ""
+        self._search_debounce_id = 0
         self._active_filter = "all"
         self._css_provider = None
         self._current_edge_banner = None
@@ -189,10 +190,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # gesture. We want the popup to hide rather than destroy so the
         # daemon can re-show it on the next D-Bus Toggle without
         # reconstructing the entire widget tree.
-        self.connect(
-            "close-request",
-            lambda _w: (self.set_visible(False), True)[1],
-        )
+        self.connect("close-request", self._on_close_request)
 
         # Sensitive-entry purge loop — kept identical to the GTK 3 version.
         GLib.timeout_add_seconds(10, self._cleanup_sensitive)
@@ -1075,8 +1073,37 @@ class ClipmanWindow(Adw.ApplicationWindow):
     # ------------------------------------------------------------------
 
     def _on_search_changed(self, entry):
+        # Update the query synchronously so the newest keystroke wins, but
+        # coalesce the (expensive) refresh: every character otherwise runs a
+        # ``LIKE '%q%'`` scan and rebuilds up to ~200 ListBox rows, which is a
+        # real source of input lag while typing. Debounce so only the last
+        # keystroke in a burst actually rebuilds the list.
         self._search_query = entry.get_text().strip()
+        self._cancel_search_debounce()
+        self._search_debounce_id = GLib.timeout_add(
+            150, self._run_search_refresh
+        )
+
+    def _run_search_refresh(self):
+        # One-shot debounce callback: clear the id first (the source has
+        # fired, so it must not be removed again) then rebuild the list.
+        self._search_debounce_id = 0
         self.refresh()
+        return False
+
+    def _cancel_search_debounce(self):
+        # Remove a still-pending debounce source. Guard against a zero/None id
+        # (nothing scheduled, or the source already fired and cleared itself).
+        if self._search_debounce_id:
+            GLib.source_remove(self._search_debounce_id)
+            self._search_debounce_id = 0
+
+    def _on_close_request(self, _window):
+        # Hide (rather than destroy) so the daemon can re-show the popup on the
+        # next D-Bus Toggle. Drop any in-flight search debounce on the way out.
+        self._cancel_search_debounce()
+        self.set_visible(False)
+        return True
 
     def _on_filter_toggled(self, button, filter_id):
         if not button.get_active():
@@ -1205,6 +1232,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         search entry.
         """
         if keyval == Gdk.KEY_Escape:
+            self._cancel_search_debounce()
             self.set_visible(False)
             return True
 

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -500,6 +500,57 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertLess(iw, 1600)
         self.assertLess(ih, 1200)
 
+    def test_search_changed_debounces_refresh(self):
+        """Typing must NOT rebuild the list synchronously per keystroke.
+
+        Regression for the input-lag bug where every ``search-changed``
+        ran a ``LIKE '%q%'`` scan and rebuilt up to ~200 rows. The handler
+        now updates ``_search_query`` immediately but coalesces the refresh
+        behind a one-shot GLib timeout, so a burst of keystrokes schedules
+        a single pending source instead of N synchronous rebuilds.
+
+        Driven without real timing: assert the query updates and a debounce
+        id is armed but ``refresh`` is untouched, then fire the debounce
+        callback directly and assert exactly one refresh + a cleared id.
+        """
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestDebounce")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+
+        # Count refresh() calls without actually rebuilding the list.
+        refresh_calls = []
+        window.refresh = lambda: refresh_calls.append(True)
+
+        class _FakeEntry:
+            def __init__(self, text):
+                self._text = text
+
+            def get_text(self):
+                return self._text
+
+        # Two quick keystrokes: query tracks the latest, refresh stays
+        # untouched, and only ONE debounce source is left armed (the first
+        # is cancelled by the second).
+        window._on_search_changed(_FakeEntry("fo"))
+        first_id = window._search_debounce_id
+        self.assertNotEqual(first_id, 0)
+        window._on_search_changed(_FakeEntry("foo"))
+        self.assertEqual(window._search_query, "foo")
+        self.assertNotEqual(window._search_debounce_id, 0)
+        self.assertNotEqual(window._search_debounce_id, first_id)
+        self.assertEqual(refresh_calls, [])  # NOT called synchronously
+
+        # Remove the still-armed real GLib source so it can't fire into a
+        # later test's main loop, then simulate what the timeout would run.
+        from gi.repository import GLib
+        GLib.source_remove(window._search_debounce_id)
+        result = window._run_search_refresh()
+        self.assertFalse(result)  # one-shot: returns False
+        self.assertEqual(len(refresh_calls), 1)  # coalesced to a single refresh
+        self.assertEqual(window._search_debounce_id, 0)  # id cleared
+
 
 @unittest.skipUnless(_HAS_GTK and _ADW_INIT_OK,
                      "GTK 4 + libadwaita not available")


### PR DESCRIPTION
Part of #132 (P5).

Typing in the search box called `refresh()` on **every keystroke** — a `LIKE '%q%'` scan plus a rebuild of up to ~200 `Gtk.ListBox` rows per character, a real source of input lag.

Now the query updates synchronously but the refresh is coalesced behind a 150 ms debounce (`_on_search_changed` → `_run_search_refresh`), with a `_cancel_search_debounce` guard wired into Escape and close-request so no GLib source leaks. `refresh()` and filtering are unchanged; all other callers (new clip, filter change, pin/delete) stay immediate — only typing is debounced.

Verified: new `test_search_changed_debounces_refresh`, full suite 312 green, ruff clean, screenshot renders.