### PR TITLE
feat(states): plumb the remaining mockup error states + snippet use-counts

### DIFF
--- a/clipman/app.py
+++ b/clipman/app.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import signal
+import sqlite3
 import dbus
 import dbus.exceptions
 import gi
@@ -44,8 +45,18 @@ class ClipmanApp(Adw.Application):
             self.window.toggle()
             return
 
-        self.db = ClipboardDB()
+        try:
+            self.db = ClipboardDB()
+        except sqlite3.OperationalError:
+            # Locked or corrupt database — show the guided error state
+            # (mockup db-corrupt) instead of crashing with a traceback.
+            logger.exception("clipboard database could not be opened")
+            self._present_db_error()
+            return
         self.monitor = ClipboardMonitor(self.db, on_new_entry=self._on_new_entry)
+        # Surface repeated wl-paste crashes in the popup instead of dying
+        # silently (mockup watcher-crashed).
+        self.monitor.on_watcher_dead = self._on_watcher_dead
         # Phase 1 of the GTK 4 + libadwaita port: keyword args only, the
         # window constructor expects (application, db, monitor) now.
         self.window = ClipmanWindow(
@@ -101,6 +112,37 @@ class ClipmanApp(Adw.Application):
         # Handle SIGINT/SIGTERM gracefully
         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, self._shutdown)
         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, self._shutdown)
