### PR TITLE
ux: element-level mockup parity — sensitive rows, richer metas, search chip, segmented switcher; Catppuccin-off follows GNOME

### DIFF
--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -143,8 +143,10 @@ class ClipmanPreferences(Adw.Dialog):
         self._parent_window = parent
 
         self.set_title(_("Preferences"))
+        # Tall enough that the Appearance page fits without a scrollbar
+        # (Adw.Dialog clamps to the work area on small screens anyway).
         self.set_content_width(760)
-        self.set_content_height(560)
+        self.set_content_height(690)
 
         # Pages carry their own title + icon; the sidebar reads both.
         self._stack = Gtk.Stack()
@@ -337,7 +339,7 @@ class ClipmanPreferences(Adw.Dialog):
         accent_group = Adw.PreferencesGroup()
         accent_group.set_title(_("Accent"))
         accent_group.set_description(
-            _("Color applied to clip text in the popup.")
+            _("Accent for controls and highlights; font color for clip text.")
         )
 
         # Accent colour picker — drives toggles, active tabs, focus rings,

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -44,32 +44,53 @@
     box-shadow: 0 0 0 2px alpha(@accent_color, 0.18);
 }
 
+/* Keyboard hint chip inside the search field (mockup .search .kbd) */
+.kbd-chip {
+    font-size: 10px;
+    padding: 1px 7px;
+    background-color: alpha(@window_fg_color, 0.06);
+    border: 1px solid alpha(@window_fg_color, 0.12);
+    border-radius: 4px;
+    color: @clip_dim;
+}
+
+/* Accent dot before the header title (mockup .title .pin-dot) */
+.pin-dot {
+    color: @accent_color;
+    font-size: 7px;
+    opacity: 0.75;
+}
+
 /* Filter pills ------------------------------------------------------- */
+
+.switcher-track {
+    background-color: alpha(@window_fg_color, 0.07);
+    border-radius: 10px;
+    padding: 2px;
+}
 
 .filter-tab {
     background-color: transparent;
     color: @clip_dim;
-    border: 1px solid alpha(@window_fg_color, 0.14);
-    border-radius: 999px;
+    border: none;
+    box-shadow: none;
+    border-radius: 8px;
     padding: 3px 12px;
     min-height: 22px;
     font-size: 0.9em;
 }
 
 .filter-tab:hover {
-    background-color: alpha(@window_fg_color, 0.06);
+    background-color: transparent;
     color: @window_fg_color;
 }
 
-.filter-tab-active {
-    background-color: @accent_color;
-    color: @accent_fg_color;
-    border-color: @accent_color;
-}
-
+/* Active tab: raised card on the track (mockup .switcher button.active) */
+.filter-tab-active,
 .filter-tab-active:hover {
-    background-color: @accent_color;
-    color: @accent_fg_color;
+    background-color: @card_bg_color;
+    color: @window_fg_color;
+    box-shadow: 0 1px 2px alpha(black, 0.15);
 }
 
 /* Count badge inside each switcher tab. */
@@ -85,8 +106,8 @@
     padding: 0;
 }
 .filter-tab-active .filter-count {
-    color: @accent_fg_color;
-    background-color: alpha(@accent_fg_color, 0.22);
+    color: @accent_color;
+    background-color: alpha(@accent_color, 0.15);
 }
 
 /* List + rows -------------------------------------------------------- */
@@ -166,6 +187,25 @@
     color: @clip_dim;
     margin: 10px 4px 3px 6px;
 }
