### PR TITLE
ux: redesign popup to match design mockups (type icons, day-grouping, switcher counts, pickers, WCAG light mode)

### DIFF
--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -262,6 +262,32 @@ class ClipmanPreferences(Adw.PreferencesDialog):
             _("Color applied to clip text in the popup.")
         )
 
+        # Accent colour picker — drives toggles, active tabs, focus rings,
+        # the recording pill. A picker (rather than the pale default) lets
+        # the user choose a high-contrast accent.
+        accent_color_row = Adw.ActionRow()
+        accent_color_row.set_title(_("Accent color"))
+        accent_color_row.set_subtitle(
+            _("Toggles, active tabs and highlights. Pick any colour or reset.")
+        )
+        cur_accent = self.db.get_setting("accent_color", "default")
+        accent_dialog = Gtk.ColorDialog()
+        accent_dialog.set_with_alpha(False)
+        self._accent_btn = Gtk.ColorDialogButton(dialog=accent_dialog)
+        self._accent_btn.set_valign(Gtk.Align.CENTER)
+        argba = Gdk.RGBA()
+        argba.parse(self._accent_display_hex(cur_accent))
+        self._accent_btn.set_rgba(argba)
+        self._accent_btn.connect("notify::rgba", self._on_accent_rgba)
+        accent_reset = Gtk.Button.new_from_icon_name("edit-undo-symbolic")
+        accent_reset.set_tooltip_text(_("Reset to theme default"))
+        accent_reset.add_css_class("flat")
+        accent_reset.set_valign(Gtk.Align.CENTER)
+        accent_reset.connect("clicked", self._on_accent_reset)
+        accent_color_row.add_suffix(self._accent_btn)
+        accent_color_row.add_suffix(accent_reset)
+        accent_group.add(accent_color_row)
+
         accent_row = Adw.ActionRow()
         accent_row.set_title(_("Font color"))
         accent_row.set_subtitle(
@@ -335,6 +361,25 @@ class ClipmanPreferences(Adw.PreferencesDialog):
         page.add(layout_group)
 
         return page
+
+    def _accent_display_hex(self, value):
+        """Hex to show in the accent button (custom hex, or the Catppuccin
+        mauve default so the button isn't blank)."""
+        if isinstance(value, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+            return value
+        return "#cba6f7"
+
+    def _on_accent_rgba(self, button, _pspec):
+        rgba = button.get_rgba()
+        hex_value = "#{:02x}{:02x}{:02x}".format(
+            round(rgba.red * 255),
+            round(rgba.green * 255),
+            round(rgba.blue * 255),
+        )
+        self._save("accent_color", hex_value)
+
+    def _on_accent_reset(self, _button):
+        self._save("accent_color", "default")
 
     def _font_color_display_hex(self, value):
         """Resolve a stored font_color (hex, legacy preset id, or

--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -35,6 +35,7 @@ categories of message:
 
 import logging
 import os
+import re
 import subprocess
 import time
 
@@ -263,37 +264,30 @@ class ClipmanPreferences(Adw.PreferencesDialog):
 
         accent_row = Adw.ActionRow()
         accent_row.set_title(_("Font color"))
-        accent_row.set_subtitle(_("Pick a preset or fall back to default."))
-
-        swatches = Gtk.Box(
-            orientation=Gtk.Orientation.HORIZONTAL, spacing=6
+        accent_row.set_subtitle(
+            _("Pick any colour, or reset to the theme default.")
         )
-        swatches.set_valign(Gtk.Align.CENTER)
+
         current_font_color = self.db.get_setting("font_color", "default")
-        for preset_id, hex_value, tooltip in FONT_COLOR_PRESETS:
-            btn = Gtk.Button()
-            btn.set_tooltip_text(tooltip)
-            btn.add_css_class("circular")
-            btn.set_size_request(28, 28)
-            if hex_value:
-                # Inline CSS provider so the swatch fills with the preset.
-                provider = Gtk.CssProvider()
-                provider.load_from_data(
-                    f"button {{ background: {hex_value}; }}".encode(), -1
-                )
-                btn.get_style_context().add_provider(
-                    provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-                )
-            else:
-                btn.set_label("A")
-            if preset_id == current_font_color:
-                btn.add_css_class("suggested-action")
-            btn.connect(
-                "clicked",
-                lambda _b, pid=preset_id: self._on_font_color_picked(pid),
-            )
-            swatches.append(btn)
-        accent_row.add_suffix(swatches)
+        color_dialog = Gtk.ColorDialog()
+        color_dialog.set_with_alpha(False)
+        self._font_color_btn = Gtk.ColorDialogButton(dialog=color_dialog)
+        self._font_color_btn.set_valign(Gtk.Align.CENTER)
+        rgba = Gdk.RGBA()
+        rgba.parse(self._font_color_display_hex(current_font_color))
+        self._font_color_btn.set_rgba(rgba)
+        self._font_color_btn.connect(
+            "notify::rgba", self._on_font_color_rgba
+        )
+
+        reset_btn = Gtk.Button.new_from_icon_name("edit-undo-symbolic")
+        reset_btn.set_tooltip_text(_("Reset to theme default"))
+        reset_btn.add_css_class("flat")
+        reset_btn.set_valign(Gtk.Align.CENTER)
+        reset_btn.connect("clicked", self._on_font_color_reset)
+
+        accent_row.add_suffix(self._font_color_btn)
+        accent_row.add_suffix(reset_btn)
         accent_group.add(accent_row)
         page.add(accent_group)
 
@@ -342,10 +336,28 @@ class ClipmanPreferences(Adw.PreferencesDialog):
 
         return page
 
-    def _on_font_color_picked(self, preset_id):
-        self._save("font_color", preset_id)
-        # Caller refreshes; we don't redraw the swatch row here because
-        # the user will see the new color in the popup itself.
+    def _font_color_display_hex(self, value):
+        """Resolve a stored font_color (hex, legacy preset id, or
+        'default') to a hex the colour button can display."""
+        if isinstance(value, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+            return value
+        for preset_id, hex_value, _tip in FONT_COLOR_PRESETS:
+            if preset_id == value and hex_value:
+                return hex_value
+        # 'default' — show a neutral so the button isn't misleading.
+        return "#9e9e9e"
+
+    def _on_font_color_rgba(self, button, _pspec):
+        rgba = button.get_rgba()
+        hex_value = "#{:02x}{:02x}{:02x}".format(
+            round(rgba.red * 255),
+            round(rgba.green * 255),
+            round(rgba.blue * 255),
+        )
+        self._save("font_color", hex_value)
+
+    def _on_font_color_reset(self, _button):
+        self._save("font_color", "default")
 
     # ------------------------------------------------------------------
     # Pane 2: Privacy

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -48,8 +48,8 @@
 
 .filter-tab {
     background-color: transparent;
-    color: alpha(@window_fg_color, 0.8);
-    border: 1px solid alpha(@window_fg_color, 0.12);
+    color: @clip_dim;
+    border: 1px solid alpha(@window_fg_color, 0.14);
     border-radius: 999px;
     padding: 3px 12px;
     min-height: 22px;
@@ -76,8 +76,8 @@
 .filter-count {
     font-size: 0.76em;
     font-weight: 600;
-    color: alpha(@window_fg_color, 0.75);
-    background-color: alpha(@window_fg_color, 0.14);
+    color: @clip_dim;
+    background-color: alpha(@window_fg_color, 0.12);
     border-radius: 999px;
     padding: 0 6px;
 }
@@ -128,7 +128,7 @@
 }
 
 .clip-row .subtitle {
-    color: alpha(@card_fg_color, 0.85);
+    color: @clip_dim;
     font-size: 0.85em;
 }
 
@@ -155,7 +155,7 @@
 .clip-section-header {
     font-size: 0.72em;
     font-weight: 700;
-    color: alpha(@window_fg_color, 0.55);
+    color: @clip_dim;
     margin: 8px 4px 2px 6px;
 }
 
@@ -178,7 +178,7 @@
 }
 
 .clipman-count {
-    color: alpha(@window_fg_color, 0.68);
+    color: @clip_dim;
     font-size: 0.82em;
 }
 
@@ -205,7 +205,7 @@
 }
 
 .clipman-clear {
-    color: alpha(@window_fg_color, 0.72);
+    color: @clip_dim;
     font-size: 0.82em;
     padding: 2px 8px;
     min-height: 0;

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -115,13 +115,33 @@
     font-size: 0.85em;
 }
 
-/* Per-type symbolic icon in each row's prefix. Symbolic icons inherit
-   the foreground colour, so they adapt to light/dark and the user's
-   system theme; dim slightly so they read as a quiet type hint. */
+/* Colour-coded type icon: the symbolic icon is tinted per clip type as a
+   quiet, scannable hint (no heavy background chip). Colours come from the
+   @type_* tokens injected by window._type_color_block(). */
 
-.clip-type-icon {
-    color: alpha(@window_fg_color, 0.55);
-    margin: 0 6px 0 2px;
+.clip-tile {
+    min-width: 24px;
+    margin: 0 4px 0 2px;
+}
+
+.clip-tile > image {
+    -gtk-icon-size: 16px;
+}
+
+.clip-tile.type-text  > image { color: @type_text; }
+.clip-tile.type-link  > image { color: @type_link; }
+.clip-tile.type-code  > image { color: @type_code; }
+.clip-tile.type-image > image { color: @type_image; }
+.clip-tile.type-snip  > image { color: @type_snip; }
+
+/* Row actions (pin / delete) fade in on hover; pinned rows keep them on. */
+.clip-actions {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+.clipman-list row:hover .clip-actions,
+.clip-row.pinned .clip-actions {
+    opacity: 1;
 }
 
 /* Footer hints ------------------------------------------------------- */

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -72,6 +72,23 @@
     color: @accent_fg_color;
 }
 
+/* Count badge inside each switcher tab. */
+.filter-count {
+    font-size: 0.76em;
+    font-weight: 500;
+    color: alpha(@window_fg_color, 0.5);
+    background-color: alpha(@window_fg_color, 0.10);
+    border-radius: 999px;
+    padding: 0 6px;
+}
+.filter-count:empty {
+    padding: 0;
+}
+.filter-tab-active .filter-count {
+    color: @accent_fg_color;
+    background-color: alpha(@accent_fg_color, 0.22);
+}
+
 /* List + rows -------------------------------------------------------- */
 
 .clipman-list {

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -144,18 +144,50 @@
     opacity: 1;
 }
 
-/* Footer hints ------------------------------------------------------- */
+/* Footer: item count · recording pill · clear all -------------------- */
 
 .clipman-footer {
-    padding: 4px 8px;
-    border-top: 1px solid alpha(@window_fg_color, 0.06);
+    padding: 4px 10px;
+    border-top: 1px solid alpha(@window_fg_color, 0.08);
     background-color: alpha(@window_fg_color, 0.02);
 }
 
-.clipman-footer-hint {
-    color: alpha(@window_fg_color, 0.55);
-    font-size: 0.8em;
-    letter-spacing: 0.02em;
+.clipman-count {
+    color: alpha(@window_fg_color, 0.5);
+    font-size: 0.82em;
+}
+
+.recording-pill {
+    padding: 2px 8px;
+    border-radius: 9999px;
+    background-color: alpha(@accent_color, 0.14);
+}
+.recording-pill label {
+    color: @accent_color;
+    font-size: 0.78em;
+    font-weight: 500;
+}
+.recording-pill image {
+    -gtk-icon-size: 11px;
+    color: @accent_color;
+}
+.recording-pill.paused {
+    background-color: alpha(@warning_color, 0.16);
+}
+.recording-pill.paused label,
+.recording-pill.paused image {
+    color: @warning_color;
+}
+
+.clipman-clear {
+    color: alpha(@window_fg_color, 0.6);
+    font-size: 0.82em;
+    padding: 2px 8px;
+    min-height: 0;
+}
+.clipman-clear:hover {
+    color: @error_color;
+    background-color: alpha(@error_color, 0.12);
 }
 
 /* Status page (empty / no-results) ----------------------------------- */

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -48,8 +48,8 @@
 
 .filter-tab {
     background-color: transparent;
-    color: alpha(@window_fg_color, 0.65);
-    border: 1px solid alpha(@window_fg_color, 0.10);
+    color: alpha(@window_fg_color, 0.8);
+    border: 1px solid alpha(@window_fg_color, 0.12);
     border-radius: 999px;
     padding: 3px 12px;
     min-height: 22px;
@@ -75,9 +75,9 @@
 /* Count badge inside each switcher tab. */
 .filter-count {
     font-size: 0.76em;
-    font-weight: 500;
-    color: alpha(@window_fg_color, 0.5);
-    background-color: alpha(@window_fg_color, 0.10);
+    font-weight: 600;
+    color: alpha(@window_fg_color, 0.75);
+    background-color: alpha(@window_fg_color, 0.14);
     border-radius: 999px;
     padding: 0 6px;
 }
@@ -128,7 +128,7 @@
 }
 
 .clip-row .subtitle {
-    color: alpha(@card_fg_color, 0.65);
+    color: alpha(@card_fg_color, 0.85);
     font-size: 0.85em;
 }
 
@@ -170,7 +170,7 @@
 }
 
 .clipman-count {
-    color: alpha(@window_fg_color, 0.5);
+    color: alpha(@window_fg_color, 0.68);
     font-size: 0.82em;
 }
 
@@ -197,7 +197,7 @@
 }
 
 .clipman-clear {
-    color: alpha(@window_fg_color, 0.6);
+    color: alpha(@window_fg_color, 0.72);
     font-size: 0.82em;
     padding: 2px 8px;
     min-height: 0;

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -151,6 +151,14 @@
 .clip-tile.type-image > image { color: @type_image; }
 .clip-tile.type-snip  > image { color: @type_snip; }
 
+/* Dated section headers (★ Pinned / Today / Yesterday / Earlier). */
+.clip-section-header {
+    font-size: 0.72em;
+    font-weight: 700;
+    color: alpha(@window_fg_color, 0.55);
+    margin: 8px 4px 2px 6px;
+}
+
 /* Row actions (pin / delete) fade in on hover; pinned rows keep them on. */
 .clip-actions {
     opacity: 0;

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -581,21 +581,38 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._list_stack.add_named(self._empty_slot, "empty")
         root.append(self._list_stack)
 
-        # -- Footer hints --------------------------------------------------
-        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        # -- Footer: item count · recording status · clear all ------------
+        # (docs/design mockup). Shortcuts still work (↵ paste, P pin,
+        # ⌫ delete, Esc close); the footer now carries state + a bulk action.
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         footer.add_css_class("clipman-footer")
-        footer.set_halign(Gtk.Align.CENTER)
-        footer.set_margin_top(4)
-        footer.set_margin_bottom(6)
-        for text in [
-            "↵ " + _("Paste"),
-            "⌫ " + _("Delete"),
-            "P " + _("Pin"),
-            "Esc " + _("Close"),
-        ]:
-            lbl = Gtk.Label(label=text)
-            lbl.add_css_class("clipman-footer-hint")
-            footer.append(lbl)
+
+        self._count_label = Gtk.Label(label="")
+        self._count_label.add_css_class("clipman-count")
+        self._count_label.set_halign(Gtk.Align.START)
+        self._count_label.set_hexpand(True)
+        footer.append(self._count_label)
+
+        # Recording / incognito status pill (reflects the header toggle).
+        self._recording_pill = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL, spacing=4
+        )
+        self._recording_pill.add_css_class("recording-pill")
+        self._recording_pill.set_valign(Gtk.Align.CENTER)
+        self._recording_icon = Gtk.Image.new_from_icon_name(
+            "media-record-symbolic"
+        )
+        self._recording_label = Gtk.Label(label=_("Recording"))
+        self._recording_pill.append(self._recording_icon)
+        self._recording_pill.append(self._recording_label)
+        footer.append(self._recording_pill)
+
+        clear_btn = Gtk.Button(label=_("Clear all"))
+        clear_btn.add_css_class("flat")
+        clear_btn.add_css_class("clipman-clear")
+        clear_btn.set_valign(Gtk.Align.CENTER)
+        clear_btn.connect("clicked", self._on_clear_all)
+        footer.append(clear_btn)
 
         # -- Assemble the ToolbarView -------------------------------------
         # Body (search + filters + list/banner stack) becomes the
@@ -629,6 +646,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
         # Cancel any in-flight incremental fill from a previous refresh.
         self._cancel_fill()
+        self._update_count(len(items))
 
         if not items:
             self._store.remove_all()
@@ -665,6 +683,42 @@ class ClipmanWindow(Adw.ApplicationWindow):
             return True
         self._fill_id = 0
         return False
+
+    def _update_count(self, n):
+        """Set the footer item/snippet count for the current view."""
+        if not hasattr(self, "_count_label"):
+            return
+        if self._active_filter == "snippets":
+            label = _("{n} snippet").format(n=n) if n == 1 \
+                else _("{n} snippets").format(n=n)
+        else:
+            label = _("{n} item").format(n=n) if n == 1 \
+                else _("{n} items").format(n=n)
+        self._count_label.set_text(label)
+
+    def _on_clear_all(self, _button):
+        """Clear unpinned history after confirmation (pinned entries stay)."""
+        dialog = Adw.AlertDialog(
+            heading=_("Clear clipboard history?"),
+            body=_("This removes all unpinned entries. Pinned entries and "
+                   "snippets are kept. This can't be undone."),
+        )
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("clear", _("Clear"))
+        dialog.set_response_appearance(
+            "clear", Adw.ResponseAppearance.DESTRUCTIVE
+        )
+        dialog.set_default_response("cancel")
+        dialog.set_close_response("cancel")
+
+        def _on_response(_dlg, response):
+            if response == "clear":
+                self.db.clear_unpinned()
+                self.refresh()
+
+        self._register_child(dialog)
+        dialog.connect("response", _on_response)
+        dialog.present(self)
 
     def _cancel_fill(self):
         """Drop any pending incremental-fill idle source and its backlog."""
@@ -1492,10 +1546,24 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self.db.delete_entry(entry_id)
         self.refresh()
 
+    def _update_recording_pill(self, incognito):
+        """Reflect incognito state in the footer status pill."""
+        if not hasattr(self, "_recording_pill"):
+            return
+        if incognito:
+            self._recording_icon.set_from_icon_name("view-conceal-symbolic")
+            self._recording_label.set_text(_("Paused"))
+            self._recording_pill.add_css_class("paused")
+        else:
+            self._recording_icon.set_from_icon_name("media-record-symbolic")
+            self._recording_label.set_text(_("Recording"))
+            self._recording_pill.remove_css_class("paused")
+
     def _on_incognito_toggled(self, button):
+        active = button.get_active()
+        self._update_recording_pill(active)
         if self.monitor is None:
             return
-        active = button.get_active()
         self.monitor.set_incognito(active)
         button.set_tooltip_text(
             _("Incognito mode: ON — clipboard not recorded")

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -264,6 +264,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._show_count_badges = (
             self.db.get_setting("show_count_badges", "true") != "false"
         )
+        self._accent_color = (
+            self.db.get_setting("accent_color", "default") or "default"
+        )
 
         self._font_color = self.db.get_setting(
             "font_color", DEFAULT_FONT_COLOR
@@ -381,6 +384,24 @@ class ClipmanWindow(Adw.ApplicationWindow):
             for name, value in colors.items()
         )
 
+    def _accent_override_block(self):
+        """Override libadwaita's accent @-tokens with the user's chosen
+        accent (or nothing when 'default'). Picks a contrasting foreground
+        by luminance so switch knobs / active-tab text stay readable — the
+        pale default mauve was the low-contrast case the user hit.
+        """
+        val = self._accent_color
+        if not (isinstance(val, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", val)):
+            return ""
+        r, g, b = (int(val[1:3], 16), int(val[3:5], 16), int(val[5:7], 16))
+        luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+        fg = "#1e1e2e" if luminance > 0.6 else "#ffffff"
+        return "\n".join([
+            f"@define-color accent_bg_color {val};",
+            f"@define-color accent_color {val};",
+            f"@define-color accent_fg_color {fg};",
+        ]) + "\n"
+
     def _apply_css(self):
         """Inject ``style.css`` with Python ``string.Template`` substitutions.
 
@@ -411,7 +432,13 @@ class ClipmanWindow(Adw.ApplicationWindow):
         )
         # Type-tile colours are always defined (independent of the
         # Catppuccin toggle) so row tiles never reference an undefined @color.
-        css_string = self._type_color_block() + "\n" + palette + template_body
+        # The accent override comes after the palette so it wins.
+        css_string = (
+            self._type_color_block() + "\n"
+            + palette
+            + self._accent_override_block()
+            + template_body
+        )
 
         display = Gdk.Display.get_default()
         if self._css_provider is not None:
@@ -1747,6 +1774,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 "false", "0", ""
             )
             self._update_filter_counts()
