### PR TITLE
ux(states): mockup parity — copy/tones, banners with dismiss, kbd hints, reachable triggers

### DIFF
--- a/clipman/edge_states.py
+++ b/clipman/edge_states.py
@@ -57,6 +57,10 @@ class StateSpec:
     body: str
     primary_action: tuple[str, str] | None = None
     secondary_action: tuple[str, str] | None = None
+    # Optional keyboard hint rendered under a statuspage's buttons as
+    # keycaps; tokens starting with an em-dash render as plain dim text
+    # (mockup: ['Super', 'V', '— or your custom shortcut']).
+    kbd: tuple[str, ...] | None = None
 
 
 # ---------------------------------------------------------------------
@@ -83,18 +87,20 @@ STATES: dict[str, StateSpec] = {
         tone="info",
         icon_name="edit-paste-symbolic",
         title=_("Nothing copied yet"),
-        body=_("Copy text or an image and it will appear here."),
+        body=_("Copy text or an image and it will appear here. The popup "
+               "stays hidden until you summon it."),
+        kbd=("Super", "V", _("— or your custom shortcut")),
     ),
     "no-snippets-yet": StateSpec(
         id="no-snippets-yet",
         kind="statuspage",
         tone="info",
-        icon_name="text-x-generic-symbolic",
+        icon_name="user-bookmarks-symbolic",
         title=_("No snippets yet"),
-        body=_("Snippets are reusable text fragments you can paste with "
-               "one click. Add some from Preferences -> Storage, or use "
-               "the New button when this list is showing."),
-        primary_action=(_("Add a snippet"), "open-snippets-dialog"),
+        body=_("Save reusable text — signatures, addresses, code stubs — "
+               "and paste them from here."),
+        primary_action=(_("Add snippet"), "open-snippets-dialog"),
+        kbd=("Ctrl", "N"),
     ),
     "no-results": StateSpec(
         id="no-results",
@@ -102,7 +108,8 @@ STATES: dict[str, StateSpec] = {
         tone="info",
         icon_name="system-search-symbolic",
         title=_("No clips match that search"),
-        body=_("Try a shorter query or clear the search box."),
+        body=_("Try a shorter query, switch the filter to All, or clear "
+               "the search box."),
         primary_action=(_("Clear search"), "clear-search"),
     ),
     "first-run": StateSpec(
@@ -138,7 +145,7 @@ STATES: dict[str, StateSpec] = {
     "sensitive-cleared": StateSpec(
         id="sensitive-cleared",
         kind="banner",
-        tone="info",
+        tone="warning",
         icon_name="security-high-symbolic",
         title=_("Sensitive items cleared"),
         body=_("Clips matching token / password patterns were purged "
@@ -163,7 +170,8 @@ STATES: dict[str, StateSpec] = {
         icon_name="dialog-error-symbolic",
         title=_("Backup failed"),
         body=_("The destination is full, read-only, or otherwise "
-               "unwritable. Pick a different folder and retry."),
+               "unwritable. Pick a different folder or free up space, "
+               "then retry."),
         primary_action=(_("Retry"), "retry-backup"),
         secondary_action=(_("Choose another location"), "rechoose-backup"),
     ),
@@ -174,7 +182,8 @@ STATES: dict[str, StateSpec] = {
         icon_name="dialog-error-symbolic",
         title=_("Restore failed"),
         body=_("That file isn't a Clipman backup, or it includes "
-               "triggers/views we won't import."),
+               "triggers/views we won't import. Pick a .db file exported "
+               "by Clipman."),
         primary_action=(_("Close"), "close-dialog"),
         secondary_action=(_("Pick another file"), "rechoose-restore"),
     ),
@@ -194,7 +203,8 @@ STATES: dict[str, StateSpec] = {
         icon_name="drive-harddisk-symbolic",
         title=_("Can't open the clipboard database"),
         body=_("Another Clipman process may be running, or the database "
-               "file is corrupt."),
+               "file is corrupt. Close other instances, or restore a "
+               "backup."),
         primary_action=(_("Reveal database folder"), "reveal-db-folder"),
         secondary_action=(_("Restore from backup"), "open-restore"),
     ),
@@ -289,22 +299,54 @@ def render_edge_state(
         spec = STATES["empty"]
 
     if spec.kind == "banner":
-        banner = Adw.Banner()
-        banner.set_title(spec.title)
-        primary_action_id: str | None = None
-        if spec.primary_action is not None:
-            banner.set_button_label(spec.primary_action[0])
-            primary_action_id = spec.primary_action[1]
-            banner.action_id = primary_action_id
-        banner.set_revealed(True)
+        # Custom banner (mockup fidelity): Adw.Banner shows a single title
+        # line only — the mockup's banners carry an icon, a secondary desc
+        # line, a text action AND a dismiss X.
+        banner = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        banner.add_css_class("edge-banner")
         if spec.tone in _TONE_CSS:
             banner.add_css_class(_TONE_CSS[spec.tone])
+
+        icon = Gtk.Image.new_from_icon_name(spec.icon_name)
+        icon.set_valign(Gtk.Align.CENTER)
+        banner.append(icon)
+
+        text_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=1)
+        text_box.set_valign(Gtk.Align.CENTER)
+        text_box.set_hexpand(True)
+        title = Gtk.Label(label=spec.title, xalign=0)
+        title.add_css_class("edge-banner-title")
+        title.set_wrap(True)
+        desc = Gtk.Label(label=spec.body, xalign=0)
+        desc.add_css_class("edge-banner-desc")
+        desc.set_wrap(True)
+        text_box.append(title)
+        text_box.append(desc)
+        banner.append(text_box)
+
+        if spec.primary_action is not None:
+            btn = Gtk.Button(label=spec.primary_action[0])
+            btn.add_css_class("flat")
+            btn.add_css_class("edge-banner-action")
+            btn.set_valign(Gtk.Align.CENTER)
+            btn.action_id = spec.primary_action[1]
+            if on_action is not None:
+                btn.connect(
+                    "clicked",
+                    lambda _b, _aid=spec.primary_action[1]: on_action(_aid),
+                )
+            banner.append(btn)
+
+        close = Gtk.Button.new_from_icon_name("window-close-symbolic")
+        close.add_css_class("flat")
+        close.add_css_class("circular")
+        close.set_valign(Gtk.Align.CENTER)
+        close.set_tooltip_text(_("Dismiss"))
+        if on_action is not None:
+            close.connect("clicked", lambda _b: on_action("dismiss-banner"))
+        banner.append(close)
+
         banner.state_spec = spec
-        if on_action is not None and primary_action_id is not None:
-            banner.connect(
-                "button-clicked",
-                lambda _b, _aid=primary_action_id: on_action(_aid),
-            )
         return banner
 
     if spec.kind == "alertdialog":
@@ -318,12 +360,14 @@ def render_edge_state(
                 spec.primary_action[1], spec.primary_action[0]
             )
             dialog.set_default_response(spec.primary_action[1])
-        if spec.tone == "error":
-            if spec.primary_action is not None:
-                dialog.set_response_appearance(
-                    spec.primary_action[1],
-                    Adw.ResponseAppearance.DESTRUCTIVE,
-                )
+        if spec.primary_action is not None:
+            # Mockup dialogs style the primary as the safe/suggested move
+            # (Retry / Close / Got it) — destructive red is reserved for
+            # genuinely destructive actions, which none of these are.
+            dialog.set_response_appearance(
+                spec.primary_action[1],
+                Adw.ResponseAppearance.SUGGESTED,
+            )
         dialog.state_spec = spec
         if on_action is not None:
             # AlertDialog responses are already action_ids (we registered
@@ -362,7 +406,14 @@ def render_edge_state(
             button_box.append(btn)
         if spec.primary_action is not None:
             btn = Gtk.Button(label=spec.primary_action[0])
-            btn.add_css_class("suggested-action")
+            # CTA tone follows the state (mockup: warning states get an
+            # amber CTA, error states a red one, info the accent).
+            if spec.tone == "error":
+                btn.add_css_class("destructive-action")
+            elif spec.tone == "warning":
+                btn.add_css_class("warning-cta")
+            else:
+                btn.add_css_class("suggested-action")
             btn.add_css_class("pill")
             btn.action_id = spec.primary_action[1]
             if on_action is not None:
@@ -372,6 +423,24 @@ def render_edge_state(
                 )
             button_box.append(btn)
         page.set_child(button_box)
+
+    if spec.kbd:
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=14)
+        existing = page.get_child()
+        if existing is not None:
+            page.set_child(None)
+            outer.append(existing)
+        kbd_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        kbd_box.set_halign(Gtk.Align.CENTER)
+        for token in spec.kbd:
+            lbl = Gtk.Label(label=token)
+            if token.startswith("—"):
+                lbl.add_css_class("dim-label")
+            else:
+                lbl.add_css_class("keycap")
+            kbd_box.append(lbl)
+        outer.append(kbd_box)
+        page.set_child(outer)
 
     page.state_spec = spec
     return page

--- a/clipman/style.css
+++ b/clipman/style.css
@@ -292,3 +292,65 @@
     color: alpha(@window_fg_color, 0.35);
     -gtk-icon-size: 48px;
 }
+
+/* Amber CTA on warning statuspages (mockup tone-warning-cta). */
+button.warning-cta {
+    background-color: @warning_color;
+    color: @warning_fg_color;
+}
+button.warning-cta:hover {
+    background-color: alpha(@warning_color, 0.85);
+}
+
+/* Keycap hints under statuspage buttons (mockup .keycap). */
+.keycap {
+    font-size: 0.78em;
+    font-weight: 600;
+    padding: 1px 8px;
+    background-color: alpha(@window_fg_color, 0.07);
+    border: 1px solid alpha(@window_fg_color, 0.16);
+    border-bottom-width: 2px;
+    border-radius: 6px;
+    color: @clip_dim;
+}
+
+/* Edge banners (mockup states.html): icon · title/desc · action · X.
+   Adw.Banner can't show a desc line or dismiss button, so the renderer
+   builds this custom row; tones tint the background. */
+.edge-banner {
+    padding: 8px 10px;
+    margin: 6px 8px 2px 8px;
+    border-radius: 10px;
+    background-color: alpha(@accent_color, 0.10);
+}
+.edge-banner > image {
+    color: @accent_color;
+    -gtk-icon-size: 16px;
+}
+.edge-banner-title {
+    font-weight: 600;
+    font-size: 0.9em;
+}
+.edge-banner-desc {
+    font-size: 0.8em;
+    color: @clip_dim;
+}
+.edge-banner-action {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: @accent_color;
+}
+.edge-banner.warning {
+    background-color: alpha(@warning_color, 0.12);
+}
+.edge-banner.warning > image,
+.edge-banner.warning .edge-banner-action {
+    color: @warning_color;
+}
+.edge-banner.error {
+    background-color: alpha(@error_color, 0.12);
+}
+.edge-banner.error > image,
+.edge-banner.error .edge-banner-action {
+    color: @error_color;
+}

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -823,6 +823,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 state_id = "no-results"
             elif is_snippets:
                 state_id = "no-snippets-yet"
+            elif not self._extension_connected():
+                # Empty AND the Shell extension isn't on the bus: guide the
+                # setup instead of a generic empty state (mockup first-run /
+                # snap-required).
+                state_id = ("extension-missing" if os.environ.get("SNAP")
+                            else "first-run")
             else:
                 state_id = "empty"
             self._show_edge_state(state_id)
@@ -883,6 +889,12 @@ class ClipmanWindow(Adw.ApplicationWindow):
         if self._active_filter == "snippets":
             label = _("{n} snippet").format(n=n) if n == 1 \
                 else _("{n} snippets").format(n=n)
+        elif self._search_query:
+            try:
+                total = self.db.count_entries()
+            except Exception:
+                total = n
+            label = _("{n} of {total} items").format(n=n, total=total)
         else:
             label = _("{n} item").format(n=n) if n == 1 \
                 else _("{n} items").format(n=n)
@@ -1008,6 +1020,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         "reveal-db-folder",
         "retry-update-check",
         "close-dialog",
+        "dismiss-banner",
     })
 
     def _on_edge_action(self, action_id):
