### PR TITLE
fix+ux: incognito applies immediately, stone light theme, sidebar Preferences

### DIFF
--- a/clipman/app.py
+++ b/clipman/app.py
@@ -56,7 +56,8 @@ class ClipmanApp(Adw.Application):
         # the window so the header toggle, tooltip and privacy banner all
         # reflect it — previously this setting was saved but never read, so
         # "start in incognito" silently did nothing and clips were recorded.
-        if self.db.get_setting("incognito_on_launch", "false") == "true":
+        if (self.db.get_setting("incognito_on_launch", "false") or "").strip(
+        ).lower() == "true":
             self.window.set_incognito(True)
 
         # Register the D-Bus service BEFORE calling hold() — if another

--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -156,7 +156,14 @@ class ClipmanPreferences(Adw.PreferencesDialog):
     # ------------------------------------------------------------------
 
     def _save(self, key, value):
-        """Persist + notify. ``value`` is coerced to ``str`` for SQLite."""
+        """Persist + notify. ``value`` is coerced to ``str`` for SQLite.
+
+        Booleans are stored lowercase (``true``/``false``) — Python's
+        ``str(True)`` is ``"True"``, which broke case-sensitive readers
+        (e.g. ``incognito_on_launch == "true"`` in app.py never matched).
+        """
+        if isinstance(value, bool):
+            value = "true" if value else "false"
         self.db.set_setting(key, str(value))
         try:
             self._on_setting_changed(key, value)
@@ -243,9 +250,7 @@ class ClipmanPreferences(Adw.PreferencesDialog):
         catppuccin_row.set_subtitle(
             _("Off: follow your system GNOME theme and accent color.")
         )
