### PR TITLE
fix(install): launch the daemon once — systemd service only

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLIPMAN_PY="$SCRIPT_DIR/clipman.py"
 AUTOSTART_DIR="$HOME/.config/autostart"
+LEGACY_AUTOSTART="$AUTOSTART_DIR/com.clipman.Clipman.desktop"
 DATA_DIR="$HOME/.local/share/clipman"
 EXTENSION_UUID="clipman@clipman.com"
 EXTENSION_DIR="$HOME/.local/share/gnome-shell/extensions/$EXTENSION_UUID"
@@ -32,7 +33,6 @@ fi
 # Step 2: Create data directories
 echo "[2/6] Creating data directories..."
 mkdir -p "$DATA_DIR/images"
-mkdir -p "$AUTOSTART_DIR"
 
 # Step 3: Install GNOME Shell extension for native clipboard monitoring
 echo "[3/6] Installing GNOME Shell clipboard extension..."
@@ -42,9 +42,13 @@ cp "$SCRIPT_DIR/extension/extension.js" "$EXTENSION_DIR/"
 gnome-extensions enable "$EXTENSION_UUID" 2>/dev/null || true
 echo "  Extension installed. You may need to log out and back in to activate it."
 
-# Step 4: Generate and install autostart desktop file + icon
-echo "[4/6] Setting up autostart..."
-sed "s|CLIPMAN_PATH_PLACEHOLDER|$SCRIPT_DIR|g" "$SCRIPT_DIR/data/com.clipman.Clipman.desktop" > "$AUTOSTART_DIR/com.clipman.Clipman.desktop"
+# Step 4: Install application icon
+# Clipman autostarts via the systemd user service (Step 6) ONLY. We do not
+# also drop an XDG autostart .desktop: running both starts the daemon twice,
+# and the two instances race for the com.clipman.Daemon bus name, leaving an
+# orphaned process. Remove any autostart file left by an older installer.
+echo "[4/6] Installing application icon..."
+rm -f "$LEGACY_AUTOSTART"
 ICON_DIR="$HOME/.local/share/icons/hicolor/scalable/apps"
 mkdir -p "$ICON_DIR"
 cp "$SCRIPT_DIR/data/com.clipman.Clipman.svg" "$ICON_DIR/"


### PR DESCRIPTION
## Problem

`install.sh` set up **two** autostart mechanisms for the daemon:

- **Step 4** — an XDG autostart entry at `~/.config/autostart/com.clipman.Clipman.desktop`
- **Step 6** — a systemd **user service** (`clipman.service`, enabled)

Both fire on login, so `clipman.py` starts **twice**. The two instances race for the `com.clipman.Daemon` D-Bus name; the loser lingers as an orphaned process. Because that orphan isn't tracked by the systemd unit, it even survives `systemctl --user stop clipman.service` — which makes redeploys/upgrades unreliable (a stale daemon keeps serving old code).

## Fix

Keep the **systemd user service as the single launch path** and stop dropping the duplicate autostart `.desktop`.

Why systemd over the XDG autostart entry:
- `Restart=on-failure` (the daemon comes back if it crashes)
- logs to journald (`journalctl --user -u clipman.service`)
- proper lifecycle via `graphical-session.target`
- manageable with `systemctl --user`

The installer now also `rm -f`s any autostart file left behind by an older install, so upgrading users are healed automatically.

```mermaid
flowchart LR
  subgraph before["Before — double launch"]
    L1[login] --> A[XDG autostart .desktop]
    L1 --> S[systemd clipman.service]
    A --> D1[clipman.py #1]
    S --> D2[clipman.py #2]
    D1 -. race for .-> N[(com.clipman.Daemon)]
    D2 -. bus name .-> N
    D2 --> O[orphaned stale daemon]
  end
  subgraph after["After — single launch"]
    L2[login] --> S2[systemd clipman.service]
    S2 --> D3[clipman.py]
    D3 --> N2[(com.clipman.Daemon)]
  end
```

## Verification
- `bash -n install.sh` — syntax OK
- Removed the live duplicate on this machine; daemon now has a single, service-tracked instance that restarts cleanly.

_Note: `data/com.clipman.Clipman.desktop` is retained (now unused by the installer) in case we later ship a proper application launcher entry rather than an autostart one._