### PR TITLE
ux(prefs): make the Catppuccin palette optional (follow system theme)

### DIFF
--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -227,6 +227,22 @@ class ClipmanPreferences(Adw.PreferencesWindow):
             ),
         )
         theme_group.add(theme_row)
+
+        catppuccin_row = Adw.SwitchRow()
+        catppuccin_row.set_title(_("Catppuccin theme"))
+        catppuccin_row.set_subtitle(
+            _("Off: follow your system GNOME theme and accent color.")
+        )
+        catppuccin_row.set_active(
+            self.db.get_setting("use_catppuccin", "true") != "false"
+        )
+        catppuccin_row.connect(
+            "notify::active",
+            lambda row, _pspec: self._save(
+                "use_catppuccin", "true" if row.get_active() else "false"
+            ),
+        )
+        theme_group.add(catppuccin_row)
         page.add(theme_group)
 
         # --- Accent / font color group ------------------------------------

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -161,6 +161,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
             else DEFAULT_THEME
         )
 
+        # When off, don't force the Catppuccin @-token overrides so the app
+        # follows the user's system GNOME/Adwaita theme + accent. Default on.
+        self._use_catppuccin = (
+            self.db.get_setting("use_catppuccin", "true") != "false"
+        )
+
         self._font_color = self.db.get_setting(
             "font_color", DEFAULT_FONT_COLOR
         ) or DEFAULT_FONT_COLOR
@@ -265,7 +271,14 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 font_size=str(self._font_size),
                 font_color=self._resolve_font_color(),
             )
-        css_string = self._catppuccin_palette_block() + "\n" + template_body
+        # Only force the Catppuccin palette when enabled; otherwise emit
+        # just the template so libadwaita keeps the system theme/accent.
+        palette = (
+            self._catppuccin_palette_block() + "\n"
+            if self._use_catppuccin
+            else ""
+        )
+        css_string = palette + template_body
 
         display = Gdk.Display.get_default()
         if self._css_provider is not None:
@@ -1187,6 +1200,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 value if value in ("auto", "dark", "light") else DEFAULT_THEME
             )
             self._apply_theme()
+            self._apply_css()  # palette block depends on the theme
+        elif key == "use_catppuccin":
+            self._use_catppuccin = str(value).lower() not in ("false", "0", "")
+            self._apply_css()
         elif key == "font_size":
             try:
                 self._font_size = max(8, min(20, int(value)))

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -259,6 +259,25 @@ class TestWindowConstruction(unittest.TestCase):
         prefs = ClipmanPreferences(db, parent, on_setting_changed=None)
         self.assertIsNotNone(prefs)
 
+    def test_catppuccin_palette_is_optional(self):
+        """use_catppuccin gates whether the forced @-token palette is applied
+        (off = follow the system GNOME theme/accent)."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestCatppuccin")
+
+        w_on = ClipmanWindow(application=app, db=db, monitor=None)
+        self.assertTrue(w_on._use_catppuccin)  # default on
+        self.assertIn("@define-color", w_on._catppuccin_palette_block())
+
+        db.set_setting("use_catppuccin", "false")
+        w_off = ClipmanWindow(application=app, db=db, monitor=None)
+        self.assertFalse(w_off._use_catppuccin)
+        # hot-reload back on without raising
+        w_off._on_setting_changed("use_catppuccin", "true")
+        self.assertTrue(w_off._use_catppuccin)
+
     def test_snippets_dialog_constructs(self):
         from clipman.snippets_dialog import SnippetsDialog
 


### PR DESCRIPTION
Part of #132 (U1).

The popup force-injected the Catppuccin `@define-color` overrides app-wide, ignoring the user's system GNOME/Adwaita **accent + theme** — a big driver of the 'non-native / heavy' feel.

**Change (non-breaking, default = Catppuccin ON):**
- New `use_catppuccin` setting + a **'Catppuccin theme' switch** on the Appearance page (subtitle: *Off: follow your system GNOME theme and accent color*).
- `_apply_css()` skips the palette block when off → the popup inherits the system theme + accent.
- Re-apply CSS on theme change too, so Mocha/Latte swap live.

**Verified:** new `test_catppuccin_palette_is_optional`; full suite 313 green; ruff clean. Screenshots confirm: ON = Catppuccin; OFF = system theme (e.g. Ubuntu's orange accent + standard Adwaita dark).