### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-22
+
+A polish release driven by a full four-dimension audit (docs, code, UI,
+repo meta): every public claim re-aligned with the shipped product, the
+two GTK deprecations removed, the update banner made dismissable, and
+the UI brought to full parity with the design mockups. Rebuilding the
+snap also pulls the patched libcurl from USN-8651-1.
+
 ### Added — GNOME Shell 49 & 50 support (#186)
 
 - The Shell extension (v7) now declares support for GNOME Shell 49 and
@@ -15,6 +23,51 @@ All notable changes to Clipman are documented in this file.
   the popup is additionally hidden from the dash and Alt+Tab via the
   supported `Meta.Window.hide_from_window_list()` API, which the code
   already feature-detected.
+
+### Fixed
+
+- **The update banner can now be dismissed** (#231). `updates.dismiss()`
+  existed but nothing called it — the bare `Adw.Banner` has no dismiss
+  control, so once a release was out the banner reappeared on every
+  launch. The notice is now a custom banner row (icon · title/desc ·
+  action · dismiss X) and the X persists the dismissal per version.
+- Backup/restore use `Gtk.FileDialog` instead of the deprecated
+  `Gtk.FileChooserNative`; thumbnails use `Gdk.MemoryTexture` instead of
+  the deprecated `Gdk.Texture.new_for_pixbuf` (#229). Zero deprecation
+  warnings in the test suite.
+
+### Changed — UI parity with the design mockups (#231)
+
+- Header and footer sit on the raised mantle surface; status-page icons
+  are tinted per tone; privacy states (paused pill, incognito banner)
+  use the mockup's lavender instead of warning amber; the search field
+  rests recessed and raises on focus; image thumbnails get rounded
+  corners; filter tabs left-aligned; Preferences gains an "In-popup
+  shortcuts" reference group. README screenshots retaken from this
+  build (`scripts/screenshot.py --theme/--incognito`).
+
+### Documentation (#226, #230)
+
+- Truth sweep: marketing-site install commands fixed (they referenced
+  nonexistent v1.1.0 asset names), the privacy FAQ now accurately
+  describes the optional once-daily update check, README/llms.txt
+  describe the shipped preferences dialog/palettes/list implementation,
+  test counts and support tables refreshed, `CITATION.cff` auto-bumped
+  by `bump-version.sh`.
+- New `AGENTS.md`: tool-agnostic working guide (workflow, verification
+  recipes, platform gotchas, release chain) for AI-assisted development.
+
+### CI (#227)
+
+- Bot workflows use job-scoped token permissions, commit-SHA-pinned
+  actions and the harden-runner first step (OpenSSF Scorecard
+  Token-Permissions fix).
+
+### Compatibility
+
+Unchanged from 1.2.0 otherwise: Python 3.10–3.12, GNOME Shell 45–50,
+Wayland. No D-Bus contract changes; no database migrations. The GNOME
+Shell extension remains at v7 (no upload needed).
 
 ## [1.2.0] - 2026-07-18
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ authors:
   - given-names: Mohammed
     family-names: El-sayed Ahmed
 abstract: "Clipman is a clipboard history manager for Wayland (GNOME, KDE, Sway, Hyprland). Press Super+V to view your clipboard history, search entries, pin favorites, and instantly paste previous copies — like Windows Win+V, but for Linux."
-version: 1.2.0
-date-released: 2026-07-18
+version: 1.2.1
+date-released: 2026-08-22
 url: "https://mohammedel-sayedahmed.github.io/clipman/"
 repository-code: "https://github.com/MohammedEl-sayedAhmed/clipman"
 license: Apache-2.0

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mohammed El-sayed Ahmed <MohammedEl-sayedAhmed@users.noreply.github.com>
 pkgname=clipman-clipboard
-pkgver=1.2.0
+pkgver=1.2.1
 pkgrel=1
 pkgdesc="A clipboard history manager for Wayland (GNOME, KDE, Sway, Hyprland, etc.)"
 arch=('any')

--- a/clipman/_version.py
+++ b/clipman/_version.py
@@ -12,4 +12,4 @@ expect it (tests, CLI ``--version``, pyproject metadata).
 ``scripts/bump-version.sh`` patches the literal in this file.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
+++ b/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
@@ -41,7 +41,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.2.0.tar.gz",
+                    "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.2.1.tar.gz",
                     "sha256": "bb5f2ccfb41eea1bf92bfe76fb1b786bb14f782782f155b2575f72d7859cc116"
                 },
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clipman-clipboard"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Wayland-native clipboard history manager built with GTK 4 and libadwaita"
 readme = "README.md"
 license = "Apache-2.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: clipman
-version: '1.2.0'
+version: '1.2.1'
 summary: Clipboard history for Wayland — like Win+V for Linux
 description: |
   A fast, native clipboard manager for Wayland (GNOME, KDE, Sway,


### PR DESCRIPTION
Release PR for **v1.2.1** — the audit-driven polish release. Version bumped across pyproject, `_version.py`, snap, flathub, AUR, and (for the first time via the new `bump-version.sh` step) `CITATION.cff`.

Full notes in `CHANGELOG.md` §1.2.1. Highlights:
- GNOME Shell 49 & 50 support (extension v7, already live on e.g.o.)
- Update banner finally dismissable (bug: `dismiss()` had no caller)
- GTK 4.10/4.12 deprecations removed (zero warnings in the suite)
- UI parity with the design mockups + fresh README screenshots
- Docs truth sweep + `AGENTS.md`; Scorecard CI hardening
- The snap rebuild pulls the patched libcurl (**resolves USN-8651-1** for stable and edge)

After merge: tag `v1.2.1` via the API → `release.yml` publishes PyPI/Snap/AUR/GitHub Latest. The PyPI page's stale "GNOME 46–48" README snapshot gets refreshed by this release. No extension upload needed (still v7).