### PR TITLE
fix(wayland): Win+V parity — focus, dismiss, no-taskbar, fixed panel, Preferences

### DIFF
--- a/clipman/dbus_service.py
+++ b/clipman/dbus_service.py
@@ -25,9 +25,10 @@ class ClipmanDBusService(dbus.service.Object):
         # visible by default, so ``set_visible(True/False)`` is the
         # canonical API.
         self.window.refresh()
-        self.window.set_visible(True)
-        self.window.search_entry.grab_focus()
-        self.window.present()
+        # Shared show path: present + idle grab_focus + extension activate
+        # (matches ClipmanWindow.toggle()), so Show() also gets real input
+        # focus on GNOME Wayland instead of a visible-but-dead popup.
+        self.window._present_focused()
 
     @dbus.service.method(IFACE, in_signature="", out_signature="")
     def Hide(self):

--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -114,8 +114,14 @@ EVENT_KEYS = frozenset({
 })
 
 
-class ClipmanPreferences(Adw.PreferencesWindow):
-    """Six-pane preferences window.
+class ClipmanPreferences(Adw.PreferencesDialog):
+    """Six-pane preferences dialog.
+
+    An ``Adw.PreferencesDialog`` (not a separate top-level window) so it
+    presents in-surface, anchored to the popup via ``present(parent)``.
+    A top-level ``Adw.PreferencesWindow`` opened *behind* the popup on
+    Wayland and looked unresponsive. ``parent`` is accepted for call-site
+    compatibility; anchoring happens in the caller's ``present(parent)``.
 
     ``on_setting_changed`` is a callable that the parent window passes
     in; it's invoked with ``(key, value)`` whenever any persisted
