### PR TITLE
chore(extension): bump metadata version to 6 for the Win+V D-Bus surface

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,7 +3,7 @@
     "name": "Clipman Clipboard Monitor",
     "description": "Native Wayland clipboard change detection for the Clipman clipboard manager. Listens to Meta.Selection owner-changed signals and forwards clipboard content to the Clipman daemon via D-Bus. Provides paste simulation and window positioning services. Requires the Clipman daemon (clipman.service) to be running.",
     "shell-version": ["45", "46", "47", "48"],
-    "version": 5,
+    "version": 6,
     "url": "https://github.com/MohammedEl-sayedAhmed/clipman",
     "donations": {
         "paypal": "mohammedelsayedammar"


### PR DESCRIPTION
The Win+V parity work (#141) changed the extension's D-Bus surface (added `RestorePreviousFocus`, dash/alt-tab filtering, window activation) but didn't bump `metadata.json` — so extensions.gnome.org still serves the **pre-Win+V v5** (uploaded 2026-02-28) under the same number. A ≥1.2.0 daemon paired with that old extension loses focus-activation and paste.

This bumps to **v6** per the repo convention (bump on D-Bus/behavior changes). The v6 zip is the artifact to upload to e.g.o. — uploads there are manual (maintainer account) and go through human review.