+        elif key == "accent_color":
+            self._accent_color = value or "default"
+            self._apply_css()
         elif key == "font_size":
             try:
                 self._font_size = max(8, min(20, int(value)))

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -317,16 +317,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
         Adw.StyleManager.get_default().set_color_scheme(scheme)
 
     def _resolve_font_color(self):
-        """Translate the ``font_color`` preset id to a CSS colour value.
+        """Translate the ``font_color`` setting to a CSS colour value.
 
-        ``FONT_COLOR_PRESETS`` lives in ``preferences.py``; we import it
-        lazily because ``preferences`` pulls in Adw at module scope and
-        we want ``window.py`` importable for headless tests.
+        Accepts a raw ``#rrggbb`` (the generic colour picker) or a legacy
+        preset id (``FONT_COLOR_PRESETS``, imported lazily since
+        ``preferences`` pulls in Adw at module scope and we want
+        ``window.py`` importable for headless tests). Falls back to the
+        theme default.
         """
+        val = self._font_color or "default"
+        if isinstance(val, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", val):
+            return val
+
         from clipman.preferences import FONT_COLOR_PRESETS
 
         for preset_id, hex_value, _tooltip in FONT_COLOR_PRESETS:
-            if preset_id == self._font_color and hex_value:
+            if preset_id == val and hex_value:
                 return hex_value
         return _DEFAULT_FONT_COLOR_TOKEN
 

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -525,14 +525,24 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._filter_box.set_halign(Gtk.Align.CENTER)
 
         self._filter_buttons = {}
+        self._filter_count_labels = {}
         first = None
         for fid, label in [
             ("all", _("All")),
-            ("pinned", _("Pinned")),
+            ("text", _("Text")),
+            ("images", _("Images")),
             ("snippets", _("Snippets")),
         ]:
-            btn = Gtk.ToggleButton(label=label)
+            btn = Gtk.ToggleButton()
             btn.add_css_class("filter-tab")
+            content = Gtk.Box(
+                orientation=Gtk.Orientation.HORIZONTAL, spacing=6
+            )
+            content.append(Gtk.Label(label=label))
+            count_lbl = Gtk.Label(label="")
+            count_lbl.add_css_class("filter-count")
+            content.append(count_lbl)
+            btn.set_child(content)
             if fid == "all":
                 btn.set_active(True)
                 btn.add_css_class("filter-tab-active")
@@ -543,6 +553,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
             btn.connect("toggled", self._on_filter_toggled, fid)
             self._filter_box.append(btn)
             self._filter_buttons[fid] = btn
+            self._filter_count_labels[fid] = count_lbl
         root.append(self._filter_box)
 
         # -- Scrollable list + empty status page --------------------------
@@ -626,7 +637,6 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def refresh(self):
         is_snippets = self._active_filter == "snippets"
-        is_pinned_only = self._active_filter == "pinned"
 
         if is_snippets:
             entries = (
@@ -640,13 +650,21 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 entries = self.db.search(self._search_query)
             else:
                 entries = self.db.get_entries(limit=200)
-            if is_pinned_only:
-                entries = [e for e in entries if e["pinned"]]
+            if self._active_filter == "text":
+                entries = [
+                    e for e in entries
+                    if (e.get("content_type") or "text") == "text"
+                ]
+            elif self._active_filter == "images":
+                entries = [
+                    e for e in entries if e.get("content_type") == "image"
+                ]
             items = [ClipItem(e, "entry") for e in entries]
 
         # Cancel any in-flight incremental fill from a previous refresh.
         self._cancel_fill()
         self._update_count(len(items))
+        self._update_filter_counts()
 
         if not items:
             self._store.remove_all()
@@ -683,6 +701,23 @@ class ClipmanWindow(Adw.ApplicationWindow):
             return True
         self._fill_id = 0
         return False
+
+    def _update_filter_counts(self):
+        """Refresh the count badge on each switcher tab."""
+        if not hasattr(self, "_filter_count_labels"):
+            return
+        try:
+            counts = {
+                "all": self.db.count_entries(),
+                "text": self.db.count_entries("text"),
+                "images": self.db.count_entries("image"),
+                "snippets": len(self.db.get_snippets()),
+            }
+        except Exception:
+            logger.debug("filter count query failed", exc_info=True)
+            return
+        for fid, label in self._filter_count_labels.items():
+            label.set_text(str(counts.get(fid, 0)))
 
     def _update_count(self, n):
         """Set the footer item/snippet count for the current view."""

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -152,12 +152,19 @@ _TYPE_COLORS_DARK = {
     "type_snip": "#f9e2af",
 }
 _TYPE_COLORS_LIGHT = {
-    "type_text": "#2563eb",
-    "type_link": "#0891b2",
-    "type_code": "#0d9488",
-    "type_image": "#9333ea",
-    "type_snip": "#b45309",
+    "type_text": "#1d4ed8",
+    "type_link": "#155e75",
+    "type_code": "#115e59",
+    "type_image": "#7e22ce",
+    "type_snip": "#92400e",
 }
+
+# Secondary ("dim") text colour, per effective theme. Catppuccin subtext
+# tones that clear WCAG AA on each background — the alpha-of-fg approach
+# failed in light mode because Latte's muted #4c4f69 text can't hold
+# contrast once faded. #a6adc8 = 7.4:1 on dark, #5c5f77 = 5.5:1 on light.
+_DIM_TEXT_DARK = "#a6adc8"
+_DIM_TEXT_LIGHT = "#5c5f77"
 
 _URL_RE = re.compile(r"^(https?://|www\.)\S+$", re.IGNORECASE)
 # Conservative code detection: only strong, code-specific signals so plain
@@ -384,6 +391,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
             for name, value in colors.items()
         )
 
+    def _dim_color_block(self):
+        """@clip_dim — the secondary-text colour for the effective theme.
+        Always emitted (independent of the Catppuccin toggle) so CSS never
+        references an undefined @clip_dim."""
+        if self._theme == "light":
+            dim = _DIM_TEXT_LIGHT
+        elif self._theme == "dark":
+            dim = _DIM_TEXT_DARK
+        else:
+            try:
+                is_dark = Adw.StyleManager.get_default().get_dark()
+            except Exception:
+                is_dark = True
+            dim = _DIM_TEXT_DARK if is_dark else _DIM_TEXT_LIGHT
+        return f"@define-color clip_dim {dim};\n"
+
     def _accent_override_block(self):
         """Override libadwaita's accent @-tokens with the user's chosen
         accent (or nothing when 'default'). Picks a contrasting foreground