@@ -123,16 +129,19 @@ class ClipmanPreferences(Adw.PreferencesWindow):
     without a restart.
     """
 
-    def __init__(self, db, parent, on_setting_changed=None):
+    def __init__(self, db, parent=None, on_setting_changed=None):
         super().__init__()
         self.db = db
         self._on_setting_changed = on_setting_changed or (lambda k, v: None)
         self._kbd_dialog = None  # held so the GC doesn't collect mid-capture
+        # As an Adw.Dialog this is NOT a Gtk.Window, so it can't be the
+        # parent of a Gtk.FileChooserNative. Keep the real toplevel (the
+        # ClipmanWindow passed in) for the backup/restore choosers.
+        self._parent_window = parent
 
-        self.set_modal(True)
-        self.set_transient_for(parent)
+        # Adw.Dialog manages its own sizing/stacking — no set_modal /
+        # set_transient_for / set_default_size (those are Window APIs).
         self.set_search_enabled(True)
-        self.set_default_size(820, 600)
 
         self.add(self._build_appearance_page())
         self.add(self._build_privacy_page())
@@ -586,7 +595,7 @@ class ClipmanPreferences(Adw.PreferencesWindow):
     def _on_backup_clicked(self, _btn):
         chooser = Gtk.FileChooserNative.new(
             _("Export backup"),
-            self,
+            self._parent_window,
             Gtk.FileChooserAction.SAVE,
             _("Save"),
             _("Cancel"),
@@ -611,7 +620,7 @@ class ClipmanPreferences(Adw.PreferencesWindow):
     def _on_restore_clicked(self, _btn):
         chooser = Gtk.FileChooserNative.new(
             _("Restore from backup"),
-            self,
+            self._parent_window,
             Gtk.FileChooserAction.OPEN,
             _("Open"),
             _("Cancel"),

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -140,9 +140,19 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._active_filter = "all"
         self._css_provider = None
         self._current_edge_banner = None
+        # Reference to the currently-open in-app dialog (preferences /
+        # snippets / edge alert). dismiss-on-focus-loss checks whether it
+        # is still mapped rather than a boolean latch, because hiding the
+        # popup does NOT emit a dialog's "closed" signal.
+        self._child_dialog = None
+        # Pending _move_to_cursor timeout id, so a show->hide within 50ms
+        # can cancel it (a stale timer would re-activate a closed popup).
+        self._cursor_move_id = 0
 
         self.set_title("Clipman")
         self.set_default_size(380, self._clamped_default_height())
+        # Win+V is a fixed overlay panel, not a resizable app window.
+        self.set_resizable(False)
         self.add_css_class("clipman-window")
 
         # Load persisted settings (only the subset Phase 1 actually uses;
@@ -190,6 +200,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         key_ctrl = Gtk.EventControllerKey()
         key_ctrl.connect("key-pressed", self._on_key_pressed)
         self.add_controller(key_ctrl)
+
+        # Win+V parity: dismiss when the popup loses focus (user clicks
+        # another window / elsewhere). GTK 3 had a focus-out->hide handler
+        # that was dropped in the GTK 4 port; restore it via is-active.
+        self.connect("notify::is-active", self._on_active_changed)
 
         # On Wayland the compositor delivers ``close-request`` when the
         # user clicks outside the popup or hits the compositor close
@@ -530,8 +545,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         spec = getattr(widget, "state_spec", None)
         kind = spec.kind if spec is not None else "statuspage"
 
-        # AlertDialog presents itself modally; nothing to mount.
+        # AlertDialog presents itself modally; nothing to mount. Track it
+        # as a child so a focus-losing action (e.g. its button opening a
+        # browser) doesn't trip dismiss-on-focus-loss and hide both.
         if kind == "alertdialog":
+            self._register_child(widget)
             widget.present(self)
             self._list_stack.set_visible_child_name("list")
             return
@@ -907,29 +925,47 @@ class ClipmanWindow(Adw.ApplicationWindow):
     # Paste path — GTK 4 clipboard API with wl-copy + wtype/ydotool fallback
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _is_wayland():
+        return bool(os.environ.get("WAYLAND_DISPLAY"))
+
+    def _wl_copy(self, data, mime=None):
+        """Set the clipboard via wl-copy and return True on success.
+
+        wl-copy owns the selection from a temporary surface it focuses
+        itself, so it works from a background process — unlike GTK's
+        Gdk.Clipboard, whose core wl_data_device.set_selection needs a
+        serial from input focus the daemon doesn't have. It forks a helper
+        that keeps serving the selection until it's replaced.
+        """
+        cmd = ["wl-copy"]
+        if mime:
+            cmd += ["--type", mime]
+        try:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stderr=subprocess.DEVNULL
+            )
+            proc.communicate(input=data)
+            return proc.returncode == 0
+        except OSError:
+            logger.debug("wl-copy unavailable", exc_info=True)
+            return False
+
     def _copy_to_clipboard(self, text):
         if self.monitor:
             self.monitor.set_self_copy(True)
+        # On Wayland the daemon is a background process, so Gdk.Clipboard.set()
+        # silently fails to claim the selection (no input-focus serial). Prefer
+        # wl-copy, which is built to set the clipboard from the background; fall
+        # back to GTK on X11 (no focus requirement) or if wl-copy is missing.
+        if self._is_wayland() and self._wl_copy(text.encode("utf-8")):
+            return
         try:
             clipboard = Gdk.Display.get_default().get_clipboard()
             clipboard.set(text)
         except Exception:
-            # GTK clipboard API can fail under Xwayland or before the
-            # display is ready; fall through to the wl-copy CLI which
-            # is more reliable on Wayland sessions.
             logger.debug("GTK clipboard.set failed", exc_info=True)
-            try:
-                proc = subprocess.Popen(
-                    ["wl-copy"],
-                    stdin=subprocess.PIPE,
-                    stderr=subprocess.DEVNULL,
-                )
-                proc.communicate(input=text.encode("utf-8"))
-            except OSError:
-                # wl-copy isn't installed either — the user will have
-                # to copy manually. Log so we can diagnose support
-                # requests but don't surface a popup error.
-                logger.debug("wl-copy fallback failed", exc_info=True)
+            self._wl_copy(text.encode("utf-8"))
 
     def _copy_image_to_clipboard(self, image_path):
         """Push an image file at ``image_path`` onto the system clipboard.
@@ -947,27 +983,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
             return False
         if self.monitor:
             self.monitor.set_self_copy(True)
+        # Wayland: prefer wl-copy (works from the background daemon); GTK's
+        # set_texture() has the same input-focus limitation as text.
+        if self._is_wayland():
+            try:
+                with open(image_path, "rb") as fh:
+                    if self._wl_copy(fh.read(), mime="image/png"):
+                        return True
+            except OSError:
+                logger.debug("reading image for wl-copy failed", exc_info=True)
         try:
             texture = Gdk.Texture.new_from_filename(image_path)
             clipboard = Gdk.Display.get_default().get_clipboard()
             clipboard.set_texture(texture)
             return True
         except Exception:
-            logger.debug(
-                "Gdk.Texture clipboard set failed; trying wl-copy fallback",
-                exc_info=True,
-            )
-        try:
-            with open(image_path, "rb") as fh:
-                proc = subprocess.Popen(
-                    ["wl-copy", "--type", "image/png"],
-                    stdin=fh,
-                    stderr=subprocess.DEVNULL,
-                )
-                proc.communicate()
-            return proc.returncode == 0
-        except OSError:
-            logger.debug("wl-copy image fallback failed", exc_info=True)
+            logger.debug("Gdk.Texture clipboard set failed", exc_info=True)
             return False
 
     # Per-mode command tables. ``wtype`` and ``ydotool`` use different
@@ -1025,9 +1056,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 continue
         if not any_binary_available:
             # Neither wtype nor ydotool is installed. Show the popup
-            # again with the dedicated edge state so the user has a
-            # clear next step.
-            self.set_visible(True)
+            # again (focused) with the dedicated edge state so the user
+            # has a clear next step.
+            self._present_focused()
             self._show_edge_state("paste-target-missing")
         return False
 
@@ -1047,7 +1078,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         if entry.get("id"):
             self.db.update_accessed(entry["id"])
         self.set_visible(False)
-        GLib.timeout_add(80, self._simulate_paste)
+        self._dispatch_paste()
 
     def _paste_snippet(self, snippet):
         text = snippet.get("content_text") or ""
@@ -1056,7 +1087,74 @@ class ClipmanWindow(Adw.ApplicationWindow):
         text = self._expand_snippet_tokens(text)
         self._copy_to_clipboard(text)
         self.set_visible(False)
+        self._dispatch_paste()
+
+    def _dispatch_paste(self):
+        """Restore focus to the user's window, then synthesise the paste.
+
+        On GNOME Wayland a naive paste fails twice over: the popup stole
+        input focus (the Shell activated it so its buttons/keys work), and
+        wtype can't inject at all — Mutter exposes no virtual-keyboard
+        protocol, so ``wtype`` exits with "compositor does not support the
+        virtual keyboard protocol". We therefore drive both steps through the
+        Shell extension: ``RestorePreviousFocus`` hands focus back to the
+        window the user came from, then ``SimulatePaste`` synthesises the
+        keystroke with a Clutter virtual device (which runs inside the
+        compositor and does work). Fall back to wtype/ydotool only when the
+        extension is absent — other compositors, where wtype works and the
+        popup never stole focus.
+        """
+        mode = self.db.get_setting("paste_mode", "auto") or "auto"
+        if self._paste_via_shell(mode):
+            return
         GLib.timeout_add(80, self._simulate_paste)
+
+    def _paste_via_shell(self, mode):
+        """Best-effort paste via the GNOME Shell extension: restore focus,
+        then inject the keystroke through Clutter. Returns True once the
+        requests are dispatched, False if the extension isn't reachable (so
+        the caller can fall back to wtype/ydotool)."""
+        iface = self._shell_extension_iface()
+        if iface is None:
+            return False
+        try:
+            iface.RestorePreviousFocus()
+        except Exception as exc:
+            logger.debug("Shell focus-restore failed: %s", exc, exc_info=True)
+            return False
+
+        # Give the compositor a frame to move focus onto the restored window
+        # before the keys land, then inject via the Shell (not wtype).
+        def _fire_keystroke():
+            try:
+                iface.SimulatePaste(mode)
+            except Exception as exc:
+                logger.debug(
+                    "Shell SimulatePaste failed: %s", exc, exc_info=True
+                )
+            return False
+
+        # ~120ms: comfortably longer than a compositor focus cycle so the
+        # keys land on the restored window, still imperceptible to the user.
+        GLib.timeout_add(120, _fire_keystroke)
+        return True
+
+    def _shell_extension_iface(self):
+        """Return the GNOME Shell extension's D-Bus interface, or None if it
+        isn't available (non-GNOME session, extension disabled, no bus)."""
+        try:
+            import dbus
+            bus = dbus.SessionBus()
+            proxy = bus.get_object(
+                "org.gnome.Shell.Extensions.clipman",
+                "/org/gnome/Shell/Extensions/clipman",
+            )
+            return dbus.Interface(
+                proxy, "org.gnome.Shell.Extensions.clipman"
+            )
+        except Exception as exc:
+            logger.debug("Shell extension unavailable: %s", exc, exc_info=True)
+            return None
 
     def _expand_snippet_tokens(self, text):
         """Substitute ``${date}``, ``${time}``, ``${clipboard}`` tokens.
@@ -1110,10 +1208,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
             self._search_debounce_id = 0
 
     def _on_close_request(self, _window):
-        # Hide (rather than destroy) so the daemon can re-show the popup on the
-        # next D-Bus Toggle. Drop any in-flight search debounce on the way out.
-        self._cancel_search_debounce()
-        self.set_visible(False)
+        # Hide (rather than destroy) so the daemon can re-show the popup on
+        # the next D-Bus Toggle. _hide() tears down transient state.
+        self._hide()
         return True
 
     def _on_filter_toggled(self, button, filter_id):
@@ -1133,7 +1230,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         from clipman.snippets_dialog import SnippetsDialog
 
         dialog = SnippetsDialog(self.db)
-        dialog.connect("closed", lambda _d: self.refresh())
+        self._register_child(dialog, on_closed=lambda _d: self.refresh())
         dialog.present(self)
 
     def _on_row_activated(self, _listbox, row):
@@ -1184,7 +1281,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
         prefs = ClipmanPreferences(
             self.db, self, on_setting_changed=self._on_setting_changed
         )
-        prefs.present()
+        # In-surface dialog anchored to the popup so it can't open behind
+        # it on Wayland; tracked so dismiss-on-focus-loss is guarded.
+        self._register_child(prefs)
+        prefs.present(self)
 
     def _on_setting_changed(self, key, value):
         """Hot-reload settings the popup cares about.
