### PR TITLE
fix(flatpak): correct v1.2.1 tarball hash, refresh metainfo releases

### DIFF
--- a/data/com.clipman.Clipman.metainfo.xml
+++ b/data/com.clipman.Clipman.metainfo.xml
@@ -71,6 +71,16 @@
   </supports>
 
   <releases>
+    <release version="1.2.1" date="2026-08-22">
+      <description>
+        <p>Polish release: GNOME Shell 49 and 50 support, a dismissable update banner, GTK 4.10/4.12 deprecation removals, and full UI parity with the design mockups.</p>
+      </description>
+    </release>
+    <release version="1.2.0" date="2026-07-18">
+      <description>
+        <p>The GTK 4 line is now stable: true Win+V behaviour on GNOME Wayland, a much faster virtualized history list, and a full redesign to the project design mockups.</p>
+      </description>
+    </release>
     <release version="1.1.0" date="2026-06-25">
       <description>
         <p>GTK 3 to GTK 4 + libadwaita port and Catppuccin palette overlay.</p>

--- a/data/io.github.MohammedEl_sayedAhmed.Clipman.metainfo.xml
+++ b/data/io.github.MohammedEl_sayedAhmed.Clipman.metainfo.xml
@@ -5,7 +5,7 @@
   <summary>Clipboard history manager for GNOME on Wayland</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
-  <developer id="io.github.MohammedEl-sayedAhmed">
+  <developer id="io.github.mohammedel-sayedahmed">
     <name>Mohammed El-sayed Ahmed</name>
   </developer>
 
@@ -68,6 +68,16 @@
   </supports>
 
   <releases>
+    <release version="1.2.1" date="2026-08-22">
+      <description>
+        <p>Polish release: GNOME Shell 49 and 50 support, a dismissable update banner, GTK 4.10/4.12 deprecation removals, and full UI parity with the design mockups.</p>
+      </description>
+    </release>
+    <release version="1.2.0" date="2026-07-18">
+      <description>
+        <p>The GTK 4 line is now stable: true Win+V behaviour on GNOME Wayland, a much faster virtualized history list, and a full redesign to the project design mockups.</p>
+      </description>
+    </release>
     <release version="1.1.0" date="2026-06-25">
       <description>
         <p>GTK 3 to GTK 4 + libadwaita port and Catppuccin palette overlay.</p>

--- a/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
+++ b/flathub/io.github.MohammedEl_sayedAhmed.Clipman.json
@@ -42,7 +42,7 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/MohammedEl-sayedAhmed/clipman/archive/refs/tags/v1.2.1.tar.gz",
-                    "sha256": "bb5f2ccfb41eea1bf92bfe76fb1b786bb14f782782f155b2575f72d7859cc116"
+                    "sha256": "c129056324b3b25dbdb10989c866e69d13a511626cfa2682ce094851aa6be4d5"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Flatpak manifest/AppStream hygiene, all verified with Flathub's own linter (`flatpak-builder-lint` manifest + appstream pass):

- Manifest source hash was stale: `bump-version.sh` rewrites the tag URL but can't know the new tarball's sha256 at bump time, so it rots each release — corrected to the real v1.2.1 digest (post-tag refresh should join the release checklist).
- `<releases>` in both AppStream files stopped at 1.1.0 — added 1.2.0/1.2.1.
- `developer id` lowercased (AppStream requires lowercase ASCII; was linted as `developer-id-invalid`).