### PR TITLE
docs: record the snap gnome-extension migration and self-healing rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,17 @@ specific assistant.
 7. PyPI/store pages render the **README snapshot from the release** —
    README fixes reach PyPI only via the next release.
 8. Snap Store security emails ("built with packages that have since
-   received security updates", USN-…) are resolved by any rebuild — a
-   release does it; otherwise dispatch the snap rebuild workflow.
+   received security updates", USN-…) are resolved by any rebuild and
+   now **self-heal**: the weekly `snap-refresh` cron rebuilds every
+   published channel (stable/candidate/beta from the latest release
+   tag, edge from main — never publish a main build to stable, it
+   would leak unreleased code). The snap uses `extensions: [gnome]`,
+   so the GTK stack (and its libcurl-via-libappstream tail, the old
+   recurring offender) lives in Canonical's gnome-46-2404 content snap
+   and is off our scan surface entirely; only `wtype` (+ wl-clipboard,
+   built from source) is ours. For an immediate fix, dispatch
+   `snap-refresh.yml` with the target channel — the channel choice
+   picks the right source ref automatically.
 
 ## Bots & automation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+### Changed — Snap packaging (#237, #238)
+
+- The snap now uses the `gnome` extension: the GTK4/libadwaita runtime
+  (GTK 4.18 / libadwaita 1.7) comes from Canonical's `gnome-46-2404`
+  content snap instead of being staged from the Ubuntu archive. This
+  removes the `libadwaita → libappstream → libcurl` dependency tail
+  that made every curl security update trip the Snap Store's daily
+  scan (three "outdated Ubuntu packages" emails in five weeks), shrinks
+  the snap to ~13 MB, and hands GTK-stack security rebuilds to
+  Canonical. Only `wtype` and the from-source `wl-clipboard` remain
+  first-party payload.
+- The weekly snap rebuild now refreshes every published channel —
+  stable/candidate/beta are rebuilt from the latest release tag, edge
+  from main — so store security notices self-resolve within a week
+  with no manual action.
+
 ## [1.2.1] - 2026-08-22
 
 A polish release driven by a full four-dimension audit (docs, code, UI,


### PR DESCRIPTION
Follow-up to #237/#238: AGENTS.md's USN guidance now describes the self-healing weekly rebuild and the delegated GTK stack (with the main→stable prohibition spelled out), and CHANGELOG gains the Unreleased packaging entry so the next release notes carry it.