### PR TITLE
fix(incognito): one persistent state — header toggle persists too

### DIFF
--- a/clipman/style.css
+++ b/clipman/style.css
@@ -102,9 +102,6 @@
     border-radius: 999px;
     padding: 0 6px;
 }
-.filter-count:empty {
-    padding: 0;
-}
 .filter-tab-active .filter-count {
     color: @accent_color;
     background-color: alpha(@accent_color, 0.15);

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -1947,6 +1947,17 @@ class ClipmanWindow(Adw.ApplicationWindow):
     def _on_incognito_toggled(self, button):
         active = button.get_active()
         self._update_recording_pill(active)
+        # Incognito is ONE persistent state: the header toggle, footer pill
+        # and the Privacy switch all read/write the same setting. Previously
+        # only the Privacy switch persisted, so a daemon restart silently
+        # re-enabled incognito that the user had turned off in the header —
+        # copies were dropped with no obvious cause.
+        try:
+            self.db.set_setting(
+                "incognito_on_launch", "true" if active else "false"
+            )
+        except Exception:
+            logger.debug("persisting incognito failed", exc_info=True)
         if self.monitor is None:
             return
         self.monitor.set_incognito(active)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -252,6 +252,26 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertEqual(window._recording_label.get_text(), "Recording")
         self.assertFalse(window._recording_pill.has_css_class("paused"))
 
+    def test_incognito_header_toggle_persists(self):
+        """The header incognito toggle persists across restarts.
+
+        Regression: only the Privacy switch persisted incognito, so a
+        daemon restart silently re-enabled incognito the user had turned
+        off in the header — copies were dropped with no visible cause.
+        """
+        from unittest.mock import MagicMock
+
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestIncogPersist")
+        window = ClipmanWindow(application=app, db=db, monitor=MagicMock())
+
+        window._incognito_btn.set_active(True)
+        self.assertEqual(db.get_setting("incognito_on_launch"), "true")
+        window._incognito_btn.set_active(False)
+        self.assertEqual(db.get_setting("incognito_on_launch"), "false")
+
     def test_preferences_window_constructs(self):
         from clipman.preferences import ClipmanPreferences
         from clipman.window import ClipmanWindow


### PR DESCRIPTION
## Copies silently stopped being recorded

Root cause: incognito had **two toggles with different lifetimes**. The Privacy switch persisted `incognito_on_launch=true`; the user later turned incognito **off** via the header button — which was session-only — so the next daemon restart silently re-enabled incognito from the stale setting and every copy was dropped with no visible cause.

**Fix:** incognito is now one coherent persistent state. The header toggle (and the footer pill, which drives it) writes the same `incognito_on_launch` setting the Privacy switch uses, so "off" survives restarts and all three controls stay in sync.

Also removes the `.filter-count:empty` CSS rule — GTK CSS has no `:empty` pseudo-class and it logged a theme-parser error on every startup (badge visibility is already handled in code).

### Tests
328 pass; new regression test asserts the header toggle round-trips the persisted setting.