### PR TITLE
docs(site): embed the animated demo on the landing page

### DIFF
--- a/docs/demo/clipman-reel.html
+++ b/docs/demo/clipman-reel.html
@@ -1,3 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+<body>
 <title>Clipman Demo Reel</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -329,7 +336,9 @@ body.capture .stage{width:100vw; height:100vh; max-width:none; border-radius:0; 
   const groups=[...content.querySelectorAll('.group')];
   const reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
   const HASH=location.hash;
-  if(HASH.startsWith('#capture')){document.body.classList.add('capture'); if(HASH.includes('vertical'))document.body.classList.add('vertical');}
+  const RECORDING=HASH.startsWith('#capture');  // full-bleed, stop on the outro card (for recording)
+  const EMBED=HASH.startsWith('#embed');        // full-bleed, looping (for site iframe embed)
+  if(RECORDING||EMBED){document.body.classList.add('capture'); if(HASH.includes('vertical'))document.body.classList.add('vertical');}
   let S0=1, curScale=1, RUN=0, paused=false, capsOn=!HASH.includes('nocap');
 
   const NAMES=['Intro','Search','Filter','Paste','Pin','Privacy','Outro'];
@@ -443,7 +452,7 @@ body.capture .stage{width:100vw; height:100vh; max-width:none; border-radius:0; 
     if(!await ok(me,700))return;
     outro.classList.add('show');
     if(!await ok(me,2700))return;
-    if(document.body.classList.contains('capture')){ window.__done=true; return; } // hold the card for a clean recording end
+    if(RECORDING){ window.__done=true; return; } // hold the card for a clean recording end
     outro.classList.remove('show');
     if(!await ok(me,650))return;
     window.__loop=(window.__loop||0)+1;
@@ -459,3 +468,6 @@ body.capture .stage{width:100vw; height:100vh; max-width:none; border-radius:0; 
   if(document.fonts&&document.fonts.ready){document.fonts.ready.then(fit);}
 })();
 </script>
+
+</body>
+</html>

--- a/docs/demo/record.js
+++ b/docs/demo/record.js
@@ -9,7 +9,7 @@ const fs = require('fs');
   const base = process.argv[3] || 'clipman-demo';
   const dir = path.resolve(__dirname, 'rec');
   fs.mkdirSync(dir, { recursive: true });
-  const file = 'file://' + path.resolve(__dirname, 'clipman-reel-standalone.html') + hash;
+  const file = 'file://' + path.resolve(__dirname, 'clipman-reel.html') + hash;
 
   const browser = await chromium.launch({
     channel: 'chrome',

--- a/docs/index.html
+++ b/docs/index.html
@@ -589,6 +589,24 @@ html[data-theme="light"] .demo-stage iframe {
 }
 .demo-foot a { font-family: var(--mono); }
 
+/* Animated product demo (motion reel), embedded as a 16:9 live iframe. */
+.reel-stage { margin: 0 0 26px; display: flex; justify-content: center; }
+.reel-frame {
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    background: #131220;
+    box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.55),
+                0 4px 12px -4px rgba(0, 0, 0, 0.18);
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+}
+html[data-theme="light"] .reel-frame {
+    box-shadow: 0 24px 60px -22px rgba(28, 25, 23, 0.22),
+                0 4px 12px -4px rgba(28, 25, 23, 0.08);
+}
+
 /* ================================================================
    BY THE NUMBERS
    ================================================================ */
@@ -1094,9 +1112,15 @@ footer.site .legal .mono { font-size: 0.78rem; }
       <p class="eyebrow">Live preview</p>
       <h2>Clipboard history shouldn't be a <span class="accent">leap of faith</span>.</h2>
       <p class="lede">
-        This is the redesigned main popup, embedded right here. Flip through real states —
-        full history, empty, no-results, incognito paused — without installing anything.
+        Watch the whole flow — search, paste, pin, incognito — then flip through the real
+        states yourself below. Both run right in this page; nothing to install.
       </p>
+
+      <div class="reel-stage">
+        <iframe class="reel-frame" title="Clipman — animated product demo"
+                src="demo/clipman-reel.html#embed" loading="lazy"
+                referrerpolicy="no-referrer" scrolling="no"></iframe>
+      </div>
 
       <div class="demo-wrap">
         <div class="demo-bar">


### PR DESCRIPTION
## What

Embeds the animated product demo on the marketing site as the hero of the **Live preview** section.

- New `#embed` mode in the reel — full-bleed + **looping** — shipped as a self-contained standalone `docs/demo/clipman-reel.html`.
- A 16:9 lazy-loaded `<iframe class="reel-frame">` above the existing interactive state explorer (which is unchanged).
- `record.js` now targets `clipman-reel.html` directly.

## Why an iframe, not a video

The iframe plays the scene at the browser's **native refresh rate** — the same buttery-smooth motion as the source, with no encoding artifacts and no extra binary. The downloadable MP4/GIF (README) remain for contexts that can't run an iframe.

Verified locally: the reel renders full-bleed and loops in-page; the two theme screenshots and the state explorer are untouched.