@@ -435,6 +458,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # The accent override comes after the palette so it wins.
         css_string = (
             self._type_color_block() + "\n"
+            + self._dim_color_block()
             + palette
             + self._accent_override_block()
             + template_body

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -10,6 +10,7 @@ module without changes.
 
 import logging
 import os
+import re
 import subprocess
 import time
 from string import Template
@@ -120,22 +121,64 @@ DEFAULT_FONT_COLOR = "default"
 # Keeps the .clip-row .title colour aligned with libadwaita's card fg.
 _DEFAULT_FONT_COLOR_TOKEN = "@card_fg_color"
 
-# Per-type symbolic icon shown in each row's prefix so the list is
-# scannable by type. Symbolic icons inherit the foreground colour, so
-# they adapt to light/dark and the user's system theme — unlike the old
-# hard-coded 3px colour bar. (content_type is only text/image; snippets
-# use the "snip" key.)
-TYPE_ICONS = {
-    "text": "text-x-generic-symbolic",
-    "image": "image-x-generic-symbolic",
-    "snip": "emblem-documents-symbolic",
-}
-
 # Incremental list fill (see ClipmanWindow.refresh): paint this many rows
 # immediately, then stream the remaining history in idle batches of this
 # size so a large history never freezes the popup on open / filter switch.
 _FILL_FIRST = 30
 _FILL_BATCH = 60
+
+# Per-row visual type -> symbolic icon + coloured tile (mockup parity,
+# docs/design/main-window.html). Text entries are further classified into
+# link / code so the tile colour is a quick scannable type hint.
+ROW_TYPE_ICONS = {
+    "text": "text-x-generic-symbolic",
+    "link": "insert-link-symbolic",
+    "code": "utilities-terminal-symbolic",
+    "image": "image-x-generic-symbolic",
+    "snip": "emblem-documents-symbolic",
+}
+_TILE_TYPE_CLASSES = ("type-text", "type-link", "type-code",
+                      "type-image", "type-snip")
+
+# Tile colours, keyed to the @define-color tokens emitted by
+# _type_color_block(); values mirror docs/design/tokens.css (Catppuccin
+# Mocha for dark, the mockup's high-contrast set for light).
+_TYPE_COLORS_DARK = {
+    "type_text": "#89b4fa",
+    "type_link": "#74c7ec",
+    "type_code": "#94e2d5",
+    "type_image": "#cba6f7",
+    "type_snip": "#f9e2af",
+}
+_TYPE_COLORS_LIGHT = {
+    "type_text": "#2563eb",
+    "type_link": "#0891b2",
+    "type_code": "#0d9488",
+    "type_image": "#9333ea",
+    "type_snip": "#b45309",
+}
+
+_URL_RE = re.compile(r"^(https?://|www\.)\S+$", re.IGNORECASE)
+# Conservative code detection: only strong, code-specific signals so plain
+# notes ("cd cabinet", "from the shop") don't get mislabeled as code.
+_CODE_HINT_RE = re.compile(
+    r"^\s*(def |class |function |import |#!/|\$ )"   # code-y line starts
+    r"|[{};]\s*$"                                     # line ends in ; { }
+    r"|=>|</[a-zA-Z]",                               # arrows, closing tags
+    re.MULTILINE,
+)
+
+
+def _classify_text(text):
+    """Classify a text entry into 'link', 'code', or 'text' for its tile."""
+    stripped = (text or "").strip()
+    if not stripped:
+        return "text"
+    if "\n" not in stripped and _URL_RE.match(stripped):
+        return "link"
+    if _CODE_HINT_RE.search(stripped):
+        return "code"
+    return "text"
 
 
 class ClipItem(GObject.Object):
@@ -306,6 +349,28 @@ class ClipmanWindow(Adw.ApplicationWindow):
             for name, hex_value in palette.items()
         )
 