-        catppuccin_row.set_active(
-            self.db.get_setting("use_catppuccin", "true") != "false"
-        )
+        catppuccin_row.set_active(self._get_bool("use_catppuccin", True))
         catppuccin_row.connect(
             "notify::active",
             lambda row, _pspec: self._save(

--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -115,14 +115,16 @@ EVENT_KEYS = frozenset({
 })
 
 
-class ClipmanPreferences(Adw.PreferencesDialog):
-    """Six-pane preferences dialog.
+class ClipmanPreferences(Adw.Dialog):
+    """Six-pane preferences dialog with a left sidebar.
 
-    An ``Adw.PreferencesDialog`` (not a separate top-level window) so it
-    presents in-surface, anchored to the popup via ``present(parent)``.
-    A top-level ``Adw.PreferencesWindow`` opened *behind* the popup on
-    Wayland and looked unresponsive. ``parent`` is accepted for call-site
-    compatibility; anchoring happens in the caller's ``present(parent)``.
+    An ``Adw.Dialog`` (not a separate top-level window) so it presents
+    in-surface, anchored to the popup via ``present(parent)`` — a
+    top-level window opened *behind* the popup on Wayland and looked
+    unresponsive. The layout matches ``docs/design/preferences.html``:
+    a persistent icon+label sidebar on the left and the selected page on
+    the right (Adw.PreferencesDialog's bottom view-switcher tabs read as
+    cramped at this size).
 
     ``on_setting_changed`` is a callable that the parent window passes
     in; it's invoked with ``(key, value)`` whenever any persisted
@@ -140,16 +142,87 @@ class ClipmanPreferences(Adw.PreferencesDialog):
         # ClipmanWindow passed in) for the backup/restore choosers.
         self._parent_window = parent
 
-        # Adw.Dialog manages its own sizing/stacking — no set_modal /
-        # set_transient_for / set_default_size (those are Window APIs).
-        self.set_search_enabled(True)
+        self.set_title(_("Preferences"))
+        self.set_content_width(760)
+        self.set_content_height(560)
 
-        self.add(self._build_appearance_page())
-        self.add(self._build_privacy_page())
-        self.add(self._build_shortcuts_page())
-        self.add(self._build_storage_page())
-        self.add(self._build_updates_page())
-        self.add(self._build_about_page())
+        # Pages carry their own title + icon; the sidebar reads both.
+        self._stack = Gtk.Stack()
+        self._stack.set_hexpand(True)
+        self._stack.set_vexpand(True)
+
+        self._sidebar = Gtk.ListBox()
+        self._sidebar.add_css_class("navigation-sidebar")
+        self._sidebar.set_selection_mode(Gtk.SelectionMode.BROWSE)
+        self._sidebar.connect("row-selected", self._on_nav_selected)
+
+        for pid, page in [
+            ("appearance", self._build_appearance_page()),
+            ("privacy", self._build_privacy_page()),
+            ("shortcuts", self._build_shortcuts_page()),
+            ("storage", self._build_storage_page()),
+            ("updates", self._build_updates_page()),
+            ("about", self._build_about_page()),
+        ]:
+            self._stack.add_named(page, pid)
+            row = Gtk.ListBoxRow()
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+            box.set_margin_top(8)
+            box.set_margin_bottom(8)
+            box.set_margin_start(6)
+            box.set_margin_end(6)
+            box.append(Gtk.Image.new_from_icon_name(page.get_icon_name()))
+            box.append(Gtk.Label(label=page.get_title(), xalign=0))
+            row.set_child(box)
+            row._page_id = pid
+            row._page_title = page.get_title()
+            self._sidebar.append(row)
+
+        self._title_widget = Adw.WindowTitle(
+            title=_("Preferences"), subtitle=""
+        )
+        header = Adw.HeaderBar()
+        header.set_title_widget(self._title_widget)
+
+        sidebar_scroll = Gtk.ScrolledWindow()
+        sidebar_scroll.set_policy(
+            Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC
+        )
+        sidebar_scroll.set_child(self._sidebar)
+        sidebar_scroll.set_size_request(180, -1)
+        sidebar_scroll.add_css_class("prefs-sidebar")
+
+        content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        content.append(sidebar_scroll)
+        content.append(
+            Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+        )
+        content.append(self._stack)
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(content)
+        self.set_child(toolbar_view)
+
+        self._sidebar.select_row(self._sidebar.get_row_at_index(0))
+
+    def _on_nav_selected(self, _listbox, row):
+        if row is None:
+            return
+        self._stack.set_visible_child_name(row._page_id)
+        self._title_widget.set_title(row._page_title)
+
+    def show_page(self, page_id):
+        """Select ``page_id`` in the sidebar (deep links from edge states)."""
+        i = 0
+        while True:
+            row = self._sidebar.get_row_at_index(i)
+            if row is None:
+                break
+            if row._page_id == page_id:
+                self._sidebar.select_row(row)
+                break
+            i += 1
 
     # ------------------------------------------------------------------
     # Generic helpers
@@ -425,9 +498,10 @@ class ClipmanPreferences(Adw.PreferencesDialog):
         )
 
         incog_row = Adw.SwitchRow()
-        incog_row.set_title(_("Start in incognito mode"))
+        incog_row.set_title(_("Incognito mode"))
         incog_row.set_subtitle(
-            _("Useful on shared machines or before opening a password manager.")
+            _("Takes effect immediately and applies on every launch. "
+              "Useful on shared machines or before a password manager.")
         )
         incog_row.set_active(self._get_bool("incognito_on_launch", False))
         incog_row.connect(
@@ -607,7 +681,9 @@ class ClipmanPreferences(Adw.PreferencesDialog):
         page.add(cap_group)
 
         backup_group = Adw.PreferencesGroup()
-        backup_group.set_title(_("Backup & restore"))
+        # Group titles are parsed as Pango markup — a bare "&" logs a
+        # markup-parse warning and drops the text; escape it.
+        backup_group.set_title(_("Backup &amp; restore"))
         backup_group.set_description(
             _("Export your history as a portable .clipman file.")
         )

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -231,6 +231,15 @@
     background-color: alpha(@error_color, 0.12);
 }
 
+/* Preferences sidebar (docs/design/preferences.html) ------------------ */
+
+.prefs-sidebar {
+    background-color: mix(@window_bg_color, @window_fg_color, 0.03);
+}
+.prefs-sidebar listbox {
+    background-color: transparent;
+}
+
 /* Status page (empty / no-results) ----------------------------------- */
 
 .clipman-window statuspage {

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -100,13 +100,18 @@
    hairline separators, the standard Adwaita grouped list). Do NOT give
    each row its own border/background/radius/margin — that stacks a card
    inside the card and reads as heavy, cluttered chips. Keep only sizing. */
+/* Rows read as elevated cards on the window background (mockup
+   .group-rows: bg-surface + hairline dividers). Contiguous rows in a
+   section form one card block; the dated header sits on the window bg. */
 .clipman-list > row {
     padding: 2px 4px;
     min-height: 44px;
+    background-color: @card_bg_color;
+    border-bottom: 1px solid alpha(@window_fg_color, 0.06);
 }
 
 .clipman-list > row:hover {
-    background-color: alpha(@accent_color, 0.06);
+    background-color: mix(@card_bg_color, @window_fg_color, 0.05);
 }
 
 .clipman-list > row:selected,
@@ -151,12 +156,15 @@
 .clip-tile.type-image > image { color: @type_image; }
 .clip-tile.type-snip  > image { color: @type_snip; }
 
-/* Dated section headers (★ Pinned / Today / Yesterday / Earlier). */
+/* Dated section headers (★ PINNED / TODAY / …). Uppercased in code
+   (GTK CSS has no text-transform); tracked out like the mockup's
+   .group-header (letter-spacing 0.06em). */
 .clip-section-header {
     font-size: 0.72em;
-    font-weight: 700;
+    font-weight: 600;
+    letter-spacing: 0.8px;
     color: @clip_dim;
-    margin: 8px 4px 2px 6px;
+    margin: 10px 4px 3px 6px;
 }
 
 /* Row actions (pin / delete) fade in on hover; pinned rows keep them on. */
@@ -185,24 +193,24 @@
 .recording-pill {
     padding: 2px 8px;
     border-radius: 9999px;
-    background-color: alpha(@accent_color, 0.14);
+    background-color: alpha(@success_color, 0.14);
     min-height: 0;
     box-shadow: none;
 }
 .recording-pill:hover {
-    background-color: alpha(@accent_color, 0.24);
+    background-color: alpha(@success_color, 0.24);
 }
 .recording-pill.paused:hover {
     background-color: alpha(@warning_color, 0.26);
 }
 .recording-pill label {
-    color: @accent_color;
+    color: @success_color;
     font-size: 0.78em;
     font-weight: 500;
 }
 .recording-pill image {
     -gtk-icon-size: 11px;
-    color: @accent_color;
+    color: @success_color;
 }
 .recording-pill.paused {
     background-color: alpha(@warning_color, 0.16);
@@ -213,7 +221,7 @@
 }
 
 .clipman-clear {
-    color: @clip_dim;
+    color: @error_color;
     font-size: 0.82em;
     padding: 2px 8px;
     min-height: 0;

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -186,6 +186,14 @@
     padding: 2px 8px;
     border-radius: 9999px;
     background-color: alpha(@accent_color, 0.14);
+    min-height: 0;
+    box-shadow: none;
+}
+.recording-pill:hover {
+    background-color: alpha(@accent_color, 0.24);
+}
+.recording-pill.paused:hover {
+    background-color: alpha(@warning_color, 0.26);
 }
 .recording-pill label {
     color: @accent_color;

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -2058,6 +2058,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """
         self.set_visible(True)
         self.present()
+        # Keep the footer status pill in sync with the real incognito state
+        # on every show — covers incognito-on-launch and any path that set
+        # it while the popup was hidden, so it never shows "Recording" while
+        # incognito is actually on.
+        self._update_recording_pill(self._incognito_btn.get_active())
         # grab_focus no-ops on a not-yet-focused Wayland toplevel; defer.
         GLib.idle_add(self.search_entry.grab_focus)
         if self._cursor_move_id:

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -266,11 +266,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # When off, don't force the Catppuccin @-token overrides so the app
         # follows the user's system GNOME/Adwaita theme + accent. Default on.
         self._use_catppuccin = (
-            self.db.get_setting("use_catppuccin", "true") != "false"
-        )
+            self.db.get_setting("use_catppuccin", "true") or ""
+        ).strip().lower() != "false"
         self._show_count_badges = (
-            self.db.get_setting("show_count_badges", "true") != "false"
-        )
+            self.db.get_setting("show_count_badges", "true") or ""
+        ).strip().lower() != "false"
         self._accent_color = (
             self.db.get_setting("accent_color", "default") or "default"
         )
@@ -678,17 +678,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
         footer.append(self._count_label)
 
         # Recording / incognito status pill (reflects the header toggle).
-        self._recording_pill = Gtk.Box(
-            orientation=Gtk.Orientation.HORIZONTAL, spacing=4
-        )
+        # Clickable status pill: shows Recording/Paused and toggles incognito
+        # (the mockup's footer indicator — replaces the bulky in-list banner).
+        self._recording_pill = Gtk.Button()
         self._recording_pill.add_css_class("recording-pill")
+        self._recording_pill.add_css_class("flat")
         self._recording_pill.set_valign(Gtk.Align.CENTER)
+        self._recording_pill.set_tooltip_text(_("Toggle incognito"))
+        self._recording_pill.connect("clicked", self._on_recording_pill_clicked)
+        pill_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
         self._recording_icon = Gtk.Image.new_from_icon_name(
             "media-record-symbolic"
         )
         self._recording_label = Gtk.Label(label=_("Recording"))
-        self._recording_pill.append(self._recording_icon)
-        self._recording_pill.append(self._recording_label)
+        pill_box.append(self._recording_icon)
+        pill_box.append(self._recording_label)
+        self._recording_pill.set_child(pill_box)
         footer.append(self._recording_pill)
 
         clear_btn = Gtk.Button(label=_("Clear all"))
@@ -1726,6 +1731,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self.db.delete_entry(entry_id)
         self.refresh()
 
+    def _on_recording_pill_clicked(self, _button):
+        """Footer pill toggles incognito (drives the header toggle so the
+        monitor, tooltip and pill all update through one handler)."""
+        self._incognito_btn.set_active(not self._incognito_btn.get_active())
+
     def _update_recording_pill(self, incognito):
         """Reflect incognito state in the footer status pill."""
         if not hasattr(self, "_recording_pill"):
@@ -1750,13 +1760,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
             if active
             else _("Incognito mode: OFF")
         )
-        # Surface (or clear) the privacy banner so the state is visible and
-        # the "Resume recording" action is reachable. Without this the
-        # incognito-on banner and its resume action were dead code.
-        if active:
-            self._show_edge_state("incognito-on")
-        else:
-            self._dismiss_edge_banner("incognito-on")
+        # The footer "Paused" pill (and this header toggle) are the incognito
+        # indicators now — no heavy in-list banner. Clear any stale one.
+        self._dismiss_edge_banner("incognito-on")
 
     def set_incognito(self, active):
         """Public entry point to set incognito state (used at launch).

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -1031,12 +1031,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._dismiss_edge_banner()
 
     def _action_open_prefs_privacy(self):
-        # Adw.PreferencesWindow auto-selects the first matching page;
-        # we expose the privacy pane via search to be deep-link friendly.
-        self._on_prefs_clicked(None)
+        self._on_prefs_clicked(None, page="privacy")
 
     def _action_open_prefs_storage(self):
-        self._on_prefs_clicked(None)
+        self._on_prefs_clicked(None, page="storage")
 
     def _action_retry_backup(self):
         # The retry flow is owned by the preferences window — bring
@@ -1780,12 +1778,14 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """
         self._incognito_btn.set_active(bool(active))
 
-    def _on_prefs_clicked(self, _button):
+    def _on_prefs_clicked(self, _button, page=None):
         from clipman.preferences import ClipmanPreferences
 
         prefs = ClipmanPreferences(
             self.db, self, on_setting_changed=self._on_setting_changed
         )
+        if page:
+            prefs.show_page(page)
         # In-surface dialog anchored to the popup so it can't open behind
         # it on Wayland; tracked so dismiss-on-focus-loss is guarded.
         self._register_child(prefs)
@@ -1815,6 +1815,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
         elif key == "accent_color":
             self._accent_color = value or "default"
             self._apply_css()
+        elif key == "incognito_on_launch":
+            # The Privacy toggle must take effect immediately, not only on
+            # the next launch — flipping it while "Recording" stayed lit
+            # read as a broken switch. Drives the header toggle, monitor
+            # and footer pill through the one handler.
+            self.set_incognito(str(value).strip().lower() in ("true", "1"))
         elif key == "font_size":
             try:
                 self._font_size = max(8, min(20, int(value)))

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -87,34 +87,38 @@ _CATPPUCCIN_MOCHA = {
     "error_bg_color":      "#f38ba8",
     "error_fg_color":      "#1e1e2e",
 }
-_CATPPUCCIN_LATTE = {
-    "window_bg_color":     "#eff1f5",
-    "view_bg_color":       "#eff1f5",
-    "headerbar_bg_color":  "#e6e9ef",
-    "card_bg_color":       "#ccd0da",
-    "dialog_bg_color":     "#eff1f5",
-    "popover_bg_color":    "#ccd0da",
-    "window_fg_color":     "#4c4f69",
-    "view_fg_color":       "#4c4f69",
-    "headerbar_fg_color":  "#4c4f69",
-    "card_fg_color":       "#4c4f69",
-    "dialog_fg_color":     "#4c4f69",
-    "popover_fg_color":    "#4c4f69",
-    "accent_color":        "#8839ef",
-    "accent_bg_color":     "#8839ef",
-    "accent_fg_color":     "#eff1f5",
-    "destructive_color":   "#d20f39",
-    "destructive_bg_color":"#d20f39",
-    "destructive_fg_color":"#eff1f5",
-    "success_color":       "#40a02b",
-    "success_bg_color":    "#40a02b",
-    "success_fg_color":    "#eff1f5",
-    "warning_color":       "#df8e1d",
-    "warning_bg_color":    "#df8e1d",
-    "warning_fg_color":    "#eff1f5",
-    "error_color":         "#d20f39",
-    "error_bg_color":      "#d20f39",
-    "error_fg_color":      "#eff1f5",
+# Light theme — the mockup's "high-contrast stone + brand-blue" palette
+# (docs/design/tokens.css body.theme-light), NOT Catppuccin Latte: white
+# cards on stone-100, near-black text (16:1), punchy blue accent. Latte's
+# muted #4c4f69 text was the root of every light-mode readability issue.
+_STONE_LIGHT = {
+    "window_bg_color":     "#f5f5f4",
+    "view_bg_color":       "#f5f5f4",
+    "headerbar_bg_color":  "#e7e5e4",
+    "card_bg_color":       "#ffffff",
+    "dialog_bg_color":     "#f5f5f4",
+    "popover_bg_color":    "#ffffff",
+    "window_fg_color":     "#1c1917",
+    "view_fg_color":       "#1c1917",
+    "headerbar_fg_color":  "#1c1917",
+    "card_fg_color":       "#1c1917",
+    "dialog_fg_color":     "#1c1917",
+    "popover_fg_color":    "#1c1917",
+    "accent_color":        "#2563eb",
+    "accent_bg_color":     "#2563eb",
+    "accent_fg_color":     "#ffffff",
+    "destructive_color":   "#dc2626",
+    "destructive_bg_color":"#dc2626",
+    "destructive_fg_color":"#ffffff",
+    "success_color":       "#15803d",
+    "success_bg_color":    "#15803d",
+    "success_fg_color":    "#ffffff",
+    "warning_color":       "#b45309",
+    "warning_bg_color":    "#b45309",
+    "warning_fg_color":    "#ffffff",
+    "error_color":         "#dc2626",
+    "error_bg_color":      "#dc2626",
+    "error_fg_color":      "#ffffff",
 }
 DEFAULT_FONT_COLOR = "default"
 
@@ -152,11 +156,11 @@ _TYPE_COLORS_DARK = {
     "type_snip": "#f9e2af",
 }
 _TYPE_COLORS_LIGHT = {
-    "type_text": "#1d4ed8",
-    "type_link": "#155e75",
-    "type_code": "#115e59",
-    "type_image": "#7e22ce",
-    "type_snip": "#92400e",
+    "type_text": "#2563eb",
+    "type_link": "#0891b2",
+    "type_code": "#0d9488",
+    "type_image": "#9333ea",
+    "type_snip": "#b45309",
 }
 
 # Secondary ("dim") text colour, per effective theme. Catppuccin subtext
@@ -164,7 +168,7 @@ _TYPE_COLORS_LIGHT = {
 # failed in light mode because Latte's muted #4c4f69 text can't hold
 # contrast once faded. #a6adc8 = 7.4:1 on dark, #5c5f77 = 5.5:1 on light.
 _DIM_TEXT_DARK = "#a6adc8"
-_DIM_TEXT_LIGHT = "#5c5f77"
+_DIM_TEXT_LIGHT = "#57534e"
 
 _URL_RE = re.compile(r"^(https?://|www\.)\S+$", re.IGNORECASE)
 # Conservative code detection: only strong, code-specific signals so plain
@@ -355,7 +359,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         otherwise — matches the marketing mockup default.
         """
         if self._theme == "light":
-            palette = _CATPPUCCIN_LATTE
+            palette = _STONE_LIGHT
         elif self._theme == "dark":
             palette = _CATPPUCCIN_MOCHA
         else:  # auto — follow system, default dark
@@ -363,7 +367,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 is_dark = Adw.StyleManager.get_default().get_dark()
             except Exception:
                 is_dark = True
-            palette = _CATPPUCCIN_MOCHA if is_dark else _CATPPUCCIN_LATTE
+            palette = _CATPPUCCIN_MOCHA if is_dark else _STONE_LIGHT
         return "\n".join(
             f"@define-color {name} {hex_value};"
             for name, hex_value in palette.items()
@@ -1291,7 +1295,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def _header_bind(self, _factory, header):
         item = header.get_item()
-        header.get_child().set_text(self._bucket(item)[1] if item else "")
+        label = self._bucket(item)[1] if item else ""
+        # Uppercase like the mockup's group headers (GTK CSS has no
+        # text-transform, so do it here; .upper() is locale-aware enough
+        # for the translated bucket names).
+        header.get_child().set_text(label.upper())
 
     def _bind_entry_row(self, row, entry):
         ctype = entry.get("content_type") or "text"

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -294,12 +294,14 @@ class TestWindowConstruction(unittest.TestCase):
         Regression guard: as a top-level Adw.PreferencesWindow it opened
         behind the popup on Wayland and looked unresponsive.
         """
+        from gi.repository import Gtk
+
         from clipman.preferences import ClipmanPreferences
 
         db = self._make_db()
         prefs = ClipmanPreferences(db, None, on_setting_changed=None)
-        self.assertIsInstance(prefs, Adw.PreferencesDialog)
         self.assertIsInstance(prefs, Adw.Dialog)
+        self.assertNotIsInstance(prefs, Gtk.Window)
 
     def test_dismiss_on_focus_loss(self):
         """notify::is-active handler hides the popup when it loses focus,
@@ -659,7 +661,9 @@ class TestWindowConstruction(unittest.TestCase):
         # actually called something rather than the warning fallback.
         called: list[str] = []
         window._open_url = lambda url: called.append(("url", url))
-        window._on_prefs_clicked = lambda _b: called.append(("prefs", None))
+        window._on_prefs_clicked = (
+            lambda _b, page=None: called.append(("prefs", page))
+        )
         window._on_snippets_clicked = lambda _b: called.append(
             ("snippets", None)
         )

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -222,13 +222,12 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertTrue(hasattr(window, "refresh"))
         self.assertTrue(hasattr(window, "refresh_update_banner"))
 
-    def test_incognito_toggle_syncs_monitor_and_banner(self):
-        """set_incognito drives the monitor, button and privacy banner.
+    def test_incognito_toggle_syncs_monitor_button_and_pill(self):
+        """set_incognito drives the monitor, header button and footer pill.
 
-        Regression for two bugs: the incognito-on banner (and its
-        "Resume recording" action) was never surfaced by the toggle, and
-        set_incognito is the launch-time entry point for the previously
-        ignored incognito_on_launch setting.
+        The bulky in-list "incognito-on" banner was replaced by the footer
+        status pill (Recording/Paused). set_incognito is also the launch-time
+        entry point for the incognito_on_launch setting.
         """
         from unittest.mock import MagicMock
 
@@ -242,12 +241,14 @@ class TestWindowConstruction(unittest.TestCase):
         window.set_incognito(True)
         self.assertTrue(window._incognito_btn.get_active())
         monitor.set_incognito.assert_called_with(True)
-        self.assertIsNotNone(window._current_edge_banner)  # banner shown
+        self.assertEqual(window._recording_label.get_text(), "Paused")
+        self.assertTrue(window._recording_pill.has_css_class("paused"))
 
         window.set_incognito(False)
         self.assertFalse(window._incognito_btn.get_active())
         monitor.set_incognito.assert_called_with(False)
-        self.assertIsNone(window._current_edge_banner)  # banner dismissed
+        self.assertEqual(window._recording_label.get_text(), "Recording")
+        self.assertFalse(window._recording_pill.has_css_class("paused"))
 
     def test_preferences_window_constructs(self):
         from clipman.preferences import ClipmanPreferences
@@ -593,6 +594,22 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertIn(("font_size", 14), received)
         # And the value persisted to the DB as a stringified int.
         self.assertEqual(db.get_setting("font_size"), "14")
+
+    def test_save_stores_bools_lowercase(self):
+        """_save persists Python bools as lowercase 'true'/'false'.
+
+        Regression: str(True) == 'True', which broke case-sensitive readers
+        like app.py's `incognito_on_launch == 'true'` — the Privacy toggle
+        silently did nothing.
+        """
+        from clipman.preferences import ClipmanPreferences
+
+        db = self._make_db()
+        prefs = ClipmanPreferences(db, None, on_setting_changed=None)
+        prefs._save("incognito_on_launch", True)
+        self.assertEqual(db.get_setting("incognito_on_launch"), "true")
+        prefs._save("incognito_on_launch", False)
+        self.assertEqual(db.get_setting("incognito_on_launch"), "false")
 
     def test_refresh_update_banner_revealed(self):
         """should_show_banner -> (True, version) reveals the banner."""


### PR DESCRIPTION
## Post-redesign review fixes — incognito UX, stone light theme, sidebar Preferences

Fixes everything surfaced in the on-device review of the redesigned popup, verified live in light and dark.

### Incognito was confusing and partly broken
- **Privacy toggle did nothing** — two stacked bugs: `_save` stored Python bools as `"True"`/`"False"` while readers compared lowercase (`incognito_on_launch == "true"` never matched), and the setting was *launch-only* anyway. Booleans now persist lowercase (readers case-insensitive to heal old rows), and the toggle **applies immediately** while still persisting as the launch default.
- **Pill said "Recording" while incognito was on** — the footer pill only updated from the header toggle; it now re-syncs to the real state on every show.
- **The bulky "Incognito is on" banner** is gone; per the mockup, the footer pill is the indicator *and* the action (click toggles incognito; green "Recording" / amber "Paused").

### Light mode never matched the marketing site
We shipped Catppuccin Latte, whose muted `#4c4f69` text was behind every light-mode readability complaint. Light mode is now the mockups' **"high-contrast stone + brand-blue"** palette (`docs/design/tokens.css`): white card rows on stone-100, near-black text (16:1), blue `#2563eb` accent, green/amber/red semantics — the Preferences subtitle already promised "Light uses warm stone". Rows render as elevated cards with hairline dividers; dated section headers are **UPPERCASE** with letter-spacing; **Clear all** is error-red (all per `main-window.html`).

### Preferences matches `preferences.html`
Rebuilt as an `Adw.Dialog` with a persistent **left sidebar** (icon + label per page) and a `Gtk.Stack`, replacing the cramped bottom view-switcher tabs. Header title follows the selected page; edge-state deep links land on the right page via `show_page()`. Also escaped the bare `&` in "Backup & restore" (Pango markup warning dropped the label).

### Tests
327 pass (headless GTK4 via xvfb). New/updated: bools persist lowercase; incognito syncs monitor+button+pill; Preferences asserts `Adw.Dialog` (not `Gtk.Window`); full toggle→pill chain verified end-to-end on-device.

Part of the stabilization pass before the next stable release (#132).