+.clip-section-header.pinned {
+    color: @type_snip;
+}
+
+/* Pinned rows: gold edge tint fading into the card (mockup .is-pinned). */
+.clip-row.pinned {
+    background: linear-gradient(90deg,
+        alpha(@type_snip, 0.12), alpha(@type_snip, 0) 18%);
+}
+
+/* Sensitive rows: masked mono preview + warning countdown meta. */
+.clip-row .title.masked {
+    font-family: monospace;
+    letter-spacing: 2px;
+    color: @clip_dim;
+}
+.clip-row .subtitle.warning {
+    color: @warning_color;
+}
 
 /* Row actions (pin / delete) fade in on hover; pinned rows keep them on. */
 .clip-actions {
@@ -188,6 +228,7 @@
 .clipman-count {
     color: @clip_dim;
     font-size: 0.82em;
+    font-feature-settings: "tnum";
 }
 
 .recording-pill {

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -324,6 +324,15 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
         self._apply_theme()
         self._apply_css()
+        # While following the system (Catppuccin off, or theme auto) the
+        # GNOME preference can flip at any time — re-emit the theme-derived
+        # tokens (@clip_dim, @type_*) so they track the new scheme.
+        try:
+            Adw.StyleManager.get_default().connect(
+                "notify::dark", lambda *_a: self._apply_css()
+            )
+        except Exception:
+            logger.debug("StyleManager dark listener failed", exc_info=True)
         self._build_ui()
 
         # Re-evaluate update banner on startup so cached info isn't lost.
@@ -354,12 +363,29 @@ class ClipmanWindow(Adw.ApplicationWindow):
     # ------------------------------------------------------------------
 
     def _apply_theme(self):
-        scheme = {
-            "auto": Adw.ColorScheme.DEFAULT,
-            "dark": Adw.ColorScheme.FORCE_DARK,
-            "light": Adw.ColorScheme.FORCE_LIGHT,
-        }.get(self._theme, Adw.ColorScheme.FORCE_DARK)
+        # Catppuccin off means "follow your system GNOME theme" (the
+        # Preferences subtitle's promise): never force a scheme, let the
+        # system light/dark preference drive appearance. The in-app
+        # Light/Dark row applies when the Catppuccin theme is on.
+        if not self._use_catppuccin:
+            scheme = Adw.ColorScheme.DEFAULT
+        else:
+            scheme = {
+                "auto": Adw.ColorScheme.DEFAULT,
+                "dark": Adw.ColorScheme.FORCE_DARK,
+                "light": Adw.ColorScheme.FORCE_LIGHT,
+            }.get(self._theme, Adw.ColorScheme.FORCE_DARK)
         Adw.StyleManager.get_default().set_color_scheme(scheme)
+
+    def _effective_dark(self):
+        """Whether the popup is effectively dark right now — honours the
+        follow-system cases (Catppuccin off, or theme == auto)."""
+        if self._use_catppuccin and self._theme in ("dark", "light"):
+            return self._theme == "dark"
+        try:
+            return Adw.StyleManager.get_default().get_dark()
+        except Exception:
+            return True
 
     def _resolve_font_color(self):
         """Translate the ``font_color`` setting to a CSS colour value.
@@ -411,16 +437,8 @@ class ClipmanWindow(Adw.ApplicationWindow):
         tiles always resolve (falling back to system theme just means the
         surrounding chrome isn't Catppuccin — the tile hues still apply).
         """
-        if self._theme == "light":
-            colors = _TYPE_COLORS_LIGHT
-        elif self._theme == "dark":
-            colors = _TYPE_COLORS_DARK
-        else:  # auto — follow system, default dark
-            try:
-                is_dark = Adw.StyleManager.get_default().get_dark()
-            except Exception:
-                is_dark = True
-            colors = _TYPE_COLORS_DARK if is_dark else _TYPE_COLORS_LIGHT
+        colors = (_TYPE_COLORS_DARK if self._effective_dark()
+                  else _TYPE_COLORS_LIGHT)
         return "\n".join(
             f"@define-color {name} {value};"
             for name, value in colors.items()
@@ -430,16 +448,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """@clip_dim — the secondary-text colour for the effective theme.
         Always emitted (independent of the Catppuccin toggle) so CSS never
         references an undefined @clip_dim."""
-        if self._theme == "light":
-            dim = _DIM_TEXT_LIGHT
-        elif self._theme == "dark":
-            dim = _DIM_TEXT_DARK
-        else:
-            try:
-                is_dark = Adw.StyleManager.get_default().get_dark()
-            except Exception:
-                is_dark = True
-            dim = _DIM_TEXT_DARK if is_dark else _DIM_TEXT_LIGHT
+        dim = _DIM_TEXT_DARK if self._effective_dark() else _DIM_TEXT_LIGHT
         return f"@define-color clip_dim {dim};\n"
 
     def _accent_override_block(self):
@@ -1461,15 +1470,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def _gold_hex(self):
         """The pin/snippet gold for the effective theme (title star)."""
-        if self._theme == "light":
-            return _TYPE_COLORS_LIGHT["type_snip"]
-        if self._theme == "dark":
-            return _TYPE_COLORS_DARK["type_snip"]
-        try:
-            is_dark = Adw.StyleManager.get_default().get_dark()
-        except Exception:
-            is_dark = True
-        return (_TYPE_COLORS_DARK if is_dark
+        return (_TYPE_COLORS_DARK if self._effective_dark()
                 else _TYPE_COLORS_LIGHT)["type_snip"]
 
     def _sensitive_remaining(self, entry):
@@ -1955,6 +1956,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
             self._apply_css()  # palette block depends on the theme
         elif key == "use_catppuccin":
             self._use_catppuccin = str(value).lower() not in ("false", "0", "")
+            self._apply_theme()  # off -> follow the system scheme
             self._apply_css()
         elif key == "show_count_badges":
             self._show_count_badges = str(value).lower() not in (

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -220,6 +220,10 @@ def _format_bytes(n):
 # real content's length (mockup: .row.is-sensitive).
 _SENSITIVE_MASK = "•" * 13
 
+# Cache-miss sentinel for _img_info_cache (distinct from the cached None
+# that marks an unreadable image).
+_IMG_INFO_MISS = object()
+
 
 class ClipItem(GObject.Object):
     """A GObject wrapper around one history entry or snippet dict so it can
@@ -1485,16 +1489,16 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
         if not image_path or not _safe_image_path(image_path):
             return None
-        info = self._img_info_cache.get(image_path)
-        if info is None:
+        info = self._img_info_cache.get(image_path, _IMG_INFO_MISS)
+        if info is _IMG_INFO_MISS:
             try:
                 size_b = os.stat(image_path).st_size
                 fmt, w, h = GdkPixbuf.Pixbuf.get_file_info(image_path)
-                info = (size_b, w, h) if fmt is not None else ()
+                info = (size_b, w, h) if fmt is not None else None
             except (OSError, TypeError, ValueError):
-                info = ()
+                info = None
             self._img_info_cache[image_path] = info
-        return info or None
+        return info
 
     def _bind_snippet_row(self, row, snippet):
         row._clip_title.set_text(snippet["name"])

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -193,6 +193,34 @@ def _classify_text(text):
     return "text"
 
 
+def _domain_of(url):
+    """Bare hostname of a URL for the row meta ("github.com"), '' if none."""
+    from urllib.parse import urlparse
+
+    u = (url or "").strip()
+    if u.lower().startswith("www."):
+        u = "https://" + u
+    try:
+        host = urlparse(u).hostname or ""
+    except ValueError:
+        return ""
+    return host[4:] if host.startswith("www.") else host
+
+
+def _format_bytes(n):
+    """Short human size for the image row meta ("1.2 MB", "640 KB")."""
+    if n >= 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    if n >= 1024:
+        return f"{n // 1024} KB"
+    return f"{n} B"
+
+
+# Masked preview for sensitive rows — fixed length so it never leaks the
+# real content's length (mockup: .row.is-sensitive).
+_SENSITIVE_MASK = "•" * 13
+
+
 class ClipItem(GObject.Object):
     """A GObject wrapper around one history entry or snippet dict so it can
     live in a ``Gio.ListStore`` and feed ``Gtk.ListView``.
@@ -244,9 +272,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # (hash.png, immutable). Without this every refresh re-decoded every
         # image thumbnail — brutal for an image-heavy history.
         self._thumb_cache = {}
+        # (bytes, w, h) per image path for the row meta line — header sniff
+        # only, cached because paths are content-addressed/immutable.
+        self._img_info_cache = {}
 
         self.set_title("Clipman")
-        self.set_default_size(380, self._clamped_default_height())
+        self.set_default_size(420, self._clamped_default_height())
         # Win+V is a fixed overlay panel, not a resizable app window.
         self.set_resizable(False)
         self.add_css_class("clipman-window")
@@ -511,7 +542,15 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
         # -- Header bar (incognito start, prefs end) -----------------------
         header = Adw.HeaderBar()
-        header.set_title_widget(Adw.WindowTitle(title="Clipman", subtitle=""))
+        title_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        title_box.set_halign(Gtk.Align.CENTER)
+        pin_dot = Gtk.Label(label="\u25cf")
+        pin_dot.add_css_class("pin-dot")
+        title_label = Gtk.Label(label="Clipman")
+        title_label.add_css_class("heading")
+        title_box.append(pin_dot)
+        title_box.append(title_label)
+        header.set_title_widget(title_box)
         # The popup is its own GtkApplicationWindow but doubles as a
         # transient overlay — title-bar controls (close / minimise /
         # maximise) clash with the close-on-Escape interaction model.
@@ -572,17 +611,30 @@ class ClipmanWindow(Adw.ApplicationWindow):
         search_box.set_margin_start(8)
         search_box.set_margin_end(8)
         self.search_entry = Gtk.SearchEntry()
-        self.search_entry.set_placeholder_text(_("Search..."))
+        self.search_entry.set_placeholder_text(_("Search clipboard history…"))
         self.search_entry.set_hexpand(True)
         self.search_entry.add_css_class("clipman-search")
         self.search_entry.connect("search-changed", self._on_search_changed)
-        search_box.append(self.search_entry)
+        # Right-aligned keyboard hint inside the field (mockup's ⌘/ chip);
+        # "/" focuses the search from anywhere in the popup.
+        search_overlay = Gtk.Overlay()
+        search_overlay.set_hexpand(True)
+        search_overlay.set_child(self.search_entry)
+        kbd_chip = Gtk.Label(label="/")
+        kbd_chip.add_css_class("kbd-chip")
+        kbd_chip.set_halign(Gtk.Align.END)
+        kbd_chip.set_valign(Gtk.Align.CENTER)
+        kbd_chip.set_margin_end(10)
+        kbd_chip.set_can_target(False)  # clicks fall through to the entry
+        search_overlay.add_overlay(kbd_chip)
+        search_box.append(search_overlay)
         root.append(search_box)
 
         # -- Filter pill row ----------------------------------------------
         self._filter_box = Gtk.Box(
-            orientation=Gtk.Orientation.HORIZONTAL, spacing=6
+            orientation=Gtk.Orientation.HORIZONTAL, spacing=2
         )
+        self._filter_box.add_css_class("switcher-track")
         self._filter_box.set_margin_top(2)
         self._filter_box.set_margin_bottom(6)
         self._filter_box.set_margin_start(8)
@@ -1287,42 +1339,101 @@ class ClipmanWindow(Adw.ApplicationWindow):
         return -1 if oa < ob else (1 if oa > ob else 0)
 
     def _header_setup(self, _factory, header):
-        label = Gtk.Label(xalign=0)
-        label.add_css_class("clip-section-header")
-        header.set_child(label)
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        title = Gtk.Label(xalign=0)
+        title.add_css_class("clip-section-header")
+        title.set_hexpand(True)
+        count = Gtk.Label(xalign=1)
+        count.add_css_class("clip-section-header")
+        box.append(title)
+        box.append(count)
+        box._h_title = title
+        box._h_count = count
+        header.set_child(box)
 
     def _header_bind(self, _factory, header):
         item = header.get_item()
-        label = self._bucket(item)[1] if item else ""
+        box = header.get_child()
+        if item is None:
+            box._h_title.set_text("")
+            box._h_count.set_text("")
+            return
+        order, label = self._bucket(item)
         # Uppercase like the mockup's group headers (GTK CSS has no
         # text-transform, so do it here; .upper() is locale-aware enough
         # for the translated bucket names).
-        header.get_child().set_text(label.upper())
+        box._h_title.set_text(label.upper())
+        if order == 0:
+            # Pinned group: gold header + item count on the right (mockup
+            # .group-header.pinned with a trailing count).
+            box._h_title.add_css_class("pinned")
+            box._h_count.add_css_class("pinned")
+            n = sum(
+                1 for i in range(self._selection.get_n_items())
+                if self._bucket(self._selection.get_item(i))[0] == 0
+            )
+            box._h_count.set_text(str(n))
+        else:
+            box._h_title.remove_css_class("pinned")
+            box._h_count.remove_css_class("pinned")
+            box._h_count.set_text("")
 
     def _bind_entry_row(self, row, entry):
         ctype = entry.get("content_type") or "text"
         text = entry.get("content_text") or ""
-        first_line = text.split("\n", 1)[0].strip() if text else ""
-        if ctype == "image":
-            title = "[Image]"
-        else:
-            title = first_line[:120] or _("(empty)")
-        # Gtk.Label.set_text renders literally, so no markup-escaping needed.
-        row._clip_title.set_text(title)
-        # Lead with the relative time (the type icon already conveys type),
-        # plus a char count for text entries.
+        sensitive = bool(entry.get("sensitive"))
+        pinned = bool(entry.get("pinned"))
+        rtype = "image" if ctype == "image" else _classify_text(text)
         ts = self._format_time(entry["accessed_at"])
-        if ctype == "text" and text:
-            n = len(text)
-            subtitle = f"{ts} · {n:,} char{'s' if n != 1 else ''}"
+
+        # --- title + meta line (mockup .preview / .meta) -----------------
+        if sensitive:
+            # Masked preview: never render sensitive content, its length,
+            # or its thumbnail. Meta carries the auto-clear countdown.
+            title = _SENSITIVE_MASK
+            row._clip_title.add_css_class("masked")
+            row._clip_subtitle.add_css_class("warning")
+            remaining = self._sensitive_remaining(entry)
+            subtitle = _("Sensitive — auto-clear in {n} s").format(n=remaining)
         else:
-            subtitle = ts
+            row._clip_title.remove_css_class("masked")
+            row._clip_subtitle.remove_css_class("warning")
+            first_line = text.split("\n", 1)[0].strip() if text else ""
+            title = ("[Image]" if ctype == "image"
+                     else first_line[:120] or _("(empty)"))
+            if ctype == "image":
+                info = self._image_info(entry.get("image_path"))
+                if info:
+                    size_b, w, h = info
+                    subtitle = f"{ts} · {_format_bytes(size_b)} · {w}×{h}"
+                else:
+                    subtitle = ts
+            elif rtype == "link":
+                domain = _domain_of(text.strip())
+                subtitle = f"{ts} · {domain}" if domain else ts
+            elif rtype == "code":
+                subtitle = f"{ts} · " + _("Code")
+            elif text:
+                n = len(text)
+                subtitle = f"{ts} · {n:,} char{'s' if n != 1 else ''}"
+            else:
+                subtitle = ts
+
+        # Pinned rows lead with a gold star in the title (mockup
+        # .is-pinned .preview::before). Markup needs escaping.
+        if pinned:
+            row._clip_title.set_markup(
+                f'<span foreground="{self._gold_hex()}">★</span> '
+                + GLib.markup_escape_text(title)
+            )
+        else:
+            row._clip_title.set_text(title)
         row._clip_subtitle.set_text(subtitle)
 
-        # Image rows show a thumbnail; everything else shows a coloured tile.
+        # --- leading visual: thumbnail or coloured tile ------------------
         texture = (
             self._thumbnail_texture(entry.get("image_path"))
-            if ctype == "image" else None
+            if ctype == "image" and not sensitive else None
         )
         if texture is not None:
             row._clip_thumb.set_paintable(texture)
@@ -1331,20 +1442,58 @@ class ClipmanWindow(Adw.ApplicationWindow):
         else:
             row._clip_thumb.set_paintable(None)
             row._clip_thumb.set_visible(False)
-            rtype = "image" if ctype == "image" else _classify_text(text)
             self._set_tile(row, rtype)
+            if sensitive:
+                # Lock icon in the type-coloured tile (mockup is-sensitive).
+                row._clip_icon.set_from_icon_name("dialog-password-symbolic")
 
-        pinned = entry.get("pinned")
         row._clip_pin.set_icon_name(
             "starred-symbolic" if pinned else "non-starred-symbolic"
         )
         row._clip_pin.set_tooltip_text(_("Unpin") if pinned else _("Pin"))
         row._clip_actions.set_visible(True)
-        # Pinned rows keep their actions visible; others fade in on hover.
+        # Pinned rows keep their actions visible + a gold edge tint; others
+        # fade actions in on hover.
         if pinned:
             row.add_css_class("pinned")
         else:
             row.remove_css_class("pinned")
+
+    def _gold_hex(self):
+        """The pin/snippet gold for the effective theme (title star)."""
+        if self._theme == "light":
+            return _TYPE_COLORS_LIGHT["type_snip"]
+        if self._theme == "dark":
+            return _TYPE_COLORS_DARK["type_snip"]
+        try:
+            is_dark = Adw.StyleManager.get_default().get_dark()
+        except Exception:
+            is_dark = True
+        return (_TYPE_COLORS_DARK if is_dark
+                else _TYPE_COLORS_LIGHT)["type_snip"]
+
+    def _sensitive_remaining(self, entry):
+        """Seconds until the purge loop removes this sensitive entry."""
+        created = entry.get("created_at") or time.time()
+        return max(0, int(self._sensitive_timeout - (time.time() - created)))
+
+    def _image_info(self, image_path):
+        """(bytes, width, height) for an image row's meta, cached; None if
+        unreadable. Uses get_file_info (header sniff — no full decode)."""
+        from clipman.database import _safe_image_path
+
+        if not image_path or not _safe_image_path(image_path):
+            return None
+        info = self._img_info_cache.get(image_path)
+        if info is None:
+            try:
+                size_b = os.stat(image_path).st_size
+                fmt, w, h = GdkPixbuf.Pixbuf.get_file_info(image_path)
+                info = (size_b, w, h) if fmt is not None else ()
+            except (OSError, TypeError, ValueError):
+                info = ()
+            self._img_info_cache[image_path] = info
+        return info or None
 
     def _bind_snippet_row(self, row, snippet):
         row._clip_title.set_text(snippet["name"])
@@ -1875,6 +2024,18 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
         search_focused = self.search_entry.has_focus()
 
+        # "/" (or Ctrl+F) jumps to the search field from anywhere in the
+        # popup — advertised by the kbd chip inside the field.
+        if not search_focused and (
+            keyval == Gdk.KEY_slash
+            or (
+                keyval in (Gdk.KEY_f, Gdk.KEY_F)
+                and _state & Gdk.ModifierType.CONTROL_MASK
+            )
+        ):
+            self.search_entry.grab_focus()
+            return True
+
         # Down arrow from the search entry drops focus into the list so
         # the user can start arrow-navigating rows. Up/Down within the
         # list itself is native to Gtk.ListView.
@@ -1984,10 +2145,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """Pick a sensible default popup height for the current monitor.
 
         Uses the primary monitor's geometry and caps at 60% of its
-        height, with 540 as the upper bound. Falls back to 540 if the
-        monitor metadata isn't queryable (offscreen / headless CI).
+        height, with 640 (the mockup's popup height) as the upper bound.
+        Falls back to 640 if the monitor metadata isn't queryable
+        (offscreen / headless CI).
         """
-        default = 540
+        default = 640
         try:
             display = Gdk.Display.get_default()
             if display is None:


### PR DESCRIPTION
## Element-level mockup parity (main window) + Catppuccin-off follows GNOME

Driven by an element-by-element parity audit of `docs/design/main-window.html` vs the implementation (every gap adversarially verified with file:line evidence), plus a live bug report. Verified on a 2K display in light and dark.

### Row parity
- **Sensitive rows** (the big one): lock icon in the type tile, fixed-length masked preview — never leaks content, its length, or a thumbnail — and an amber **"Sensitive — auto-clear in N s"** countdown derived from the same `created_at` cutoff the purge loop uses.
- **Per-type metas**: links show their domain (`· github.com`), code shows `· Code`, images show size + dimensions (`· 4 KB · 1280×720`, header-sniffed via `get_file_info`, cached — no decode).
- **Pinned**: gold ★ before the title, gold edge tint on the row, gold **★ PINNED** section header with the group count on the right.

### Chrome parity
- **Search**: mockup placeholder ("Search clipboard history…"), a `/` kbd chip inside the field, and `/` or `Ctrl+F` focuses search from anywhere.
- **Switcher**: segmented track with flat tabs; the active tab is a raised card and its count badge is accent-on-accent-soft (was a filled accent pill).
- Header title gets the mockup's accent pin-dot; the popup is the mockup's **420×640** (height still clamps to 60% of the monitor); footer count uses tabular numerals.
- Preferences dialog grows to 690px so Appearance fits without a scrollbar on larger screens; stale "Accent" group description fixed.

### Catppuccin toggle honesty (live bug report)
"Off: follow your system GNOME theme" now does what it says: with the toggle off the popup uses `Adw.ColorScheme.DEFAULT` (system light/dark) instead of forcing the in-app choice. Theme-derived tokens (`@clip_dim`, `@type_*`, pinned gold) key off the effective scheme, and a `notify::dark` listener re-emits them when the system preference flips live.

### Tests
327 pass (headless GTK4 via xvfb). Both themes screenshot-verified against the mockup with a full row-variety fixture (pinned + sensitive + link + code + image).

Part of the stabilization pass (#132).