@@ -1247,8 +1347,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         search entry.
         """
         if keyval == Gdk.KEY_Escape:
-            self._cancel_search_debounce()
-            self.set_visible(False)
+            self._hide()
             return True
 
         if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter, Gdk.KEY_ISO_Enter):
@@ -1399,6 +1498,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         Best-effort — if the extension isn't installed the window stays
         wherever the compositor placed it, which is acceptable for Phase 1.
         """
+        self._cursor_move_id = 0
+        # A stale timer must never re-position/re-activate a hidden popup
+        # (the extension now also focuses the window on move).
+        if not self.get_visible():
+            return False
         try:
             import dbus
             bus = dbus.SessionBus()
@@ -1427,12 +1531,71 @@ class ClipmanWindow(Adw.ApplicationWindow):
     # Toggle (public — dbus_service.Toggle() routes here)
     # ------------------------------------------------------------------
 
-    def toggle(self):
-        if self.get_visible():
-            self.set_visible(False)
-            return
-        self.refresh()
+    def _child_is_open(self):
+        d = self._child_dialog
+        return d is not None and d.get_mapped()
+
+    def _register_child(self, dialog, on_closed=None):
+        """Track an in-app dialog so dismiss-on-focus-loss doesn't hide the
+        popup from under it, and so hiding the popup can force-close it."""
+        self._child_dialog = dialog
+
+        def _closed(d):
+            if self._child_dialog is d:
+                self._child_dialog = None
+            if on_closed is not None:
+                on_closed(d)
+            # A focus-loss suppressed while the dialog was up is now
+            # actionable — re-evaluate so the popup can dismiss.
+            self._on_active_changed()
+
+        dialog.connect("closed", _closed)
+
+    def _present_focused(self):
+        """Show + focus the popup and (re)arm cursor positioning.
+
+        Centralises the Wayland show path so toggle(), dbus Show() and the
+        paste-target re-show all grab focus the same way.
+        """
         self.set_visible(True)
         self.present()
