### PR TITLE
chore(numbers): refresh marketing counters

### DIFF
--- a/docs/_data/numbers.json
+++ b/docs/_data/numbers.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Refreshed daily by .github/workflows/refresh-numbers.yml. The marketing page (docs/index.html) fetches this file same-origin to bypass the CORS blocks on extensions.gnome.org and the auth requirement on api.pepy.tech/v2. Manual edits will be overwritten on the next scheduled run.",
-  "updated_at": "2026-08-20T06:51:49Z",
+  "updated_at": "2026-08-20T06:54:32Z",
   "pypi": {
     "package": "clipman-clipboard",
     "last_day": 0,
-    "last_week": 3,
-    "last_month": 74,
+    "last_week": 4,
+    "last_month": 60,
     "source": "https://pypistats.org/api/packages/clipman-clipboard/recent"
   },
   "gnome": {


### PR DESCRIPTION
Automated daily refresh of marketing counters and the self-hosted star chart. Supersedes any earlier open numbers PR. Opened via NUMBERS_TOKEN so required checks run automatically; auto-merges once they pass.