+    def _type_color_block(self):
+        """@define-color tokens for the per-type row tiles.
+
+        Emitted independently of the Catppuccin toggle so the coloured
+        tiles always resolve (falling back to system theme just means the
+        surrounding chrome isn't Catppuccin — the tile hues still apply).
+        """
+        if self._theme == "light":
+            colors = _TYPE_COLORS_LIGHT
+        elif self._theme == "dark":
+            colors = _TYPE_COLORS_DARK
+        else:  # auto — follow system, default dark
+            try:
+                is_dark = Adw.StyleManager.get_default().get_dark()
+            except Exception:
+                is_dark = True
+            colors = _TYPE_COLORS_DARK if is_dark else _TYPE_COLORS_LIGHT
+        return "\n".join(
+            f"@define-color {name} {value};"
+            for name, value in colors.items()
+        )
+
     def _apply_css(self):
         """Inject ``style.css`` with Python ``string.Template`` substitutions.
 
@@ -334,7 +399,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
             if self._use_catppuccin
             else ""
         )
-        css_string = palette + template_body
+        # Type-tile colours are always defined (independent of the
+        # Catppuccin toggle) so row tiles never reference an undefined @color.
+        css_string = self._type_color_block() + "\n" + palette + template_body
 
         display = Gdk.Display.get_default()
         if self._css_provider is not None:
@@ -913,10 +980,18 @@ class ClipmanWindow(Adw.ApplicationWindow):
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         row.add_css_class("clip-row")
 
+        # Colour-coded type tile: a rounded square whose tint + icon convey
+        # the clip type at a glance (docs/design mockup). Images swap the
+        # tile for a thumbnail (below).
         icon = Gtk.Image()
-        icon.add_css_class("clip-type-icon")
+        icon.set_halign(Gtk.Align.CENTER)
         icon.set_valign(Gtk.Align.CENTER)
-        row.append(icon)
+        tile = Gtk.Box()
+        tile.add_css_class("clip-tile")
+        tile.set_halign(Gtk.Align.CENTER)
+        tile.set_valign(Gtk.Align.CENTER)
+        tile.append(icon)
+        row.append(tile)
 
         thumb = Gtk.Picture()
         thumb.set_can_shrink(True)
@@ -940,25 +1015,34 @@ class ClipmanWindow(Adw.ApplicationWindow):
         text_box.append(subtitle)
         row.append(text_box)
 
+        # Actions sit in a box that fades in on row hover (always shown for
+        # pinned rows) — docs/design mockup. See .clip-actions in style.css.
+        actions = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=2)
+        actions.add_css_class("clip-actions")
+        actions.set_valign(Gtk.Align.CENTER)
+
         pin_btn = Gtk.Button()
         pin_btn.add_css_class("flat")
         pin_btn.set_valign(Gtk.Align.CENTER)
         pin_btn.connect("clicked", self._lv_pin_clicked, row)
-        row.append(pin_btn)
+        actions.append(pin_btn)
 
         del_btn = Gtk.Button.new_from_icon_name("user-trash-symbolic")
         del_btn.add_css_class("flat")
         del_btn.set_valign(Gtk.Align.CENTER)
         del_btn.set_tooltip_text(_("Delete"))
         del_btn.connect("clicked", self._lv_delete_clicked, row)
-        row.append(del_btn)
+        actions.append(del_btn)
+        row.append(actions)
 
         row._clip_icon = icon
+        row._clip_tile = tile
         row._clip_thumb = thumb
         row._clip_title = title
         row._clip_subtitle = subtitle
         row._clip_pin = pin_btn
         row._clip_del = del_btn
+        row._clip_actions = actions
         row._clip_item = None
         list_item.set_child(row)
 
@@ -991,7 +1075,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
             subtitle = ts
         row._clip_subtitle.set_text(subtitle)
 
-        # Image rows show a thumbnail; everything else shows the type icon.
+        # Image rows show a thumbnail; everything else shows a coloured tile.
         texture = (
             self._thumbnail_texture(entry.get("image_path"))
             if ctype == "image" else None
@@ -999,22 +1083,24 @@ class ClipmanWindow(Adw.ApplicationWindow):
         if texture is not None:
             row._clip_thumb.set_paintable(texture)
             row._clip_thumb.set_visible(True)
-            row._clip_icon.set_visible(False)
+            row._clip_tile.set_visible(False)
         else:
             row._clip_thumb.set_paintable(None)
             row._clip_thumb.set_visible(False)
-            row._clip_icon.set_from_icon_name(
-                TYPE_ICONS.get(ctype, "text-x-generic-symbolic")
-            )
-            row._clip_icon.set_visible(True)
+            rtype = "image" if ctype == "image" else _classify_text(text)
+            self._set_tile(row, rtype)
 
         pinned = entry.get("pinned")
         row._clip_pin.set_icon_name(
             "starred-symbolic" if pinned else "non-starred-symbolic"
         )
         row._clip_pin.set_tooltip_text(_("Unpin") if pinned else _("Pin"))
-        row._clip_pin.set_visible(True)
-        row._clip_del.set_visible(True)
+        row._clip_actions.set_visible(True)
+        # Pinned rows keep their actions visible; others fade in on hover.
+        if pinned:
+            row.add_css_class("pinned")
+        else:
+            row.remove_css_class("pinned")
 
     def _bind_snippet_row(self, row, snippet):
         row._clip_title.set_text(snippet["name"])
@@ -1022,11 +1108,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
         row._clip_subtitle.set_text(preview[:120])
         row._clip_thumb.set_paintable(None)
         row._clip_thumb.set_visible(False)
-        row._clip_icon.set_from_icon_name(TYPE_ICONS["snip"])
-        row._clip_icon.set_visible(True)
+        self._set_tile(row, "snip")
         # Snippets are managed in the Snippets dialog — no inline pin/delete.
-        row._clip_pin.set_visible(False)
-        row._clip_del.set_visible(False)
+        row._clip_actions.set_visible(False)
+        row.remove_css_class("pinned")
+
+    def _set_tile(self, row, rtype):
+        """Show the coloured type tile for ``rtype`` (text/link/code/image/
+        snip): swap its type CSS class and icon."""
+        tile = row._clip_tile
+        for cls in _TILE_TYPE_CLASSES:
+            tile.remove_css_class(cls)
+        tile.add_css_class(f"type-{rtype}")
+        row._clip_icon.set_from_icon_name(
+            ROW_TYPE_ICONS.get(rtype, "text-x-generic-symbolic")
+        )
+        tile.set_visible(True)
 
     def _lv_pin_clicked(self, button, row):
         item = row._clip_item

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -260,6 +260,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._use_catppuccin = (
             self.db.get_setting("use_catppuccin", "true") != "false"
         )
+        self._show_count_badges = (
+            self.db.get_setting("show_count_badges", "true") != "false"
+        )
 
         self._font_color = self.db.get_setting(
             "font_color", DEFAULT_FONT_COLOR
@@ -703,8 +706,13 @@ class ClipmanWindow(Adw.ApplicationWindow):
         return False
 
     def _update_filter_counts(self):
-        """Refresh the count badge on each switcher tab."""
+        """Refresh the count badge on each switcher tab (honours the
+        ``show_count_badges`` preference)."""
         if not hasattr(self, "_filter_count_labels"):
+            return
+        if not self._show_count_badges:
+            for label in self._filter_count_labels.values():
+                label.set_visible(False)
             return
         try:
             counts = {
@@ -718,6 +726,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
             return
         for fid, label in self._filter_count_labels.items():
             label.set_text(str(counts.get(fid, 0)))
+            label.set_visible(True)
 
     def _update_count(self, n):
         """Set the footer item/snippet count for the current view."""
@@ -1648,6 +1657,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         elif key == "use_catppuccin":
             self._use_catppuccin = str(value).lower() not in ("false", "0", "")
             self._apply_css()
+        elif key == "show_count_badges":
+            self._show_count_badges = str(value).lower() not in (
+                "false", "0", ""
+            )
+            self._update_filter_counts()
         elif key == "font_size":
             try:
                 self._font_size = max(8, min(20, int(value)))

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import time
+from datetime import date, datetime, timedelta
 from string import Template
 
 import gi
@@ -567,16 +568,28 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # Virtualized list: Gio.ListStore feeds a Gtk.ListView through a
         # recycling factory, so only the visible rows (~a dozen) are ever
         # built — opening the popup and switching filters no longer rebuilds
-        # every row. SingleSelection keeps a keyboard cursor for arrow-nav
-        # and the P / Delete / Enter shortcuts.
+        # every row. A Gtk.SortListModel groups entries into dated sections
+        # (★ Pinned / Today / Yesterday / Earlier), rendered as list
+        # headers. SingleSelection keeps a keyboard cursor for arrow-nav and
+        # the P / Delete / Enter shortcuts.
         self._store = Gio.ListStore(item_type=ClipItem)
-        self._selection = Gtk.SingleSelection(model=self._store)
+        self._sort_sorter = Gtk.CustomSorter.new(self._sort_cmp)
+        self._section_sorter = Gtk.CustomSorter.new(self._section_cmp)
+        self._sortmodel = Gtk.SortListModel(
+            model=self._store, sorter=self._sort_sorter
+        )
+        self._sortmodel.set_section_sorter(self._section_sorter)
+        self._selection = Gtk.SingleSelection(model=self._sortmodel)
         self._selection.set_autoselect(False)
         self._selection.set_can_unselect(True)
         factory = Gtk.SignalListItemFactory()
         factory.connect("setup", self._row_setup)
         factory.connect("bind", self._row_bind)
+        header_factory = Gtk.SignalListItemFactory()
+        header_factory.connect("setup", self._header_setup)
+        header_factory.connect("bind", self._header_bind)
         self.listview = Gtk.ListView(model=self._selection, factory=factory)
+        self.listview.set_header_factory(header_factory)
         self.listview.set_single_click_activate(True)
         self.listview.add_css_class("clipman-list")
         self.listview.connect("activate", self._on_list_activate)
@@ -640,6 +653,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def refresh(self):
         is_snippets = self._active_filter == "snippets"
+        # Dated sections apply to clipboard history, not the flat snippet list.
+        self._sortmodel.set_section_sorter(
+            None if is_snippets else self._section_sorter
+        )
 
         if is_snippets:
             entries = (
@@ -1153,6 +1170,67 @@ class ClipmanWindow(Adw.ApplicationWindow):
         else:
             self._bind_entry_row(row, item.data)
 
+    # ------------------------------------------------------------------
+    # Section grouping: ★ Pinned / Today / Yesterday / Earlier
+    # ------------------------------------------------------------------
+
+    def _compute_bucket(self, item):
+        """Return (order, label) for the item's dated section."""
+        if item.kind != "entry":
+            return (0, "")
+        entry = item.data
+        if entry.get("pinned"):
+            return (0, _("★ Pinned"))
+        try:
+            d = datetime.fromtimestamp(entry.get("accessed_at") or 0).date()
+        except (OSError, OverflowError, ValueError):
+            return (4, _("Older"))
+        today = date.today()
+        if d >= today:
+            return (1, _("Today"))
+        if d == today - timedelta(days=1):
+            return (2, _("Yesterday"))
+        if d > today - timedelta(days=7):
+            return (3, _("Earlier this week"))
+        return (4, _("Older"))
+
+    def _bucket(self, item):
+        """Cached section (order, label) for ``item`` — recomputed per
+        refresh since ClipItems are rebuilt each time."""
+        b = getattr(item, "_bucket", None)
+        if b is None:
+            b = self._compute_bucket(item)
+            item._bucket = b
+        return b
+
+    @staticmethod
+    def _sort_ts(item):
+        if item.kind == "entry":
+            return item.data.get("accessed_at") or 0
+        return 0
+
+    def _sort_cmp(self, a, b, _u):
+        oa, ob = self._bucket(a)[0], self._bucket(b)[0]
+        if oa != ob:
+            return -1 if oa < ob else 1
+        ta, tb = self._sort_ts(a), self._sort_ts(b)  # newest first in-section
+        if ta != tb:
+            return -1 if ta > tb else 1
+        return 0
+
+    def _section_cmp(self, a, b, _u):
+        oa, ob = self._bucket(a)[0], self._bucket(b)[0]
+        return -1 if oa < ob else (1 if oa > ob else 0)
+
+    def _header_setup(self, _factory, header):
+        label = Gtk.Label(xalign=0)
+        label.add_css_class("clip-section-header")
+        header.set_child(label)
+
+    def _header_bind(self, _factory, header):
+        item = header.get_item()
+        header.get_child().set_text(self._bucket(item)[1] if item else "")
+
     def _bind_entry_row(self, row, entry):
         ctype = entry.get("content_type") or "text"
         text = entry.get("content_text") or ""
