### PR TITLE
chore(numbers): refresh marketing counters

### DIFF
--- a/docs/_data/numbers.json
+++ b/docs/_data/numbers.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Refreshed daily by .github/workflows/refresh-numbers.yml. The marketing page (docs/index.html) fetches this file same-origin to bypass the CORS blocks on extensions.gnome.org and the auth requirement on api.pepy.tech/v2. Manual edits will be overwritten on the next scheduled run.",
-  "updated_at": "2026-08-06T08:42:34Z",
+  "updated_at": "2026-08-07T07:21:16Z",
   "pypi": {
     "package": "clipman-clipboard",
     "last_day": 4,
@@ -11,7 +11,7 @@
   "gnome": {
     "extension_id": 9407,
     "uuid": "clipman@clipman.com",
-    "downloads": 4491,
+    "downloads": 4538,
     "source": "https://extensions.gnome.org/extension-info/?pk=9407"
   }
 }


### PR DESCRIPTION
Automated daily refresh of marketing counters and the self-hosted star chart. Supersedes any earlier open numbers PR. Opened via NUMBERS_TOKEN so required checks run automatically; auto-merges once they pass.