### PR TITLE
fix(window): code classifier catches calls and format braces

### DIFF
--- a/clipman/window.py
+++ b/clipman/window.py
@@ -173,10 +173,20 @@ _DIM_TEXT_LIGHT = "#57534e"
 _URL_RE = re.compile(r"^(https?://|www\.)\S+$", re.IGNORECASE)
 # Conservative code detection: only strong, code-specific signals so plain
 # notes ("cd cabinet", "from the shop") don't get mislabeled as code.
+# Each alternative is individually unambiguous in prose:
+#   - code-y line starts (def/class/import/print(/return /shebang/$ prompt)
+#   - a line ending in ; { }
+#   - arrows / closing tags
+#   - a method call: word.word( — "'{0}'.format(x)", "obj.method(arg)"
+#   - a call with a string/numeric literal argument: foo('x'), bar(3)
+#   - brace format placeholders: {0} {name} f'{x}'
 _CODE_HINT_RE = re.compile(
-    r"^\s*(def |class |function |import |#!/|\$ )"   # code-y line starts
-    r"|[{};]\s*$"                                     # line ends in ; { }
-    r"|=>|</[a-zA-Z]",                               # arrows, closing tags
+    r"^\s*(def |class |function |import |#!/|\$ |print\(|return[ (])"
+    r"|[{};]\s*$"
+    r"|=>|</[a-zA-Z]"
+    r"|\.\w+\("
+    r"|\b\w+\((['\"]|\d)"
+    r"|\{\w*\}",
     re.MULTILINE,
 )
 

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -454,6 +454,33 @@ class TestWindowConstruction(unittest.TestCase):
         window._shell_extension_iface = lambda: None
         self.assertFalse(window._paste_via_shell("auto"))
 
+    def test_classify_text_code_vs_prose(self):
+        """The row-type classifier catches obvious code without flagging
+        prose. Regression: print('...{0}...'.format(x)) showed as plain
+        text; earlier, 'cd cabinet' showed as code."""
+        from clipman.window import _classify_text
+
+        fmt_call = "print('The sum of {0} and {1} is {2}'" \
+            + ".format(num1, num2, sum))"
+        code = [
+            fmt_call,
+            "def hello():",
+            "x => x * 2",
+            "result.append(42)",
+            "git log --oneline {",
+        ]
+        prose = [
+            "cd cabinet",
+            "from the shop earlier",
+            "meet me at 5pm (maybe)",
+            "The quick brown fox jumps over the lazy dog.",
+        ]
+        for t in code:
+            self.assertEqual(_classify_text(t), "code", t)
+        for t in prose:
+            self.assertEqual(_classify_text(t), "text", t)
+        self.assertEqual(_classify_text("https://github.com/x/y"), "link")
+
     def test_copy_prefers_wl_copy_on_wayland(self):
         """On Wayland the background daemon must set the clipboard via wl-copy
         — Gdk.Clipboard.set() silently fails without input focus, so the


### PR DESCRIPTION
`print('The sum of {0} and {1} is {2}'.format(num1, num2, sum))` classified as plain text: the earlier conservative tightening (which fixed `cd cabinet` reading as code) also dropped obvious code.

Adds strong, prose-safe signals to `_CODE_HINT_RE` — method calls (`word.word(`), calls with a string/numeric literal argument (`foo('x')`, `bar(3)`), brace format placeholders (`{0}`, `{name}`), and `print(`/`return` line starts — while keeping the conservative baseline that protects prose.

**Tests:** 329 pass; new classifier regression test covers both directions (the exact reported string + `def`/arrow/call/brace cases as code; `cd cabinet` / "from the shop" / "(maybe)" / plain sentences as text; URLs stay links).