@@ -1574,7 +1652,8 @@ class ClipmanWindow(Adw.ApplicationWindow):
         dialog.present(self)
 
     def _on_list_activate(self, _listview, position):
-        item = self._store.get_item(position)
+        # Position indexes the sorted/section model the ListView shows.
+        item = self._selection.get_item(position)
         if item is None:
             return
         if item.kind == "snippet":
@@ -1720,7 +1799,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # the user can start arrow-navigating rows. Up/Down within the
         # list itself is native to Gtk.ListView.
         if keyval == Gdk.KEY_Down and search_focused:
-            if self._store.get_n_items() > 0:
+            if self._selection.get_n_items() > 0:
                 if self._selection.get_selected() == Gtk.INVALID_LIST_POSITION:
                     self._selection.set_selected(0)
                 self.listview.grab_focus()
@@ -1748,12 +1827,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """Return the selected ``ClipItem``, or the first item if none is
         selected. Returns ``None`` when the list is empty.
         """
-        if self._store.get_n_items() == 0:
+        if self._selection.get_n_items() == 0:
             return None
         pos = self._selection.get_selected()
         if pos == Gtk.INVALID_LIST_POSITION:
-            return self._store.get_item(0)
-        return self._store.get_item(pos)
+            return self._selection.get_item(0)
+        return self._selection.get_item(pos)
 
     def _activate_selected(self):
         """Paste the selected item (or the first item if none selected).

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -282,10 +282,10 @@ class TestWindowConstruction(unittest.TestCase):
         """Every row type icon must exist so no broken-icon placeholder shows."""
         from gi.repository import Gdk, Gtk
 
-        from clipman.window import TYPE_ICONS
+        from clipman.window import ROW_TYPE_ICONS
 
         theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
-        for name in TYPE_ICONS.values():
+        for name in ROW_TYPE_ICONS.values():
             self.assertTrue(theme.has_icon(name), name)
     def test_preferences_is_in_surface_dialog(self):
         """Preferences must be an Adw.Dialog (in-surface), not a top-level.


