### PR TITLE
chore(release): v1.2.0 — stable GTK4 line, drop the v1.0.6 advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-18
+
+### Highlights
+
+The GTK 4 line is now **stable** — this release closes out the
+post-rewrite stabilization tracker (#132) and removes the "use v1.0.6"
+advisory. Three fronts landed since 1.1.0: true **Win+V behaviour on
+GNOME Wayland**, a **~60× faster list**, and a **full redesign to the
+project's design mockups**.
+
+### Fixed — Wayland/Win+V parity (#141, #149, #156)
+
+- The popup now takes real input focus on GNOME Wayland: buttons, search
+  and keyboard work; clicking outside dismisses it; it stays out of the
+  dash/dock and Alt+Tab; Escape closes; paste lands in the previously
+  focused app (keystrokes are injected by the Shell extension — `wtype`
+  cannot inject on Mutter — and the clipboard is set via `wl-copy`,
+  since a background `Gdk.Clipboard.set()` silently fails).
+- The installer launches the daemon once (systemd user service only);
+  the duplicate XDG autostart that raced for the D-Bus name is gone.
+- Incognito is one persistent state across the header toggle, footer
+  pill and Privacy switch — "off" survives restarts (previously stale
+  state could silently stop recording).
+
+### Performance (#150)
+
+- Opening the popup and switching filters no longer freezes: rows are
+  lightweight widgets (~5× cheaper than `Adw.ActionRow`), image
+  thumbnails are decoded once and cached, and long histories stream in
+  incrementally. Measured on a real 263-entry history: back-to-All
+  refresh ~3.4 s → ~51 ms.
+
+### Changed — redesign to the design mockups (#151, #153–#155, #159)
+
+- Colour-coded type icons (text/link/code/image/snippet) with
+  conservative code/URL detection; per-type row metadata (domain for
+  links, size + dimensions for images, "Code" tag, snippet use-counts).
+- Day-grouped history (★ Pinned / Today / Yesterday / Earlier) with a
+  gold pinned group; hover-revealed row actions; sensitive entries are
+  masked with a lock icon and an auto-clear countdown.
+- Segmented filter switcher (All / Text / Images / Snippets) with live
+  count badges; search field with a `/` shortcut hint; footer with item
+  count, Recording/Paused pill and Clear all.
+- Preferences rebuilt with a left sidebar (matches the mockup), an
+  accent colour picker with contrast-aware foreground, and a generic
+  font colour picker replacing the fixed presets.
+- Light mode is the mockups' high-contrast "stone" palette — every
+  text/background pair now clears WCAG AA (the muted Catppuccin Latte
+  text was failing it); with the Catppuccin toggle off, the popup
+  follows the system GNOME light/dark preference.
+- All 19 design edge states are implemented and reachable, including
+  guided first-run/extension setup, watcher-crashed, clipboard-blocked,
+  shortcut-failed and a database-error screen; banners carry a
+  description line and a dismiss button.
+
+### Compatibility
+
+Toolchain floors unchanged from 1.1.0 (GTK 4 ≥ 4.10, libadwaita ≥ 1.4,
+Python 3.10–3.12, GNOME Shell 45–48). No D-Bus contract changes. SQLite
+schema gains an additive `snippets.use_count` column via automatic
+migration — downgrades to 1.1.0 remain safe.
+
 ## [1.1.0] - 2026-06-25
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -37,13 +37,9 @@ Press **Super+V** to view your clipboard history, search entries, pin favorites,
 
 <br>
 
-<sub><i>Above: the shipped GTK 4 + libadwaita popup. The full settings surface is an <code>Adw.PreferencesWindow</code>, the snippets editor is an <code>Adw.NavigationSplitView</code> dialog, and the 16 edge states (empty, no-results, incognito, sensitive-cleared, first-run, errors…) render as Adwaita <code>StatusPage</code> / <code>Banner</code> / <code>AlertDialog</code> with a shared Catppuccin overlay. <a href="https://mohammedel-sayedahmed.github.io/clipman/#design">Browse the mockups</a> · <a href="https://mohammedel-sayedahmed.github.io/clipman/">project page</a>.</i></sub>
+<sub><i>Above: the shipped GTK 4 + libadwaita popup. The full settings surface is a sidebar <code>Adw.Dialog</code>, the snippets editor is an <code>Adw.NavigationSplitView</code> dialog, and the 19 edge states (empty, no-results, incognito, sensitive-cleared, first-run, errors…) render as Adwaita <code>StatusPage</code> / <code>Banner</code> / <code>AlertDialog</code> with a shared Catppuccin overlay. <a href="https://mohammedel-sayedahmed.github.io/clipman/#design">Browse the mockups</a> · <a href="https://mohammedel-sayedahmed.github.io/clipman/">project page</a>.</i></sub>
 
 </div>
-
-> [!IMPORTANT]
-> **For a stable experience right now, install [v1.0.6](https://github.com/MohammedEl-sayedAhmed/clipman/releases/tag/v1.0.6).**
-> The current latest release (**v1.1.0**) is a GTK 4 + libadwaita rewrite that is **still being stabilized**. On some setups — notably GNOME on Wayland — the popup may not take keyboard focus (buttons/search unresponsive), may not dismiss when you click outside it, and shows up in the dash/alt‑tab. Until v1.1.x is stabilized, the last GTK 3 release **[v1.0.6](https://github.com/MohammedEl-sayedAhmed/clipman/releases/tag/v1.0.6)** is recommended. Progress is tracked in [#132](https://github.com/MohammedEl-sayedAhmed/clipman/issues/132).
 
 ---
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mohammed El-sayed Ahmed <MohammedEl-sayedAhmed@users.noreply.github.com>
 pkgname=clipman-clipboard
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="A clipboard history manager for Wayland (GNOME, KDE, Sway, Hyprland, etc.)"
 arch=('any')

--- a/clipman/_version.py
+++ b/clipman/_version.py
@@ -12,4 +12,4 @@ expect it (tests, CLI ``--version``, pyproject metadata).
 ``scripts/bump-version.sh`` patches the literal in this file.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
+++ b/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
@@ -41,7 +41,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.1.0.tar.gz",
+                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.2.0.tar.gz",
                     "sha256": "bb5f2ccfb41eea1bf92bfe76fb1b786bb14f782782f155b2575f72d7859cc116"
                 },
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clipman-clipboard"
-version = "1.1.0"
+version = "1.2.0"
 description = "A Wayland-native clipboard history manager built with GTK 4 and libadwaita"
 readme = "README.md"
 license = "Apache-2.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: clipman
-version: '1.1.0'
+version: '1.2.0'
 summary: Clipboard history for Wayland — like Win+V for Linux
 description: |
   A fast, native clipboard manager for Wayland (GNOME, KDE, Sway,


### PR DESCRIPTION
Release prep for **v1.2.0** (per the versioning policy, MINOR: no D-Bus contract changes, additive-only schema migration).

- `bump-version.sh 1.2.0` — pyproject / `_version.py` / snapcraft / PKGBUILD / flathub manifest
- CHANGELOG: 1.2.0 section — Win+V parity, ~60× list speed, full mockup redesign, WCAG-AA light mode, 19 reachable edge states, incognito persistence
- README: the "install v1.0.6, v1.1.0 is being stabilized" advisory is **removed** — the GTK4 line is stable; caption freshened
- After merge: tag `v1.2.0` → release workflow publishes **PyPI + Snap** (the snap rebuild also resolves the Snap Store USN-8525-1 notice for libcurl) and creates the GitHub Release as **Latest**

330 tests pass.