### PR TITLE
feat(extension): declare GNOME Shell 49 & 50 support (v7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+### Added — GNOME Shell 49 & 50 support (#186)
+
+- The Shell extension (v7) now declares support for GNOME Shell 49 and
+  50, covering Ubuntu 26.04 LTS. No code changes were needed: every API
+  the extension touches was verified unchanged against the Shell 49
+  headers and Mutter 50.0 (the 49/50 porting guides confirm none of the
+  removals — Meta.Rectangle constructors, Clutter.ClickAction, the X11
+  backend — intersect the extension's Wayland-native surface). On 49+
+  the popup is additionally hidden from the dash and Alt+Tab via the
+  supported `Meta.Window.hide_from_window_list()` API, which the code
+  already feature-detected.
+
 ## [1.2.0] - 2026-07-18
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Clipman is a **Wayland-native** clipboard manager built on a GNOME Shell extensi
 
 ## Requirements
 
-- Ubuntu 24.04+ with GNOME 46–48 and Wayland
+- Ubuntu 24.04+ with GNOME 46–50 and Wayland
 - Python 3.10+
 - GTK 4 + libadwaita 1.4+
 

--- a/docs/adr/0010-versioning-policy.md
+++ b/docs/adr/0010-versioning-policy.md
@@ -26,7 +26,7 @@ grown:
   `last_update_check`, `latest_known_version`, `dismissed_version` —
   see ADR 0007) are read by both the daemon and any future external
   tooling.
-- A documented support window: Python 3.10–3.12, GNOME Shell 45–48,
+- A documented support window: Python 3.10–3.12, GNOME Shell 45–50,
   Ubuntu 22.04+.
 - A toolkit choice (GTK3) that downstream packagers depend on.
 

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -2,8 +2,8 @@
     "uuid": "clipman@clipman.com",
     "name": "Clipman Clipboard Monitor",
     "description": "Native Wayland clipboard change detection for the Clipman clipboard manager. Listens to Meta.Selection owner-changed signals and forwards clipboard content to the Clipman daemon via D-Bus. Provides paste simulation and window positioning services. Requires the Clipman daemon (clipman.service) to be running.",
-    "shell-version": ["45", "46", "47", "48"],
-    "version": 6,
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
+    "version": 7,
     "url": "https://github.com/MohammedEl-sayedAhmed/clipman",
     "donations": {
         "paypal": "mohammedelsayedammar"


### PR DESCRIPTION
Closes #186.

## Problem

Ubuntu 26.04 LTS ships **GNOME Shell 50**; the e.g.o. listing (v6) declares `shell-version: 45–48`, and Shell's version validation refuses to load undeclared majors — so 26.04 users can't install the extension at all.

## What was verified (not assumed)

Every API the extension touches was checked against **primary sources** — the official [Shell 49](https://gjs.guide/extensions/upgrading/gnome-shell-49.html) and [Shell 50](https://gjs.guide/extensions/upgrading/gnome-shell-50.html) porting guides, the `gnome-49` branch C headers, and the `mutter 50.0` tag:

| Extension surface | 49 | 50 |
|---|---|---|
| `Meta.Selection` `owner-changed` + `SELECTION_CLIPBOARD` | unchanged | unchanged |
| `St.Clipboard.get_content` | unchanged | unchanged |
| Clutter seat → `create_virtual_device` → `notify_keyval` (paste) | unchanged | unchanged |
| `Gio.DBusExportedObject` service | unchanged | unchanged |
| `get_tab_list` / `Shell.App.get_windows` / `AppSystem.get_running` patches | unchanged | unchanged |
| `move_frame` / `activate` / `get_frame_rect` | unchanged¹ | unchanged¹ |

¹ 49 replaced `Meta.Rectangle` with `Mtk.Rectangle` — matters only when *constructing* rects; we only read `x/y/width/height`, which are identical.

The 49/50 removals that do exist (`Meta.Rectangle` constructors, `Clutter.ClickAction`, X11 backend, logical input devices, `maximize()` signatures) **do not intersect** this extension's Wayland-native surface.

## Change

**Metadata-only**: `shell-version` → `["45"…"50"]`, extension version → **7**. One artifact spanning 45–50 is within e.g.o. review rules (stable releases only, no future versions — GNOME 50 is stable). Bonus: on 49+ the existing `hide_from_window_list()` feature-detect activates, so the popup is hidden from dash/Alt+Tab via the supported API instead of the JS list overrides.

Also updates the README/ADR-0010 support window (45–50) and adds a changelog entry.

## Rollout

1. Merge this PR.
2. Manual upload of `clipman@clipman.com-v7.zip` to e.g.o. (no publish API) — zip layout is identical to the approved v6, `extension.js` byte-for-byte unchanged.

Tests: 330 passed + 50 subtests; ruff clean.