### PR DESCRIPTION
## Redesign the popup to match the `docs/design` mockups

Brings the shipped GTK4 popup in line with the marketing mockups (`docs/design/main-window.html`, `tokens.css`), verified on-device in light and dark. All commits keep the virtualized list from #150.

### What changed
- **Colour-coded type icons** — per-type tinted symbolic icons (text=blue, link=cyan, code=teal, image=purple, snippet=gold). Text is classified into link (URL) / code (conservative heuristic) / plain text. No heavy background chips.
- **Hover-reveal row actions** — pin/delete fade in on hover; pinned rows keep them.
- **Footer** — item/snippet count · recording (or paused) status pill · Clear all (removes unpinned, keeps pinned + snippets, behind a destructive confirm).
- **Switcher** — All / Text / Images / Snippets with live count badges (honours the existing `show_count_badges` preference).
- **Day-grouping** — history grouped into ★ Pinned / Today / Yesterday / Earlier this week / Older via a `Gtk.SortListModel` section sorter + `GtkListView` header factory. Newest-first within each; snippets stay flat.
- **Generic font-colour picker** — replaces the fixed presets (several were low-contrast in light mode) with a native `Gtk.ColorDialogButton` + reset. `_resolve_font_color` accepts raw `#rrggbb`.
- **Accent colour picker** — choose any accent (toggles, active tabs, focus, recording pill); a luminance-based foreground keeps switch knobs / active-tab text readable. Reset returns to the Catppuccin/system default.
- **WCAG-AA light mode** — measured every text/background pair; Latte's muted `#4c4f69` was failing AA once faded. Introduced a theme-aware `@clip_dim` secondary-text token (Catppuccin subtext: `#5c5f77` light 5.5:1, `#a6adc8` dark 7.4:1) and darkened the light type-icon colours (link/code/snip 3.3–4.4:1 → 6.3–6.7:1). All light-mode text now clears 4.5:1.

### Notes
- Colour tokens (`@type_*`, `@clip_dim`) are injected independently of the Catppuccin toggle, so they resolve whether Catppuccin is on or following the system theme.
- Behaviour preserved: click/Enter-to-paste, ↑/↓ nav, Down-from-search, P-pin, Delete — now read through the sorted/section model.

### Tests
326 pass (headless GTK4 via xvfb). Verified light + dark screenshots for the row redesign, switcher, footer, and day-grouping; accent picker override confirmed (custom accent applied to active tab/focus/pill with contrast-aware text).

Closes the UI/UX modernization items from the post-GTK4 tracker (#132).
