### PR TITLE
fix: replace GTK APIs deprecated since 4.10/4.12

### DIFF
--- a/clipman/preferences.py
+++ b/clipman/preferences.py
@@ -137,9 +137,10 @@ class ClipmanPreferences(Adw.Dialog):
         self.db = db
         self._on_setting_changed = on_setting_changed or (lambda k, v: None)
         self._kbd_dialog = None  # held so the GC doesn't collect mid-capture
-        # As an Adw.Dialog this is NOT a Gtk.Window, so it can't be the
-        # parent of a Gtk.FileChooserNative. Keep the real toplevel (the
-        # ClipmanWindow passed in) for the backup/restore choosers.
+        # As an Adw.Dialog this is NOT a Gtk.Window, and Gtk.FileDialog's
+        # save()/open() want a Gtk.Window (or None) as the modal parent.
+        # Keep the real toplevel (the ClipmanWindow passed in) for the
+        # backup/restore dialogs.
         self._parent_window = parent
 
         self.set_title(_("Preferences"))
@@ -749,47 +750,37 @@ class ClipmanPreferences(Adw.Dialog):
         return f"{count} entries · {size_str}"
 
     def _on_backup_clicked(self, _btn):
-        chooser = Gtk.FileChooserNative.new(
-            _("Export backup"),
-            self._parent_window,
-            Gtk.FileChooserAction.SAVE,
-            _("Save"),
-            _("Cancel"),
-        )
-        chooser.set_current_name(
+        dialog = Gtk.FileDialog()
+        dialog.set_title(_("Export backup"))
+        dialog.set_initial_name(
             f"clipman-{time.strftime('%Y%m%d-%H%M%S')}.db"
         )
-        chooser.connect("response", self._on_backup_response, chooser)
-        chooser.show()
+        dialog.save(self._parent_window, None, self._on_backup_finished)
 
-    def _on_backup_response(self, _native, response, chooser):
-        if response == Gtk.ResponseType.ACCEPT:
-            file = chooser.get_file()
-            if file is not None:
-                try:
-                    self.db.export_backup(file.get_path())
-                    self._emit_event("backup_succeeded", file.get_path())
-                except Exception as exc:
-                    self._emit_event("backup_failed", str(exc))
-        chooser.destroy()
+    def _on_backup_finished(self, dialog, result):
+        try:
+            file = dialog.save_finish(result)
+        except GLib.Error:
+            return  # dismissed
+        if file is not None:
+            try:
+                self.db.export_backup(file.get_path())
+                self._emit_event("backup_succeeded", file.get_path())
+            except Exception as exc:
+                self._emit_event("backup_failed", str(exc))
 
     def _on_restore_clicked(self, _btn):
-        chooser = Gtk.FileChooserNative.new(
-            _("Restore from backup"),
-            self._parent_window,
-            Gtk.FileChooserAction.OPEN,
-            _("Open"),
-            _("Cancel"),
-        )
-        chooser.connect("response", self._on_restore_response, chooser)
-        chooser.show()
+        dialog = Gtk.FileDialog()
+        dialog.set_title(_("Restore from backup"))
+        dialog.open(self._parent_window, None, self._on_restore_finished)
 
-    def _on_restore_response(self, _native, response, chooser):
-        if response == Gtk.ResponseType.ACCEPT:
-            file = chooser.get_file()
-            if file is not None:
-                self._confirm_restore(file.get_path())
-        chooser.destroy()
+    def _on_restore_finished(self, dialog, result):
+        try:
+            file = dialog.open_finish(result)
+        except GLib.Error:
+            return  # dismissed
+        if file is not None:
+            self._confirm_restore(file.get_path())
 
     def _confirm_restore(self, source_path):
         """Show a destructive AlertDialog before overwriting the DB.

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -531,7 +531,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._css_provider = Gtk.CssProvider()
         # ``load_from_data`` is binding-typed as ``bytes`` on older PyGObject
         # — passing a Python ``str`` raises ``TypeError`` before the popup
-        # finishes building. Adw 4.12+ ships ``load_from_string`` which
+        # finishes building. GTK 4.12+ ships ``load_from_string`` which
         # accepts ``str`` directly; fall back to the bytes form everywhere
         # else.
         if hasattr(self._css_provider, "load_from_string"):
@@ -1254,7 +1254,20 @@ class ClipmanWindow(Adw.ApplicationWindow):
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
                 image_path, box, box, True
             )
-            texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+            # Gdk.Texture.new_for_pixbuf is deprecated since GTK 4.12;
+            # build the texture from the pixbuf's raw bytes instead.
+            fmt = (
+                Gdk.MemoryFormat.R8G8B8A8
+                if pixbuf.get_has_alpha()
+                else Gdk.MemoryFormat.R8G8B8
+            )
+            texture = Gdk.MemoryTexture.new(
+                pixbuf.get_width(),
+                pixbuf.get_height(),
+                fmt,
+                pixbuf.read_pixel_bytes(),
+                pixbuf.get_rowstride(),
+            )
         except Exception:
             # Corrupt file or unsupported format — fall back to the type
             # icon rather than crashing.

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -518,10 +518,11 @@ class TestWindowConstruction(unittest.TestCase):
         self.assertEqual(wl_called, [])
 
     def test_backup_restore_use_toplevel_parent(self):
-        """FileChooserNative needs a Gtk.Window parent; the dialog isn't one.
+        """Gtk.FileDialog wants a Gtk.Window parent; the Adw.Dialog isn't one.
 
         Regression guard for the PreferencesWindow->PreferencesDialog port
-        that crashed Export/Restore with a TypeError.
+        that crashed Export/Restore with a TypeError: the preferences
+        dialog must keep the real toplevel around for save()/open().
         """
         from gi.repository import Gtk
 
@@ -533,11 +534,7 @@ class TestWindowConstruction(unittest.TestCase):
         parent = ClipmanWindow(application=app, db=db, monitor=None)
         prefs = ClipmanPreferences(db, parent, on_setting_changed=None)
         self.assertIsInstance(prefs._parent_window, Gtk.Window)
-        # The parent must be accepted by FileChooserNative (no TypeError).
-        chooser = Gtk.FileChooserNative.new(
-            "t", prefs._parent_window, Gtk.FileChooserAction.SAVE, "s", "c"
-        )
-        self.assertIsNotNone(chooser)
+        self.assertNotIsInstance(prefs, Gtk.Window)
 
     def test_window_is_not_resizable(self):
         """Win+V parity: the popup is a fixed panel, not a resizable window."""


### PR DESCRIPTION
Batch 3/5 from the cosmetics/polish audit — the two GTK deprecations in the codebase.

- **`Gtk.FileChooserNative` → `Gtk.FileDialog`** (deprecated since GTK 4.10; was the test suite's only deprecation warning). Backup/restore now use the async `save()`/`open()` + `*_finish` pattern with `GLib.Error` on dismissal. Still parented to the real toplevel — the preferences `Adw.Dialog` is not a `Gtk.Window`, which `FileDialog` wants as modal parent; the regression test now asserts that invariant directly instead of instantiating the deprecated chooser.
- **`Gdk.Texture.new_for_pixbuf` → `Gdk.MemoryTexture.new`** (deprecated since GTK 4.12 — silently: PyGObject emits no runtime warning). Thumbnails are built from the pixbuf's raw bytes with the proper memory format (`R8G8B8A8`/`R8G8B8`) and rowstride.
- Comment fix: `load_from_string` is GTK 4.12+, not "Adw 4.12+".

## Verification
- 330 tests pass with **zero deprecation warnings** (previously one).
- New texture path verified **pixel-perfect via PNG round-trip** for RGB and RGBA pixbufs, including stride-padded odd-width rows (first *and* last pixel probed).
- ruff clean.