-        self.search_entry.grab_focus()
-        GLib.timeout_add(50, self._move_to_cursor)
+        # grab_focus no-ops on a not-yet-focused Wayland toplevel; defer.
+        GLib.idle_add(self.search_entry.grab_focus)
+        if self._cursor_move_id:
+            GLib.source_remove(self._cursor_move_id)
+        self._cursor_move_id = GLib.timeout_add(50, self._move_to_cursor)
+
+    def _hide(self):
+        """Hide the popup and tear down transient state (cursor timer, search
+        debounce, any open child dialog) so nothing resurfaces or latches."""
+        if self._cursor_move_id:
+            GLib.source_remove(self._cursor_move_id)
+            self._cursor_move_id = 0
+        self._cancel_search_debounce()
+        if self._child_dialog is not None:
+            try:
+                self._child_dialog.force_close()
+            except Exception:
+                logger.debug("force_close child dialog failed", exc_info=True)
+            self._child_dialog = None
+        self.set_visible(False)
+
+    def _on_active_changed(self, *_args):
+        """Hide the popup when it loses focus (Win+V click-outside dismiss).
+
+        Skipped while an in-app dialog is still mapped so opening
+        preferences / snippets doesn't hide the popup from under them.
+        """
+        if (
+            not self.get_property("is-active")
+            and self.get_visible()
+            and not self._child_is_open()
+        ):
+            self._hide()
+
+    def toggle(self):
+        if self.get_visible():
+            self._hide()
+            return
+        self.refresh()
+        self._present_focused()

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -3,7 +3,19 @@ import Meta from 'gi://Meta';
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
+import Shell from 'gi://Shell';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// The popup's Wayland app_id / wm_class (clipman/app.py application_id).
+// Used to keep our ephemeral popup out of alt-tab and the dash, like Win+V.
+const CLIPMAN_WM_CLASS = 'com.clipman.Clipman';
+
+function _isClipmanWindow(win) {
+    if (!win)
+        return false;
+    const cls = win.get_wm_class ? win.get_wm_class() : win.wm_class;
+    return cls === CLIPMAN_WM_CLASS;
+}
 
 const PASTE_DBUS_IFACE = `
 <node>
@@ -14,6 +26,7 @@ const PASTE_DBUS_IFACE = `
     <method name="MoveWindowToCursor">
       <arg type="s" direction="in" name="title"/>
     </method>