@@ -1060,6 +1073,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
             "open-prefs-storage": self._action_open_prefs_storage,
             "reveal-db-folder": self._action_reveal_db_folder,
             "retry-update-check": self._action_retry_update_check,
+            "dismiss-banner": self._action_dismiss_banner,
             # AlertDialog close (response id when user dismisses).
             "close-dialog": self._action_close_dialog,
         }
@@ -1088,6 +1102,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def _action_open_snap_notes(self):
         self._open_url(self._SNAP_NOTES_URL)
+
+    def _action_dismiss_banner(self):
+        """X button on an edge banner — remove whatever banner is mounted."""
+        self._dismiss_edge_banner()
 
     def _action_resume_recording(self):
         if self.monitor is not None:
@@ -1546,7 +1564,8 @@ class ClipmanWindow(Adw.ApplicationWindow):
         show, latest = updates.should_show_banner(self.db)
         if show:
             self._update_banner.set_title(
-                _("Update available: v{new} (you have v{cur})").format(
+                _("A newer Clipman release is available — v{new} "
+                  "(you have v{cur})").format(
                     new=latest, cur=__version__
                 )
             )
@@ -1778,6 +1797,22 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # keys land on the restored window, still imperceptible to the user.
         GLib.timeout_add(120, _fire_keystroke)
         return True
+
+    def _extension_connected(self):
+        """Whether the GNOME Shell extension owns its bus name (cached 60s —
+        refresh() runs often and this is only advisory for empty states)."""
+        now = time.time()
+        cached = getattr(self, "_ext_check", None)
+        if cached is not None and now - cached[0] < 60:
+            return cached[1]
+        try:
+            import dbus
+            bus = dbus.SessionBus()
+            ok = bus.name_has_owner("org.gnome.Shell.Extensions.clipman")
+        except Exception:
+            ok = False
+        self._ext_check = (now, ok)
+        return ok
 
     def _shell_extension_iface(self):
         """Return the GNOME Shell extension's D-Bus interface, or None if it
@@ -2042,6 +2077,16 @@ class ClipmanWindow(Adw.ApplicationWindow):
             self.search_entry.grab_focus()
             return True
 
+        # Ctrl+N: new snippet, when the Snippets view is active (the
+        # no-snippets state advertises it as a keycap hint).
+        if (
+            self._active_filter == "snippets"
+            and keyval in (Gdk.KEY_n, Gdk.KEY_N)
+            and _state & Gdk.ModifierType.CONTROL_MASK
+        ):
+            self._on_snippets_clicked(None)
+            return True
+
         # Down arrow from the search entry drops focus into the list so
         # the user can start arrow-navigating rows. Up/Down within the
         # list itself is native to Gtk.ListView.
@@ -2177,6 +2222,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
         deleted = self.db.delete_expired_sensitive(self._sensitive_timeout)
         if deleted > 0 and self.get_visible():
             self.refresh()
+            # Surface the purge (mockup sensitive-auto-cleared banner) so
+            # rows vanishing isn't silent; X or the action dismisses it.
+            self._show_edge_state("sensitive-cleared")
         return True
 
     def _move_to_cursor(self):

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -103,7 +103,9 @@ class TestEdgeStates(unittest.TestCase):
                 # on the resulting type to decide where to mount it.
                 spec = widget.state_spec
                 if spec.kind == "banner":
-                    self.assertIsInstance(widget, Adw.Banner)
+                    # Custom banner row (icon · title/desc · action · X) —
+                    # Adw.Banner can't show a desc line or dismiss button.
+                    self.assertTrue(widget.has_css_class("edge-banner"))
                 elif spec.kind == "alertdialog":
                     self.assertIsInstance(widget, Adw.AlertDialog)
                 else:


### PR DESCRIPTION
## States parity with `docs/design/states.html`

Second half of the element-level parity audit (#154 covered the main window). Every change verified by rendered screenshots against the mockup.

### Copy / icon / tone parity
- **No snippets**: bookmark icon + mockup copy ("Save reusable text — signatures, addresses, code stubs…"), "Add snippet" CTA, **Ctrl+N** keycap hint — and Ctrl+N actually opens the snippet editor from the Snippets view.
- **Empty**: adds the mockup's "The popup stays hidden until you summon it." plus a **Super V** keycap hint.
- **No results**: mentions switching the filter to All; the footer reads **"N of TOTAL items"** while a search is active.
- **db-locked / backup-failed / restore-failed**: adopt the mockup's remedy sentences; alert-dialog primaries are `SUGGESTED` (destructive red was wrong for Retry/Close).
- StatusPage CTAs follow the state tone: amber `warning-cta`, red destructive, accent otherwise; update banner adopts the mockup wording.

### Banners are now mockup-fidelity
`Adw.Banner` can only render a title. The renderer now builds the mockup's banner row — icon · bold title · secondary desc · text action · **dismiss ✕** — with warning/error tints (`dismiss-banner` handled by the window; contract tests updated).

### States now actually reachable
- **sensitive-cleared** (warning) surfaces from the purge loop when sensitive entries are removed — rows no longer vanish silently.
- **first-run / extension-missing (snap)**: with no history and the Shell extension off the bus, the empty state routes to the guided setup pages instead of a generic "Nothing copied yet".

### Tests
327 pass (headless GTK4 via xvfb); banner kind assertion updated to the custom widget; rendered no-snippets / empty / sensitive-cleared verified against the mockup.

Part of the stabilization pass (#132).
