### PR TITLE
ci: job-scoped token permissions + pins for the two bot workflows

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -10,8 +10,9 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: write
+# Default-deny at the workflow level; the single job below is granted
+# exactly what it needs (Scorecard Token-Permissions).
+permissions: {}
 
 jobs:
   delete:
@@ -20,7 +21,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: write  # delete the merged head branch ref
     steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Delete head branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-numbers.yml
+++ b/.github/workflows/refresh-numbers.yml
@@ -28,9 +28,9 @@ on:
       - 'scripts/refresh_stats.py'
       - 'docs/_data/numbers.json'
 
-permissions:
-  contents: write       # push a refresh branch
-  pull-requests: write  # open the auto-merge PR
+# Default-deny at the workflow level; the single job below is granted
+# exactly what it needs (Scorecard Token-Permissions).
+permissions: {}
 
 concurrency:
   group: refresh-numbers
@@ -40,8 +40,15 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write       # push a refresh branch
+      pull-requests: write  # open the auto-merge PR
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           # Use the fine-grained PAT (NUMBERS_TOKEN) so the branch push and
@@ -56,7 +63,7 @@ jobs:
           # stall as before — harmless, just not hands-off).
           token: ${{ secrets.NUMBERS_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Batch 2/5 from the cosmetics/polish audit — CI hardening flagged by OpenSSF Scorecard.

- **Token-Permissions (0/10 → fixed):** `refresh-numbers.yml` and `delete-merged-branch.yml` granted `contents: write` at the *workflow* level, which every job (including any future one) inherits silently. Both now declare default-deny `permissions: {}` at the top and grant the single job exactly what it needs (`contents: write`, plus `pull-requests: write` for the numbers PR).
- **Pinned-Dependencies:** `refresh-numbers.yml` was the only workflow still referencing actions by tag (`checkout@v7.0.1`, `setup-python@v7`); now pinned to the same commit SHAs the rest of the repo uses.
- **harden-runner:** both workflows get the repo-standard `step-security/harden-runner` first step (`egress-policy: audit`), matching every other workflow.

No behavioural change — same effective permissions for each single-job workflow, same action versions the tags already resolved to. YAML validated; effective permission maps checked (`refresh: contents+PRs write`, `delete: contents write`).