+
+    def _on_watcher_dead(self):
+        if self.window is not None:
+            GLib.idle_add(self.window.show_watcher_crashed)
+
+    def _present_db_error(self):
+        """Minimal window with the db-locked statuspage (no DB available)."""
+        from gi.repository import Gtk
+
+        from clipman.database import DATA_DIR
+        from clipman.edge_states import render_edge_state
+
+        def on_action(action_id):
+            if action_id == "reveal-db-folder":
+                import subprocess
+                try:
+                    subprocess.Popen(
+                        ["xdg-open", str(DATA_DIR)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                except OSError:
+                    logger.debug("xdg-open failed", exc_info=True)
+            else:
+                self.quit()
+
+        win = Gtk.ApplicationWindow(application=self)
+        win.set_title("Clipman")
+        win.set_default_size(420, 480)
+        win.set_child(render_edge_state("db-locked", on_action=on_action))
+        win.present()
 
     def _update_check_tick_once(self):
         """One-shot initial tick — runs ``_update_check_tick`` then dies.

--- a/clipman/clipboard_monitor.py
+++ b/clipman/clipboard_monitor.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import string
 import subprocess
 import time
 
 from gi.repository import GLib
+
+logger = logging.getLogger(__name__)
 
 MAX_TEXT_SIZE = 10 * 1024 * 1024   # 10 MB
 MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
@@ -142,6 +145,9 @@ class _WlPasteWatcher:
         self._restart_count += 1
         if self._restart_count > self._MAX_RESTARTS:
             self.stop()
+            # Give up for good — surface it instead of failing silently
+            # (the popup shows the watcher-crashed state).
+            self._monitor._watcher_gave_up()
             return GLib.SOURCE_REMOVE
         self.stop()
         self.start()
@@ -197,6 +203,9 @@ class ClipboardMonitor:
     def __init__(self, db, on_new_entry=None):
         self.db = db
         self.on_new_entry = on_new_entry
+        # Optional: invoked (on the GLib main loop) when the wl-paste
+        # fallback watcher crashes repeatedly and stops retrying.
+        self.on_watcher_dead = None
         self._self_copy = False
         self._incognito = False
         self._last_event_time = 0.0
@@ -214,6 +223,15 @@ class ClipboardMonitor:
         if self._watcher is not None:
             self._watcher.stop()
             self._watcher = None
+
+    def _watcher_gave_up(self):
+        """The wl-paste watcher stopped retrying — notify the UI."""
+        self._watcher = None
+        if self.on_watcher_dead is not None:
+            try:
+                self.on_watcher_dead()
+            except Exception:
+                logger.debug("on_watcher_dead callback failed", exc_info=True)
 
     def set_self_copy(self, val: bool):
         self._self_copy = val

--- a/clipman/database.py
+++ b/clipman/database.py
@@ -110,6 +110,12 @@ class ClipboardDB:
             self.conn.execute(
                 "ALTER TABLE entries ADD COLUMN sensitive INTEGER NOT NULL DEFAULT 0"
             )
+        # Migration: snippet paste counter ("Snippet · used N×" row meta)
+        scols = [r[1] for r in self.conn.execute("PRAGMA table_info(snippets)")]
+        if "use_count" not in scols:
+            self.conn.execute(
+                "ALTER TABLE snippets ADD COLUMN use_count INTEGER NOT NULL DEFAULT 0"
+            )
         self.conn.commit()
 
     def add_entry(self, content_type: str, content_text: str = None,
@@ -385,6 +391,14 @@ class ClipboardDB:
         )
         self.conn.commit()
         return cursor.lastrowid
+
+    def increment_snippet_use(self, snippet_id: int):
+        """Bump the paste counter shown in the snippet row meta."""
+        self.conn.execute(
+            "UPDATE snippets SET use_count = use_count + 1 WHERE id = ?",
+            (snippet_id,),
+        )
+        self.conn.commit()
 
     def get_snippets(self):
         rows = self.conn.execute(

--- a/clipman/edge_states.py
+++ b/clipman/edge_states.py
@@ -1,4 +1,4 @@
-"""Pure-data declarations for the 16 edge states from the mockups.
+"""Pure-data declarations for the edge states from the mockups.
 
 Each ``StateSpec`` captures everything the renderer needs:
 - ``id``: stable identifier used by ``window.py`` to look the state up.
@@ -64,7 +64,7 @@ class StateSpec:
 
 
 # ---------------------------------------------------------------------
-# The 16 specs. Order matches the mockup picker (states.html), reading
+# The specs (16 mockup states + 3 plumbed error states). Order matches the mockup picker (states.html), reading
 # top-to-bottom: Baseline / Informational / Privacy / Setup / Errors.
 # "populated" is a sentinel: it represents the normal list-view popup,
 # is never actually rendered through ``render_edge_state`` (the list
@@ -227,6 +227,40 @@ STATES: dict[str, StateSpec] = {
                "on your clipboard. Paste it manually with Ctrl+V."),
         primary_action=(_("Got it"), "close-dialog"),
         secondary_action=(_("Install help"), "open-install-guide"),
+    ),
+    "clipboard-blocked": StateSpec(
+        id="clipboard-blocked",
+        kind="statuspage",
+        tone="error",
+        icon_name="dialog-error-symbolic",
+        title=_("Clipman can't watch the clipboard"),
+        body=_("Install wl-clipboard and use a Wayland session, or enable "
+               "the GNOME extension. Until then, copies won't be recorded."),
+        primary_action=(_("Copy install command"),
+                        "copy-install-wl-clipboard"),
+        secondary_action=(_("Setup help"), "open-install-guide"),
+    ),
+    "watcher-crashed": StateSpec(
+        id="watcher-crashed",
+        kind="statuspage",
+        tone="error",
+        icon_name="computer-fail-symbolic",
+        title=_("Clipboard watcher stopped"),
+        body=_("The wl-paste helper crashed too many times, so Clipman "
+               "stopped retrying. Restart the daemon to resume capturing "
+               "clips."),
+        primary_action=(_("Restart Clipman"), "restart-daemon"),
+    ),
+    "shortcut-failed": StateSpec(
+        id="shortcut-failed",
+        kind="alertdialog",
+        tone="warning",
+        icon_name="input-keyboard-symbolic",
+        title=_("Couldn't update the GNOME shortcut"),
+        body=_("Clipman's keybinding isn't registered with GNOME. Run "
+               "install.sh to register it, then set the shortcut again."),
+        primary_action=(_("Got it"), "close-dialog"),
+        secondary_action=(_("Copy command"), "copy-shortcut-command"),
     ),
     "history-too-large": StateSpec(
         id="history-too-large",

--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -644,8 +644,24 @@ class ClipmanPreferences(Adw.Dialog):
             self._toggle_row.set_subtitle(
                 keybindings.format_binding_for_display(binding)
             )
+        else:
+            # Registration failed (gsettings schema missing / non-GNOME):
+            # show the guided dialog instead of silently doing nothing
+            # (mockup shortcut-failed).
+            self._present_shortcut_failed()
         dialog.close()
         return True
+
+    def _present_shortcut_failed(self):
+        from clipman.edge_states import render_edge_state
+
+        parent = self._parent_window
+        if parent is not None and hasattr(parent, "_on_edge_action"):
+            parent._show_edge_state("shortcut-failed")
+            return
+        # Standalone (tests / no parent): present unwired on this dialog.
+        dlg = render_edge_state("shortcut-failed")
+        dlg.present(self)
 
     # ------------------------------------------------------------------
     # Pane 4: Storage

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -11,6 +11,7 @@ module without changes.
 import logging
 import os
 import re
+import shutil
 import subprocess
 import time
 from datetime import date, datetime, timedelta
@@ -836,9 +837,14 @@ class ClipmanWindow(Adw.ApplicationWindow):
             elif not self._extension_connected():
                 # Empty AND the Shell extension isn't on the bus: guide the
                 # setup instead of a generic empty state (mockup first-run /
-                # snap-required).
-                state_id = ("extension-missing" if os.environ.get("SNAP")
-                            else "first-run")
+                # snap-required / clipboard-blocked).
+                if os.environ.get("SNAP"):
+                    state_id = "extension-missing"
+                elif shutil.which("wl-paste") is None:
+                    # No extension AND no wl-clipboard: nothing can record.
+                    state_id = "clipboard-blocked"
+                else:
+                    state_id = "first-run"
             else:
                 state_id = "empty"
             self._show_edge_state(state_id)
@@ -1031,6 +1037,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
         "retry-update-check",
         "close-dialog",
         "dismiss-banner",
+        "copy-install-wl-clipboard",
+        "copy-shortcut-command",
+        "restart-daemon",
     })
 
     def _on_edge_action(self, action_id):
@@ -1084,6 +1093,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
             "reveal-db-folder": self._action_reveal_db_folder,
             "retry-update-check": self._action_retry_update_check,
             "dismiss-banner": self._action_dismiss_banner,
+            "copy-install-wl-clipboard": self._action_copy_wl_install,
+            "copy-shortcut-command": self._action_copy_shortcut_command,
+            "restart-daemon": self._action_restart_daemon,
             # AlertDialog close (response id when user dismisses).
             "close-dialog": self._action_close_dialog,
         }
@@ -1112,6 +1124,29 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def _action_open_snap_notes(self):
         self._open_url(self._SNAP_NOTES_URL)
+
+    def _action_copy_wl_install(self):
+        """clipboard-blocked: put the install command on the clipboard."""
+        self._copy_to_clipboard("sudo apt install wl-clipboard")
+
+    def _action_copy_shortcut_command(self):
+        """shortcut-failed: copy the register command for a terminal run."""
+        self._copy_to_clipboard("bash install.sh")
+
+    def _action_restart_daemon(self):
+        """watcher-crashed: restart the daemon (systemd brings us back)."""
+        try:
+            subprocess.Popen(
+                ["systemctl", "--user", "restart", "clipman.service"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError:
+            logger.debug("daemon restart failed", exc_info=True)
+
+    def show_watcher_crashed(self):
+        """Public — app.py routes the monitor's watcher-dead callback here."""
+        self._show_edge_state("watcher-crashed")
 
     def _action_dismiss_banner(self):
         """X button on an edge banner — remove whatever banner is mounted."""
@@ -1530,8 +1565,16 @@ class ClipmanWindow(Adw.ApplicationWindow):
 
     def _bind_snippet_row(self, row, snippet):
         row._clip_title.set_text(snippet["name"])
-        preview = (snippet.get("content_text") or "").split("\n", 1)[0]
-        row._clip_subtitle.set_text(preview[:120])
+        uses = snippet.get("use_count") or 0
+        # Mockup meta: "Snippet · used 14×"; before first use show the
+        # snippet preview so the row isn't a bare name.
+        if uses:
+            row._clip_subtitle.set_text(
+                _("Snippet · used {n}×").format(n=uses)
+            )
+        else:
+            preview = (snippet.get("content_text") or "").split("\n", 1)[0]
+            row._clip_subtitle.set_text(preview[:120])
         row._clip_thumb.set_paintable(None)
         row._clip_thumb.set_visible(False)
         self._set_tile(row, "snip")
@@ -1753,6 +1796,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         text = snippet.get("content_text") or ""
         if not text:
             return
+        if snippet.get("id"):
+            try:
+                self.db.increment_snippet_use(snippet["id"])
+            except Exception:
+                logger.debug("snippet use-count bump failed", exc_info=True)
         text = self._expand_snippet_tokens(text)
         self._copy_to_clipboard(text)
         self.set_visible(False)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -67,14 +67,15 @@ if os.environ.get("CLIPMAN_REQUIRE_GTK4") == "1" and not (_HAS_GTK and _ADW_INIT
 @unittest.skipUnless(_HAS_GTK and _ADW_INIT_OK,
                      "GTK 4 + libadwaita not available")
 class TestEdgeStates(unittest.TestCase):
-    """The 16 mockup states must all map to a renderable widget."""
+    """Every declared state must map to a renderable widget."""
 
     EXPECTED_IDS = {
         "populated", "empty", "no-snippets-yet", "no-results", "first-run",
         "incognito-on", "sensitive-shown", "sensitive-cleared",
         "extension-missing", "backup-failed", "restore-failed",
         "network-error", "db-locked", "paused", "paste-target-missing",
-        "history-too-large",
+        "history-too-large", "clipboard-blocked", "watcher-crashed",
+        "shortcut-failed",
     }
 
     def test_state_id_inventory(self):
@@ -86,7 +87,7 @@ class TestEdgeStates(unittest.TestCase):
         """
         from clipman.edge_states import STATES
         self.assertEqual(set(STATES.keys()), self.EXPECTED_IDS)
-        self.assertEqual(len(STATES), 16)
+        self.assertEqual(len(STATES), 19)
 
     def test_render_each_state_returns_widget(self):
         from clipman.edge_states import STATES, render_edge_state
@@ -980,6 +981,19 @@ class TestKeyboardShortcuts(unittest.TestCase):
         self.assertTrue(window._activate_selected())
         # Index 0 is the most-recent entry ("new").
         self.assertEqual(pasted[0]["content_text"], "new")
+
+    def test_paste_snippet_increments_use_count(self):
+        """Pasting a snippet bumps use_count and the row meta shows it."""
+        db, window = self._seeded_window(texts=())
+        db.add_snippet("sig", "regards")
+        window._active_filter = "snippets"
+        window.refresh()
+        window._selection.set_selected(0)
+        window._copy_to_clipboard = lambda text: None
+        window._dispatch_paste = lambda: None
+        self.assertTrue(window._activate_selected())
+        snip = db.get_snippets()[0]
+        self.assertEqual(snip["use_count"], 1)
 
     def test_activate_selected_pastes_snippet(self):
         db, window = self._seeded_window(texts=())


### PR DESCRIPTION
Implements **#158** — the mockup states that needed real plumbing rather than UI work:

| state | trigger now wired |
|---|---|
| `watcher-crashed` | wl-paste watcher gives up → monitor `on_watcher_dead` → error statuspage with **Restart Clipman** (`systemctl --user restart`) |
| `clipboard-blocked` | empty + no extension + no `wl-paste` binary → guided error page (**Copy install command**) |
| `shortcut-failed` | keybinding registration failure in Preferences → warning dialog (**Copy command** → `bash install.sh`) — was silent |
| `db-locked` | `sqlite3.OperationalError` at startup → minimal window with the db-locked statuspage (reveal folder / quit) — was a traceback |

Plus the mockup's snippet meta: **"Snippet · used N×"** — `use_count` column (PRAGMA-migration pattern), incremented on paste; the preview shows until first use.

`STATES` grows 16 → 19 (all from `states.html`); inventory + dispatch-contract tests updated. 329 tests pass.

Closes #158.