### PR TITLE
ux(window): replace the 3px type bar with a symbolic type icon

### DIFF
--- a/clipman/style.css
+++ b/clipman/style.css
@@ -108,21 +108,14 @@
     font-size: 0.85em;
 }
 
-/* Per-type 3px prefix bar. Tints are hard-coded so they read the same
-   in both light and dark Adw schemes — colour identity by type is more
-   important here than scheme conformance.  */
+/* Per-type symbolic icon in each row's prefix. Symbolic icons inherit
+   the foreground colour, so they adapt to light/dark and the user's
+   system theme; dim slightly so they read as a quiet type hint. */
 
-.clip-type-bar {
-    border-radius: 2px;
-    margin: 4px 6px 4px 2px;
-    min-width: 3px;
+.clip-type-icon {
+    color: alpha(@window_fg_color, 0.55);
+    margin: 0 6px 0 2px;
 }
-
-.clip-type-text  { background-color: #89b4fa; }
-.clip-type-image { background-color: #cba6f7; }
-.clip-type-link  { background-color: #74c7ec; }
-.clip-type-code  { background-color: #94e2d5; }
-.clip-type-snip  { background-color: #f9e2af; }
 
 /* Footer hints ------------------------------------------------------- */
 

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -112,15 +112,15 @@ DEFAULT_FONT_COLOR = "default"
 # Keeps the .clip-row .title colour aligned with libadwaita's card fg.
 _DEFAULT_FONT_COLOR_TOKEN = "@card_fg_color"
 
-# Hard-coded per-type accent tints — matched to docs/design/tokens.css.
-# Used to colour the 3px prefix bar on each Adw.ActionRow so users can
-# scan the list by type without reading the subtitle.
-TYPE_CLASSES = {
-    "text": "clip-type-text",
-    "image": "clip-type-image",
-    "link": "clip-type-link",
-    "code": "clip-type-code",
-    "snip": "clip-type-snip",
+# Per-type symbolic icon shown in each row's prefix so the list is
+# scannable by type. Symbolic icons inherit the foreground colour, so
+# they adapt to light/dark and the user's system theme — unlike the old
+# hard-coded 3px colour bar. (content_type is only text/image; snippets
+# use the "snip" key.)
+TYPE_ICONS = {
+    "text": "text-x-generic-symbolic",
+    "image": "image-x-generic-symbolic",
+    "snip": "emblem-documents-symbolic",
 }
 
 
@@ -826,13 +826,13 @@ class ClipmanWindow(Adw.ApplicationWindow):
         row.entry_data = entry
         row.row_kind = "entry"
 
-        # 3px coloured prefix bar (per-type tint).
-        bar = Gtk.Box()
-        bar.add_css_class("clip-type-bar")
-        bar.add_css_class(TYPE_CLASSES.get(ctype, "clip-type-text"))
-        bar.set_size_request(3, -1)
-        bar.set_valign(Gtk.Align.FILL)
-        row.add_prefix(bar)
+        # Per-type symbolic icon (scannable, theme-adaptive).
+        icon = Gtk.Image.new_from_icon_name(
+            TYPE_ICONS.get(ctype, "text-x-generic-symbolic")
+        )
+        icon.add_css_class("clip-type-icon")
+        icon.set_valign(Gtk.Align.CENTER)
+        row.add_prefix(icon)
 
         # Image entries get a 48x48 thumbnail so users can scan the list
         # visually instead of relying on the literal ``[Image]`` title.
@@ -872,12 +872,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
         row.snippet_data = snippet
         row.row_kind = "snippet"
 
-        bar = Gtk.Box()
-        bar.add_css_class("clip-type-bar")
-        bar.add_css_class(TYPE_CLASSES["snip"])
-        bar.set_size_request(3, -1)
-        bar.set_valign(Gtk.Align.FILL)
-        row.add_prefix(bar)
+        icon = Gtk.Image.new_from_icon_name(TYPE_ICONS["snip"])
+        icon.add_css_class("clip-type-icon")
+        icon.set_valign(Gtk.Align.CENTER)
+        row.add_prefix(icon)
 
         return row
 

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -278,6 +278,16 @@ class TestWindowConstruction(unittest.TestCase):
         w_off._on_setting_changed("use_catppuccin", "true")
         self.assertTrue(w_off._use_catppuccin)
 
+    def test_type_icons_resolve(self):
+        """Every row type icon must exist so no broken-icon placeholder shows."""
+        from gi.repository import Gdk, Gtk
+
+        from clipman.window import TYPE_ICONS
+
+        theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+        for name in TYPE_ICONS.values():
+            self.assertTrue(theme.has_icon(name), name)
+
     def test_snippets_dialog_constructs(self):
         from clipman.snippets_dialog import SnippetsDialog
 


### PR DESCRIPTION
Part of #132 (U5).

The per-row **3px colour bar** used hard-coded hex tints that don't adapt to light/dark or (after #146) the user's system accent. Replace it with a **dim symbolic icon per type** (text/image/snippet) that inherits the foreground colour — theme-adaptive, quieter, more modern (matches the mockups).

- `TYPE_CLASSES` (colour classes) → `TYPE_ICONS` (`text-x-generic-symbolic` / `image-x-generic-symbolic` / `emblem-documents-symbolic`, all verified present).
- Removed the unused `.clip-type-bar` + `.clip-type-*` CSS; added a subtle `.clip-type-icon`.

**Verified:** new `test_type_icons_resolve` (guards against broken-icon placeholders); full suite 314 green; ruff clean; screenshot confirms clean icon rows.