+    <method name="RestorePreviousFocus"/>
   </interface>
 </node>`;
 
@@ -63,9 +76,61 @@ export default class ClipmanExtension extends Extension {
             PASTE_DBUS_IFACE, this
         );
         this._dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell/Extensions/clipman');
+
+        // Win+V parity: keep the ephemeral popup out of alt-tab and the
+        // dash. There is no writable skip-taskbar API before GNOME 49, so
+        // we monkey-patch the two JS entry points that build those lists
+        // and filter our window out. On 49+ the daemon-side move loop uses
+        // the real Meta.Window.hide_from_window_list() instead (see below).
+        this._origGetTabList = global.display.get_tab_list;
+        const origGetTabList = this._origGetTabList;
+        global.display.get_tab_list = function (type, workspace) {
+            return origGetTabList.call(this, type, workspace)
+                .filter(w => !_isClipmanWindow(w));
+        };
+
+        this._origAppGetWindows = Shell.App.prototype.get_windows;
+        const origAppGetWindows = this._origAppGetWindows;
+        Shell.App.prototype.get_windows = function () {
+            return origAppGetWindows.call(this)
+                .filter(w => !_isClipmanWindow(w));
+        };
+
+        // The dash/dock (incl. Ubuntu Dock / Dash-to-Dock) lists running
+        // apps from AppSystem.get_running(). Our popup has no installed
+        // .desktop, so the Shell tracks it as a window-backed app that
+        // shows up there. Filter that app out of the running list so the
+        // ephemeral popup never appears in the dock — Win+V parity. We use
+        // the ORIGINAL get_windows here (the patched one above hides
+        // clipman windows, which would make this app look window-less).
+        this._origGetRunning = Shell.AppSystem.prototype.get_running;
+        const origGetRunning = this._origGetRunning;
+        Shell.AppSystem.prototype.get_running = function () {
+            return origGetRunning.call(this).filter(app => {
+                let wins;
+                try {
+                    wins = origAppGetWindows.call(app);
+                } catch {
+                    return true;
+                }
+                return !(wins.length > 0 && wins.every(_isClipmanWindow));
+            });
+        };
     }
 
     disable() {
+        if (this._origGetTabList) {
+            global.display.get_tab_list = this._origGetTabList;
+            this._origGetTabList = null;
+        }
+        if (this._origAppGetWindows) {
+            Shell.App.prototype.get_windows = this._origAppGetWindows;
+            this._origAppGetWindows = null;
+        }
+        if (this._origGetRunning) {
+            Shell.AppSystem.prototype.get_running = this._origGetRunning;
+            this._origGetRunning = null;
+        }
         if (this._clipboardTimeout) {
             GLib.source_remove(this._clipboardTimeout);
             this._clipboardTimeout = null;
@@ -136,7 +201,45 @@ export default class ClipmanExtension extends Extension {
                 winX = Math.max(workArea.x, winX);
                 winY = Math.max(workArea.y, winY);
                 metaWin.move_frame(true, winX, winY);
+                // Remember who had focus BEFORE we steal it below, so paste
+                // can hand focus back to the real target (see
+                // RestorePreviousFocus). Capture now: activate() has not run
+                // yet, so the focus window is still the user's app.
+                const focused = global.display.get_focus_window();
+                if (focused && !_isClipmanWindow(focused))
+                    this._prevFocus = focused;
+                // GNOME 49+: the supported way to drop the popup from the
+                // dash AND alt-tab in one call (no-op / undefined before 49,
+                // where the enable() list overrides handle it instead).
+                if (metaWin.hide_from_window_list)
+                    metaWin.hide_from_window_list();
+                // Give the popup real input focus. A background D-Bus
+                // daemon's window is mapped WITHOUT focus by Mutter's
+                // focus-stealing prevention, so its buttons/keys are inert
+                // until focused. The Shell has the privilege to focus it;
+                // GTK's present() does not. This is what makes Win+V-style
+                // click/type/dismiss work. On hide, focus returns to the
+                // previously-active window, so wtype paste still lands there.
+                metaWin.activate(global.get_current_time());
                 break;
+            }
+        }
+    }
+
+    RestorePreviousFocus() {
+        // The popup held input focus (so its buttons/keys worked); before
+        // the daemon fires the paste keystroke it must hand focus back to
+        // the window the user came from, otherwise Ctrl+V lands on nothing.
+        // Only the Shell can refocus another window on Wayland, so the
+        // daemon calls this after hiding the popup and just before wtype.
+        const prev = this._prevFocus;
+        this._prevFocus = null;
+        if (prev && !_isClipmanWindow(prev)) {
+            try {
+                prev.activate(global.get_current_time());
+            } catch {
+                // The target window may have closed meanwhile; the paste
+                // keystroke then goes to whatever is now focused.
             }
         }
     }

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -96,18 +96,18 @@ def main():
     def on_activate(app):
         app.hold()
         window = ClipmanWindow(application=app, db=db, monitor=None)
-        if args.view == "main":
-            window.refresh()
-            target = window
-        elif args.view == "preferences":
+        window.refresh()
+        window.set_default_size(440, 620)
+        window.present()
+        # preferences/snippets are in-surface Adw.Dialogs — present them on
+        # the window and capture the window (the dialog renders over it).
+        if args.view == "preferences":
             from clipman.preferences import ClipmanPreferences
-            target = ClipmanPreferences(parent=window, db=db)
-        else:
+            ClipmanPreferences(db, window).present(window)
+        elif args.view == "snippets":
             from clipman.snippets_dialog import SnippetsDialog
-            target = SnippetsDialog(parent=window, db=db)
-        target.set_default_size(440, 620)
-        target.present()
-        GLib.timeout_add(500, _capture, target, args.out, 20, app)
+            SnippetsDialog(db).present(window)
+        GLib.timeout_add(600, _capture, window, args.out, 20, app)
 
     app.connect("activate", on_activate)
     app.run([])

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -18,7 +18,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # Force off-screen behaviour so the test runner doesn't need a real
 # display server. Adw still needs to initialise but it's happy to do
@@ -287,6 +287,213 @@ class TestWindowConstruction(unittest.TestCase):
         theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
         for name in TYPE_ICONS.values():
             self.assertTrue(theme.has_icon(name), name)
+    def test_preferences_is_in_surface_dialog(self):
+        """Preferences must be an Adw.Dialog (in-surface), not a top-level.
+
+        Regression guard: as a top-level Adw.PreferencesWindow it opened
+        behind the popup on Wayland and looked unresponsive.
+        """
+        from clipman.preferences import ClipmanPreferences
+
+        db = self._make_db()
+        prefs = ClipmanPreferences(db, None, on_setting_changed=None)
+        self.assertIsInstance(prefs, Adw.PreferencesDialog)
+        self.assertIsInstance(prefs, Adw.Dialog)
+
+    def test_dismiss_on_focus_loss(self):
+        """notify::is-active handler hides the popup when it loses focus,
+        unless an in-app child dialog is open (Win+V click-outside dismiss)."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestDismiss")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        # Headless: the window is never compositor-active, so is-active is
+        # False — exactly the "lost focus" condition.
+        self.assertFalse(window.get_property("is-active"))
+
+        window.set_visible(True)
+        window._child_dialog = None
+        window._on_active_changed()
+        self.assertFalse(window.get_visible())  # dismissed on focus loss
+
+        # A mapped child dialog suppresses the dismiss.
+        window.set_visible(True)
+        child = MagicMock()
+        child.get_mapped.return_value = True
+        window._child_dialog = child
+        window._on_active_changed()
+        self.assertTrue(window.get_visible())  # child open -> stay put
+
+    def test_hide_cancels_timer_and_closes_child(self):
+        """_hide() must reset the cursor timer and force-close any child so
+        the dismiss guard can't latch (hiding never fires a dialog 'closed')."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestHide")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window.set_visible(True)
+        window._cursor_move_id = 0
+        child = MagicMock()
+        child.get_mapped.return_value = True
+        window._child_dialog = child
+        window._hide()
+        self.assertFalse(window.get_visible())
+        self.assertIsNone(window._child_dialog)     # ref cleared (no latch)
+        child.force_close.assert_called_once()      # stale dialog closed
+        self.assertFalse(window._child_is_open())
+
+    def test_move_to_cursor_guarded_when_hidden(self):
+        """A stale _move_to_cursor timer must not re-activate a hidden popup."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestCursor")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window.set_visible(False)
+        # Returns False (removes source) and no-ops because it's hidden.
+        self.assertFalse(window._move_to_cursor())
+        self.assertEqual(window._cursor_move_id, 0)
+
+    def test_paste_prefers_shell_injection(self):
+        """On GNOME the Shell injects the keystroke (wtype can't on Mutter),
+        so _dispatch_paste routes through the extension and must NOT also
+        fire the wtype fallback when the Shell path succeeds."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestPasteShell")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window._paste_via_shell = lambda mode: True  # extension present
+
+        with patch("clipman.window.GLib.timeout_add") as timeout_add:
+            window._dispatch_paste()
+
+        self.assertFalse(timeout_add.called)  # no wtype fallback scheduled
+
+    def test_paste_falls_back_to_wtype_without_shell(self):
+        """With no extension reachable, _dispatch_paste falls back to the
+        wtype/ydotool keystroke (works on non-GNOME compositors)."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestPasteWtype")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window._paste_via_shell = lambda mode: False  # no extension
+
+        with patch("clipman.window.GLib.timeout_add") as timeout_add:
+            window._dispatch_paste()
+
+        self.assertTrue(timeout_add.called)
+        _delay, callback = timeout_add.call_args[0][:2]
+        self.assertEqual(callback, window._simulate_paste)
+
+    def test_paste_via_shell_restores_focus_then_injects(self):
+        """The Shell path must restore focus FIRST, then inject the keystroke
+        (deferred so focus can settle) — order matters or Ctrl+V misses."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestPasteOrder")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        calls = []
+        fake_iface = MagicMock()
+        fake_iface.RestorePreviousFocus.side_effect = (
+            lambda: calls.append("focus")
+        )
+        fake_iface.SimulatePaste.side_effect = (
+            lambda m: calls.append(("paste", m))
+        )
+        window._shell_extension_iface = lambda: fake_iface
+
+        with patch("clipman.window.GLib.timeout_add") as timeout_add:
+            result = window._paste_via_shell("auto")
+
+        self.assertTrue(result)
+        self.assertEqual(calls, ["focus"])  # focus restored synchronously
+        # The keystroke is deferred via a timer; firing it injects via Shell.
+        self.assertTrue(timeout_add.called)
+        _delay, callback = timeout_add.call_args[0][:2]
+        callback()
+        self.assertEqual(calls, ["focus", ("paste", "auto")])
+
+    def test_paste_via_shell_returns_false_without_extension(self):
+        """No extension -> _paste_via_shell reports failure (so paste can
+        fall back to wtype) and never raises."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestNoExt")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window._shell_extension_iface = lambda: None
+        self.assertFalse(window._paste_via_shell("auto"))
+
+    def test_copy_prefers_wl_copy_on_wayland(self):
+        """On Wayland the background daemon must set the clipboard via wl-copy
+        — Gdk.Clipboard.set() silently fails without input focus, so the
+        stale clipboard would get pasted instead of the chosen entry."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestCopyWayland")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        calls = []
+        window._is_wayland = lambda: True
+        window._wl_copy = lambda data, mime=None: (
+            calls.append((data, mime)) or True
+        )
+
+        window._copy_to_clipboard("hello world")
+
+        self.assertEqual(calls, [(b"hello world", None)])
+
+    def test_copy_uses_gtk_off_wayland(self):
+        """Off Wayland (X11) selections don't need focus, so the daemon uses
+        GTK's clipboard and must not shell out to wl-copy."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestCopyX11")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        wl_called = []
+        window._is_wayland = lambda: False
+        window._wl_copy = lambda data, mime=None: wl_called.append(1) or True
+
+        window._copy_to_clipboard("x")  # GTK path; no wl-copy on X11
+
+        self.assertEqual(wl_called, [])
+
+    def test_backup_restore_use_toplevel_parent(self):
+        """FileChooserNative needs a Gtk.Window parent; the dialog isn't one.
+
+        Regression guard for the PreferencesWindow->PreferencesDialog port
+        that crashed Export/Restore with a TypeError.
+        """
+        from gi.repository import Gtk
+
+        from clipman.preferences import ClipmanPreferences
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestBackup")
+        parent = ClipmanWindow(application=app, db=db, monitor=None)
+        prefs = ClipmanPreferences(db, parent, on_setting_changed=None)
+        self.assertIsInstance(prefs._parent_window, Gtk.Window)
+        # The parent must be accepted by FileChooserNative (no TypeError).
+        chooser = Gtk.FileChooserNative.new(
+            "t", prefs._parent_window, Gtk.FileChooserAction.SAVE, "s", "c"
+        )
+        self.assertIsNotNone(chooser)
+
+    def test_window_is_not_resizable(self):
+        """Win+V parity: the popup is a fixed panel, not a resizable window."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestResize")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        self.assertFalse(window.get_resizable())
 
     def test_snippets_dialog_constructs(self):
         from clipman.snippets_dialog import SnippetsDialog


### PR DESCRIPTION
## Win+V parity on GNOME Wayland

Makes the GTK4 popup behave like Windows' **Win+V**. All items below were verified on real hardware (GNOME 46 Wayland, Ubuntu Dock).

### Focus & dismiss — dead buttons / no click-outside ✅
A background D-Bus daemon's window is mapped **without input focus** by Mutter's focus-stealing prevention, so its buttons/keys were inert. The Shell extension now `activate()`s the window on show (only the Shell can focus a window on Wayland; GTK `present()` can't). `notify::is-active` hides the popup on focus loss (click-outside dismiss), suppressed while an in-app child dialog is open.

### Paste — Ctrl+V landed nowhere ✅
Two Wayland traps, both fixed:
1. **Injection:** `wtype` **cannot** synthesize keys on Mutter (`compositor does not support the virtual keyboard protocol`). The paste now goes through the Shell: `RestorePreviousFocus()` hands focus back to the user's window, then `SimulatePaste()` injects Ctrl+V via a **Clutter virtual device**. `wtype`/`ydotool` remain the fallback for non-GNOME compositors.
2. **Clipboard set:** `Gdk.Clipboard.set()` **silently fails** from a background process on Wayland (core `wl_data_device` needs an input-focus serial), so the *stale* clipboard was being pasted. The daemon now sets the clipboard with **`wl-copy`** on Wayland (owns the selection from its own transient surface); GTK stays the X11 path.

### Out of taskbar / dock / alt-tab ✅
Filters the popup out of `get_tab_list` (alt-tab), `Shell.App.get_windows`, and `AppSystem.get_running` (dash/dock incl. Ubuntu Dock). Uses `hide_from_window_list()` on GNOME 49+ where available.

### Also
- Popup is non-resizable and pinned near the cursor.
- **Preferences** is now an in-surface `Adw.Dialog` (was a top-level that opened *behind* the popup and looked unresponsive); `FileChooserNative` parents to the toplevel window.

## Tests
+15 tests (326 total, headless GTK4 via xvfb): dismiss-on-focus-loss, prefs-as-dialog, hide cancels timer/child, cursor-move guard, paste prefers Shell injection / falls back to wtype / restores-focus-then-injects, clipboard prefers wl-copy on Wayland / GTK on X11, backup parent, non-resizable.

```mermaid
sequenceDiagram
  participant U as User
  participant Ext as Shell extension
  participant D as Daemon (popup)
  U->>D: Super+V
  D->>Ext: MoveWindowToCursor (capture prev focus, activate popup)
  U->>D: click entry
  D->>D: wl-copy entry text to clipboard
  D->>Ext: RestorePreviousFocus (refocus user's window)
  D->>Ext: SimulatePaste (Clutter Ctrl+V)
  Ext-->>U: pastes into the app
```

Closes the Win+V items from the post-GTK4 tracker (#132).
