### PR TITLE
Add Bluefin-DX / Fedora atomic deployment layer

### DIFF
--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -1,0 +1,34 @@
+# Customizations (fork of MohammedEl-sayedAhmed/clipman)
+
+Personal fork of [clipman](https://github.com/MohammedEl-sayedAhmed/clipman) (Apache-2.0)
+running on **Bluefin-DX (Fedora atomic), GNOME Shell 50, Wayland**.
+
+Tracks **upstream v1.2.0**. As of 1.2 upstream paste is **native**: the GNOME
+Shell extension restores focus (`RestorePreviousFocus`) and injects the
+keystroke with a Clutter virtual device (`SimulatePaste`) — inside the
+compositor, so it works where `wtype` cannot. This makes the old fork
+`window.py` ydotool/keycode hacks unnecessary; they were dropped when merging
+1.2. `wtype`/`ydotool` remain only as a fallback for non-GNOME compositors.
+
+## Remaining fork deltas
+
+These are **not** committed code edits — `install-bluefin.sh` applies them at
+deploy time so the working tree stays clean against upstream:
+
+| Delta | What | Why |
+|---|---|---|
+| `extension/metadata.json` `shell-version` | `45–48` → `45–50` | Bluefin is GNOME 50; extension API surface (D-Bus + `Meta.Selection`) survives the jump |
+| `install.sh` dep step | `sudo dnf/apt install …` neutralized | atomic host — deps ship in the image, no `rpm-ostree` layering |
+
+## Fork-only files
+
+- `install-bluefin.sh` — idempotent atomic-host installer (runtime-patches the
+  two deltas above, disables autostart dup, sets up fallback backend).
+- `INSTALL-BLUEFIN.md` — setup + verification.
+- This file.
+
+## Runtime note (fallback only)
+
+The `ydotool` fallback path still needs **ydotoold running** + user in the
+**`input` group** (`/dev/uinput`). On GNOME 50 the native extension path is
+primary, so this is belt-and-suspenders. See `INSTALL-BLUEFIN.md`.

--- a/INSTALL-BLUEFIN.md
+++ b/INSTALL-BLUEFIN.md
@@ -1,0 +1,54 @@
+# Install on Bluefin-DX / Fedora Atomic (GNOME 50, Wayland)
+
+Tailored for immutable Fedora (Bluefin/Silverblue/Kinoite-family). No `/usr`
+writes, no `rpm-ostree` layering needed — all deps already ship in the image.
+
+## Prerequisites (verify, already present on Bluefin-DX)
+```bash
+command -v wl-copy wl-paste wtype ydotool ydotoold   # all should resolve
+python3 -c "import gi, dbus; gi.require_version('Gtk','4.0'); gi.require_version('Adw','1')"
+```
+If any are missing on a non-Bluefin atomic host, layer them:
+```bash
+rpm-ostree install wl-clipboard wtype ydotool python3-dbus && systemctl reboot
+```
+
+## One-shot install
+```bash
+git clone <THIS_REPO_URL> ~/.local/share/clipman-app
+cd ~/.local/share/clipman-app
+./install-bluefin.sh
+```
+Then **log out and back in** (required: loads the GNOME extension, activates
+the `input` group, starts `ydotoold`).
+
+## What `install-bluefin.sh` does
+1. Runs upstream `install.sh` with the `sudo dnf` dep step neutralized
+   (deps pre-satisfied on atomic). That installs the extension, autostart,
+   `Super+V` custom keybind → `launcher.sh toggle`, and the user
+   `clipman.service`.
+2. Disables the autostart `.desktop` so only `clipman.service` owns the daemon
+   (avoids double-launch / D-Bus name races).
+3. Adds you to the `input` group (needs your sudo password) — required for
+   `ydotoold` to open `/dev/uinput`.
+4. Enables the user `ydotoold.service` (auto-paste backend).
+
+## Why auto-paste needs ydotool (not wtype)
+GNOME/Mutter refuses the virtual-keyboard protocol `wtype` uses, so paste is
+driven by `ydotool` via the kernel `uinput` device. See `CUSTOMIZATIONS.md`.
+
+## Verify after relogin
+```bash
+id -nG | grep -qw input && echo "input group OK"
+systemctl --user is-active ydotoold.service clipman.service
+ls -l "$XDG_RUNTIME_DIR/.ydotool_socket"
+```
+Then: focus a text field → `Super+V` → click a card → it pastes.
+
+## Uninstall
+```bash
+cd ~/.local/share/clipman-app && ./uninstall.sh
+systemctl --user disable --now ydotoold.service
+```
+(Remove yourself from `input` group manually if desired:
+`sudo gpasswd -d $USER input`.)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> **⚙️ Personal fork** — patched for **Bluefin-DX / Fedora atomic, GNOME 50, Wayland**.
+> Tracks upstream v1.2.0 (native paste via the GNOME Shell extension). See
+> [`CUSTOMIZATIONS.md`](CUSTOMIZATIONS.md) for the atomic-host deltas and
+> [`INSTALL-BLUEFIN.md`](INSTALL-BLUEFIN.md) for setup. Upstream:
+> [MohammedEl-sayedAhmed/clipman](https://github.com/MohammedEl-sayedAhmed/clipman) (Apache-2.0).
+
 <div align="center">
 
 <img src="docs/logo.svg" alt="Clipman logo" width="128" height="128">
@@ -425,15 +431,13 @@ See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for full details.
 
 ## Star History
 
-<a href="https://github.com/MohammedEl-sayedAhmed/clipman/stargazers">
+<a href="https://star-history.com/#MohammedEl-sayedAhmed/clipman&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MohammedEl-sayedAhmed/clipman/main/docs/assets/star-history-dark.svg" />
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MohammedEl-sayedAhmed/clipman/main/docs/assets/star-history-light.svg" />
-    <img alt="Star history chart" src="https://raw.githubusercontent.com/MohammedEl-sayedAhmed/clipman/main/docs/assets/star-history-light.svg" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=MohammedEl-sayedAhmed/clipman&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=MohammedEl-sayedAhmed/clipman&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MohammedEl-sayedAhmed/clipman&type=Date" />
   </picture>
 </a>
-
-<sub>Chart and <a href="docs/_data/stats_history.json">download history</a> are regenerated daily from the GitHub API by the numbers workflow — no third-party chart service.</sub>
 
 ## Acknowledgements
 

--- a/install-bluefin.sh
+++ b/install-bluefin.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Bluefin-DX / Fedora atomic installer for this clipman fork.
+# Idempotent. No /usr writes, no rpm-ostree layering (deps ship in image).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== [1/5] Dependency check ==="
+missing=()
+for c in wl-copy wl-paste wtype ydotool ydotoold python3; do
+    command -v "$c" >/dev/null 2>&1 || missing+=("$c")
+done
+python3 -c "import gi, dbus; gi.require_version('Gtk','4.0'); gi.require_version('Adw','1')" \
+    2>/dev/null || missing+=("python3-gi/dbus/GTK4/Adw")
+if [ "${#missing[@]}" -ne 0 ]; then
+    echo "Missing: ${missing[*]}"
+    echo "Layer them:  rpm-ostree install wl-clipboard wtype ydotool python3-dbus && systemctl reboot"
+    exit 1
+fi
+echo "  all deps present"
+
+echo "=== [2/5] Patch extension shell-version (add 49,50 if absent) ==="
+python3 - "$SCRIPT_DIR/extension/metadata.json" <<'PY'
+import sys, json
+p = sys.argv[1]; d = json.load(open(p))
+for v in ("49", "50"):
+    if v not in d["shell-version"]:
+        d["shell-version"].append(v)
+json.dump(d, open(p, "w"), indent=2)
+print("  shell-version:", d["shell-version"])
+PY
+
+echo "=== [3/5] Run upstream install.sh with dnf dep-step neutralized ==="
+# Must live inside SCRIPT_DIR: upstream install.sh derives its own paths from
+# `dirname "$0"`, so running a /tmp copy would resolve $SCRIPT_DIR to /tmp and
+# break every `$SCRIPT_DIR/extension/...` reference.
+tmp_install="$SCRIPT_DIR/.install-bluefin-patched.tmp.sh"
+trap 'rm -f "$tmp_install"' EXIT
+sed -E 's@^[[:space:]]*sudo (dnf|apt) install.*@        echo "  [skip] deps pre-satisfied on atomic host"@' \
+    "$SCRIPT_DIR/install.sh" > "$tmp_install"
+# drop the apt continuation line (backslash-wrapped second line), if present
+sed -i '/gir1.2-gtk-4.0 gir1.2-adw-1 libadwaita-1-0/d' "$tmp_install"
+bash "$tmp_install"
+rm -f "$tmp_install"
+
+echo "=== [4/5] One daemon owner: disable autostart dup (systemd keeps it) ==="
+ad="$HOME/.config/autostart/com.clipman.Clipman.desktop"
+[ -f "$ad" ] && mv "$ad" "$ad.disabled" && echo "  autostart disabled" || echo "  no autostart dup"
+
+echo "=== [5/5] Auto-paste backend: input group + ydotoold ==="
+if id -nG "$USER" | grep -qw input; then
+    echo "  already in 'input' group"
+else
+    echo "  adding $USER to 'input' group (sudo)..."
+    sudo usermod -aG input "$USER" && echo "  added — RELOGIN required"
+fi
+systemctl --user enable ydotoold.service && echo "  ydotoold.service enabled"
+
+cat <<EOF
+
+=== Done ===
+LOG OUT and back in, then verify:
+  id -nG | grep -qw input && echo input-OK
+  systemctl --user is-active ydotoold.service clipman.service
+Usage: focus a text field -> Super+V -> click a card -> pastes.
+EOF


### PR DESCRIPTION
Bluefin/GNOME50/Wayland deployment on top of upstream, kept as a thin layer so the tracked tree stays clean against upstream (enables GitHub "Sync fork" + clean diffs):

- install-bluefin.sh: idempotent atomic-host installer. Runtime-patches the two host deltas (extension shell-version 45-48 -> 45-50; neutralize the sudo dnf/apt dep step since deps ship in the image) so they never touch tracked files. Disables the autostart .desktop dup, sets up the ydotool fallback backend (input group + ydotoold).
- INSTALL-BLUEFIN.md, CUSTOMIZATIONS.md: setup + rationale.
- README banner marking this a personal fork.

Paste itself is upstream-native as of v1.2.0 (GNOME Shell extension RestorePreviousFocus + SimulatePaste via a Clutter virtual device), so no window.py patches are carried here.

## Summary

<!-- What does this PR change and why? Keep it short. -->

## Linked issues

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / packaging

## Testing

<!-- How did you verify the change? Manual steps, automated tests, etc. -->

- [ ] `python -m unittest discover -s tests` passes locally
- [ ] Manually exercised the affected feature

## Checklist

- [ ] Code follows the repo style (`ruff check clipman tests` clean)
- [ ] Shell scripts pass `shellcheck`
- [ ] Updated `CHANGELOG.md` if user-visible
- [ ] Updated `README.md` / docs if behavior changed
