### PR TITLE
Single-source dependency manifest, dev bootstrap, and CI parity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,12 +18,12 @@
 
 <!-- How did you verify the change? Manual steps, automated tests, etc. -->
 
-- [ ] `python -m unittest discover -s tests` passes locally
+- [ ] `scripts/dev.sh test` passes locally
 - [ ] Manually exercised the affected feature
 
 ## Checklist
 
-- [ ] Code follows the repo style (`ruff check clipman tests` clean)
-- [ ] Shell scripts pass `shellcheck`
+- [ ] Code follows the repo style (`scripts/dev.sh ruff` clean)
+- [ ] Shell scripts pass `scripts/dev.sh shellcheck`
 - [ ] Updated `CHANGELOG.md` if user-visible
 - [ ] Updated `README.md` / docs if behavior changed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,10 +37,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install ruff
-        run: pip install ruff==0.15.13
+        run: pip install -e '.[lint]'
 
       - name: Run ruff
-        run: ruff check clipman tests
+        run: scripts/dev.sh ruff
 
   shell:
     name: Shell (shellcheck)
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+        run: scripts/deps.sh --lint --install --yes
 
       - name: Run shellcheck
-        run: shellcheck --severity=warning install.sh uninstall.sh launcher.sh
+        run: scripts/dev.sh shellcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
+    env:
+      CLIPMAN_REQUIRE_GTK4: "1"
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
@@ -130,18 +132,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            gir1.2-gtk-3.0 python3-gi python3-dbus wl-clipboard \
-            libcairo2-dev libgirepository-2.0-dev || \
-          sudo apt-get install -y libgirepository1.0-dev
+        timeout-minutes: 4
+        run: scripts/deps.sh --dev --install --yes
 
       - name: Install Python dependencies
-        run: pip install PyGObject pydbus
+        run: pip install -e '.[test]'
 
       - name: Run tests
-        run: python -m unittest discover -s tests
+        run: scripts/dev.sh test
 
   build-pypi:
     name: Build PyPI artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     env:
-      # Tests/test_window.py reads this: when set to "1" the GTK4 /
-      # libadwaita smoke tests FAIL (instead of skipping) if the
-      # typelibs aren't importable. That keeps a future apt-package
-      # rename from silently turning the GTK4 suite into a no-op on
-      # CI without anyone noticing.
+      # "1" makes the GTK4/libadwaita tests fail instead of skip when the
+      # typelibs are missing, so a package rename cannot silently no-op them.
       CLIPMAN_REQUIRE_GTK4: "1"
     steps:
       - name: Harden runner
@@ -47,23 +44,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            wl-clipboard \
-            wtype \
-            python3-gi \
-            python3-dbus \
-            gir1.2-gtk-4.0 \
-            gir1.2-adw-1 \
-            libadwaita-1-0 \
-            xvfb \
-            libcairo2-dev \
-            libgirepository-2.0-dev || \
-          sudo apt-get install -y libgirepository1.0-dev
+        timeout-minutes: 4
+        run: scripts/deps.sh --dev --install --yes
 
       - name: Install Python dependencies
-        run: pip install PyGObject pydbus
+        run: pip install -e '.[test]'
 
       - name: Run tests
-        run: xvfb-run -a python -m unittest discover -s tests
+        run: scripts/dev.sh test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,15 +42,27 @@ specific assistant.
 
 ## Verification recipes
 
-- Use the **system Python** (`/usr/bin/python3`) — project venvs lack the
-  `gi` bindings.
-- Full suite: `CLIPMAN_REQUIRE_GTK4=1 xvfb-run -a /usr/bin/python3 -m pytest -q`
-  (CI equivalent: `xvfb-run -a python -m unittest discover -s tests`).
-- Lint scope matches CI exactly: `ruff check clipman tests`.
-- Headless visual checks: `xvfb-run -a /usr/bin/python3 scripts/screenshot.py`
-  renders the real window/preferences to PNG. Caveat: `Adw.Dialog` content
-  can't be captured through the xvfb harness ("empty render node") — snapshot
-  the dialog's child widget, or verify on a real display.
+- Setup: `scripts/dev-setup.sh` (or `make setup`) installs the system
+  packages via `scripts/deps.sh`, creates `.venv` with
+  `--system-site-packages` — so the venv *does* see `gi` and `dbus` — and
+  installs the `dev` extras. `scripts/dev.sh` picks `$CLIPMAN_PYTHON`,
+  else `.venv/bin/python`, else `python3`.
+- Full suite: `scripts/dev.sh test` — identical to CI: pytest under
+  `xvfb-run -a` with `CLIPMAN_REQUIRE_GTK4=1`, falling back to
+  `unittest discover -s tests` when pytest is not importable. Extra
+  arguments go to the runner (`scripts/dev.sh test -k database`). 331 tests.
+  The `test` extra caps PyGObject below 3.59: CI builds it from source
+  against noble's GLib 2.80, so bump the cap deliberately.
+- Lint: `scripts/dev.sh lint` = `ruff check clipman tests` +
+  `shellcheck --severity=warning install.sh uninstall.sh launcher.sh scripts/*.sh`,
+  the exact CI scopes (`ruff` / `shellcheck` subcommands run one half;
+  `check` runs lint then test). Ruff is pinned at 0.15.13 in the `lint`
+  extra — newer releases report findings CI does not.
+- Headless visual checks: `scripts/dev.sh screenshot --out /tmp/x.png`
+  renders the real window/preferences to PNG under xvfb. Caveat:
+  `Adw.Dialog` content can't be captured through the xvfb harness ("empty
+  render node") — snapshot the dialog's child widget, or verify on a real
+  display.
 - The CodeQL **security-baseline gate** fails PRs on *new* findings —
   historically `py/empty-except`, `py/multiple-definition`,
   `py/implicit-string-concatenation-in-list`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to Clipman are documented in this file.
 
 ## [Unreleased]
 
+### Added — developer tooling
+
+- `scripts/deps.sh`: one manifest of system packages (`runtime`, `test`,
+  `lint` sets; apt, dnf, pacman). `install.sh` and CI read it; the apt
+  list used to be copied by hand into `install.sh`, `test.yml` and
+  `release.yml`.
+- `scripts/dev-setup.sh`: one-command bootstrap. Installs the system
+  packages, creates `.venv` with `--system-site-packages`, installs the
+  `dev` extras and the git hooks.
+- `scripts/dev.sh`: task runner (`test`, `lint`, `check`, `screenshot`,
+  `hooks-test`, …) with an optional `Makefile` wrapper. `dev.sh test` is
+  exactly what CI runs.
+- `lint`, `test` and `dev` extras in `pyproject.toml` (ruff pinned at
+  0.15.13, pytest, PyGObject, dbus-python).
+
+### Fixed — CI ran fewer tests than it reported
+
+- The release workflow's test job installed the GTK 3 typelibs, set no
+  `CLIPMAN_REQUIRE_GTK4` and ran without xvfb, so the widget tests were
+  skipped on the release-gating run. It now runs the same three steps
+  as `test.yml`.
+- CI installed `pydbus`, but the app imports `dbus` (dbus-python), so
+  `clipman.app` failed to import under the matrix interpreter and
+  `test_app.py` skipped (8 tests). The `test` extra installs dbus-python.
+- `test_keybindings.py` probed `gi.repository.Gdk` as an attribute,
+  which only exists once another module has imported Gdk, so it skipped
+  (10 tests) depending on import order. It now imports the submodule.
+  Every CI run had reported `OK (skipped=18)`.
+- The `toggle` smoke test in `test_entry_point.py` now runs without a
+  display and against a dead session bus, so it fails fast instead of
+  starting the daemon, and cannot toggle a developer's real one.
+- `scripts/install-hooks.sh` no longer blocks on `read` when there is
+  no terminal and, without one, only replaces a foreign
+  `core.hooksPath` when `--replace` is given.
+
 ### Changed — Snap packaging (#237, #238)
 
 - The snap now uses the `gnome` extension: the GTK4/libadwaita runtime
@@ -19,6 +54,15 @@ All notable changes to Clipman are documented in this file.
   stable/candidate/beta are rebuilt from the latest release tag, edge
   from main — so store security notices self-resolve within a week
   with no manual action.
+
+### Changed — CI
+
+- `test.yml`, `lint.yml` and the release test job install system
+  packages via `scripts/deps.sh` and run the suite via
+  `scripts/dev.sh test`, so a local run and CI are the same command.
+  The apt step is capped at four minutes; apt retries with a 30 s fetch
+  timeout so a stalled mirror fails inside the cap. The last red run on
+  `main` was an apt stall that consumed the whole job budget.
 
 ## [1.2.1] - 2026-08-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,18 +60,25 @@ clipman/
 
 ### Running Tests
 
+One-command setup, then the suite exactly as CI runs it:
+
 ```bash
-python3 -m unittest discover -s tests
+scripts/dev-setup.sh      # or: make setup
+scripts/dev.sh test       # or: make test
 ```
 
-All 330 tests should pass. GTK 4 is required at test time (CI runs the suite under `xvfb-run`); D-Bus is not. Tests cover the database layer, clipboard monitor, window/classification logic, app lifecycle, keybindings, and the update check. See [docs/development.md](docs/development.md) for the fuller dev setup.
+`dev-setup.sh` installs the system packages, creates `.venv` and installs the `dev` extras. The venv uses `--system-site-packages`, so the distro's PyGObject and dbus-python bindings are reused and never rebuilt. `dev.sh test` runs pytest under `xvfb-run` with `CLIPMAN_REQUIRE_GTK4=1` (falling back to `unittest` when pytest is not importable); pytest arguments pass through, e.g. `scripts/dev.sh test -k database`.
+
+All 331 tests should pass. GTK 4 is required at test time; a session bus is not. Tests cover the database layer, clipboard monitor, window/classification logic, app lifecycle, keybindings, and the update check. See [docs/development.md](docs/development.md) for the fuller dev setup.
 
 ### Lint
 
 ```bash
-ruff check clipman tests
-shellcheck --severity=warning install.sh uninstall.sh launcher.sh
+scripts/dev.sh lint       # or: make lint  — ruff + shellcheck
+scripts/dev.sh check      # or: make check — lint, then test
 ```
+
+`lint` runs `ruff check clipman tests` and `shellcheck --severity=warning install.sh uninstall.sh launcher.sh scripts/*.sh`, the same scopes as CI; `scripts/dev.sh ruff` and `scripts/dev.sh shellcheck` run either half alone. Ruff is pinned in the `lint` extra so the local version matches CI.
 
 - Ruff config lives in `pyproject.toml`. The per-file `E402` ignores in `clipman/app.py` and `clipman/window.py` are intentional — `gi.require_version()` legitimately must precede the `from gi.repository import ...` calls.
 - Run shellcheck whenever you touch a shell script.
@@ -110,23 +117,11 @@ Introspect or call them with `gdbus`:
 
 ### Dev system packages
 
-Ubuntu 24.04+ (and other Debian-family distros with GTK 4):
+`scripts/deps.sh` is the single manifest (apt, dnf, pacman); `scripts/dev-setup.sh` installs from it. To use it by hand:
 
 ```bash
-sudo apt-get install -y \
-    python3 python3-gi python3-dbus \
-    gir1.2-gtk-4.0 gir1.2-adw-1 libadwaita-1-0 \
-    wl-clipboard libcairo2-dev libgirepository-2.0-dev \
-    gnome-shell-extensions
-```
-
-Fedora:
-
-```bash
-sudo dnf install -y \
-    python3-gobject python3-dbus gtk4 libadwaita \
-    wl-clipboard cairo-devel gobject-introspection-devel \
-    gnome-extensions-app
+scripts/deps.sh --dev --print      # the list for this host's package manager
+scripts/deps.sh --dev --install    # install what is missing (sudo when needed)
 ```
 
 See [docs/development.md](docs/development.md) for the full setup.
@@ -181,7 +176,7 @@ GTK 4 + libadwaita, theming is layered:
 
 1. Create a feature branch: `git checkout -b feature/your-feature`
 2. Make your changes
-3. Run the test suite: `python3 -m unittest discover -s tests`
+3. Run the checks: `scripts/dev.sh check` (lint, then the test suite)
 4. Commit with a clear message describing what and why
 5. Push and open a Pull Request
 
@@ -189,24 +184,28 @@ GTK 4 + libadwaita, theming is layered:
 
 The repo ships opt-in local hooks under [`.githooks/`](.githooks/) that
 guard against AI-tool footprints and wrong-account commits. They are
-**not required** to contribute; CI does not run them. If you maintain
-multiple GitHub accounts on one machine and want belt-and-suspenders,
-run once:
+**not required** to contribute; CI does not run them.
+`scripts/dev-setup.sh` installs them when nothing else owns
+`core.hooksPath`. To install (or re-install) them by hand:
 
 ```sh
 scripts/install-hooks.sh
 ```
 
-See [docs/hooks.md](docs/hooks.md) for what each hook checks and how to
-opt out.
+If `core.hooksPath` already points elsewhere the script asks before
+replacing it; pass `--replace` to skip the prompt. Without a terminal it
+never blocks on stdin — it exits 1 with that hint instead.
+`scripts/dev.sh hooks-test` runs the hooks' own test corpus. See
+[docs/hooks.md](docs/hooks.md) for what each hook checks and how to opt
+out.
 
 ## How a PR gets reviewed
 
 - **Timeline.** A single maintainer reviews PRs (see GOVERNANCE.md). Typical first response within a week.
 - **What reviewers check.**
-  - Tests pass: `python3 -m unittest discover -s tests`.
-  - `ruff check clipman tests` clean.
-  - `shellcheck --severity=warning install.sh uninstall.sh launcher.sh` clean if any shell script was touched.
+  - Tests pass: `scripts/dev.sh test` (the same command CI runs).
+  - `scripts/dev.sh ruff` clean (`ruff check clipman tests`).
+  - `scripts/dev.sh shellcheck` clean if any shell script was touched (`--severity=warning` over `install.sh`, `uninstall.sh`, `launcher.sh`, `scripts/*.sh`).
   - User-visible change → `CHANGELOG.md` `[Unreleased]` entry.
   - Substantive architectural decision → ADR added under `docs/adr/` per ADR 0001.
   - D-Bus contract change (signature, new method, new arg) → `extension/metadata.json` `version` integer bumped per [ADR 0005](docs/adr/0005-paste-mode-as-dbus-arg.md).
@@ -233,9 +232,9 @@ When filing a bug report, please include:
 
 ## Definition of Done
 
-- [ ] `xvfb-run -a python3 -m unittest discover -s tests` passes locally (330 tests)
-- [ ] `ruff check clipman tests` is clean
-- [ ] `shellcheck --severity=warning install.sh uninstall.sh launcher.sh` is clean if any shell script was touched
+- [ ] `scripts/dev.sh test` passes locally (331 tests)
+- [ ] `scripts/dev.sh ruff` is clean
+- [ ] `scripts/dev.sh shellcheck` is clean if any shell script was touched
 - [ ] `CHANGELOG.md` `[Unreleased]` updated for user-visible changes
 - [ ] ADR added under `docs/adr/` for substantive architectural decisions
 - [ ] `extension/metadata.json` `version` integer bumped if the D-Bus contract changed (per [ADR 0005](docs/adr/0005-paste-mode-as-dbus-arg.md))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Optional wrapper; every target delegates to scripts/dev.sh (what CI runs).
+# Extra runner args: make test ARGS="-k database".
+
+ARGS ?=
+
+.PHONY: setup test lint check screenshot hooks-test deps help
+
+help:
+	@scripts/dev.sh help
+
+setup:
+	scripts/dev.sh setup
+
+test:
+	scripts/dev.sh test $(ARGS)
+
+lint:
+	scripts/dev.sh lint
+
+check:
+	scripts/dev.sh check $(ARGS)
+
+screenshot:
+	scripts/dev.sh screenshot $(ARGS)
+
+hooks-test:
+	scripts/dev.sh hooks-test
+
+deps:
+	scripts/dev.sh deps $(ARGS)

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -14,12 +14,12 @@ on `main`.
 | Dependency review | `dependency-review.yml` | `pull_request` to `main` | Fails the PR on high-severity vulnerabilities or disallowed licenses introduced by dependency changes. | No (informational; no contexts on protection ruleset) |
 | Auto-label PR | `labeler.yml` | `pull_request_target` to `main` | Applies path-based labels from `.github/labeler.yml` so triage knows which area a PR touches. | No |
 | Sync labels | `labels.yml` | `push` to `main` touching `.github/labels.yml`, `workflow_dispatch` | Reconciles repository labels with the declarative `.github/labels.yml` source of truth. | No (push-only) |
-| Lint | `lint.yml` | `push` to `main`, `pull_request` to `main` | `ruff check clipman tests` for Python and `shellcheck` for `install.sh` / `uninstall.sh` / `launcher.sh`. | Yes — `Python (ruff)` and `Shell (shellcheck)` |
+| Lint | `lint.yml` | `push` to `main`, `pull_request` to `main` | `scripts/dev.sh ruff` (`ruff check clipman tests`) and `scripts/dev.sh shellcheck` (`install.sh`, `uninstall.sh`, `launcher.sh`, `scripts/*.sh`). | Yes — `Python (ruff)` and `Shell (shellcheck)` |
 | Release | `release.yml` | `push` of tag matching `v*.*.*`, `workflow_dispatch` | End-to-end release pipeline: pre-flight version checks, matrix tests, builds (PyPI, snap, .deb/.rpm, AppImage, extension bundle), and publishes to PyPI, Snap Store, AUR, and GitHub Releases. | No (tag-triggered only) |
 | Scorecard | `scorecard.yml` | `push` to `main`, weekly cron (`37 4 * * 1`), `branch_protection_rule` | OSSF Scorecard supply-chain analysis; uploads SARIF to the GitHub Security tab and publishes results. | No |
 | Secret scan | `secret-scan.yml` | `push` to `main`, `pull_request` to `main` | Runs `gitleaks` over full git history to catch committed credentials. | Yes — `gitleaks` |
 | Snap refresh | `snap-refresh.yml` | Weekly cron (`0 4 * * 1`), `workflow_dispatch`, `push`/`pull_request` to `main` touching snap-relevant paths | Rebuilds the snap to pick up Ubuntu archive security updates; can publish to the Snap Store on the scheduled run. See ADR 0009. | No |
-| Tests | `test.yml` | `push` to `main`, `pull_request` to `main` | `python -m unittest discover -s tests` across the Python 3.10 / 3.11 / 3.12 matrix on `ubuntu-24.04`. | Yes — `test (3.10)`, `test (3.11)`, `test (3.12)` |
+| Tests | `test.yml` | `push` to `main`, `pull_request` to `main` | `scripts/dev.sh test` (pytest under `xvfb-run` with `CLIPMAN_REQUIRE_GTK4=1`) across the Python 3.10 / 3.11 / 3.12 matrix on `ubuntu-24.04`; system packages come from `scripts/deps.sh`. | Yes — `test (3.10)`, `test (3.11)`, `test (3.12)` |
 
 The remaining required context on `main` is `review`, which is enforced
 by the protection ruleset itself rather than by a workflow file.

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,37 +15,36 @@ the canonical map. Two halves matter for development:
 
 ## Prerequisites
 
-System packages (Ubuntu/Debian — Ubuntu 24.04+ recommended for
-libadwaita 1.4):
+Ubuntu 24.04+ is the baseline (libadwaita 1.4); the same scripts know
+the Fedora (dnf) and Arch (pacman) package names. One command installs
+the system packages, creates `.venv`, installs the dev extras and the
+git hooks:
 
 ```bash
-sudo apt-get install -y \
-    python3 python3-gi python3-dbus \
-    gir1.2-gtk-4.0 gir1.2-adw-1 libadwaita-1-0 \
-    wl-clipboard libcairo2-dev libgirepository-2.0-dev \
-    gnome-shell-extensions
+scripts/dev-setup.sh      # or: make setup
 ```
 
-Fedora equivalents:
+The venv is created with `--system-site-packages`, so the distro's
+PyGObject and dbus-python bindings are reused and never rebuilt
+against a different GIR stack. Re-running the script is safe; it skips
+what is already in place. If it cannot `sudo` without a password it
+prints the exact package-manager command and carries on.
+
+The venv step needs PyPI; set `CLIPMAN_NO_NETWORK=1` to skip it and
+install the extras later. With a distro PyGObject older than 3.46, or
+a non-distro interpreter, pip builds PyGObject from source, which also
+needs a C compiler and GLib 2.80.
+
+
+`scripts/deps.sh` is the single source of truth for the system package
+lists (`runtime`, `test`, `lint` sets). `install.sh` and CI read it
+too, so there is no second copy to keep in sync:
 
 ```bash
-sudo dnf install -y \
-    python3-gobject python3-dbus gtk4 libadwaita \
-    wl-clipboard cairo-devel gobject-introspection-devel \
-    gnome-extensions-app
+scripts/deps.sh --runtime --print    # what install.sh installs
+scripts/deps.sh --dev --check        # what is missing for development
+scripts/deps.sh --dev --install      # install it (sudo when needed)
 ```
-
-A virtualenv is optional but recommended for lint/test tooling:
-
-```bash
-python3 -m venv .venv
-. .venv/bin/activate
-pip install ruff
-```
-
-PyGObject is imported through the system path — don't `pip install
-PyGObject` inside the venv, it'll diverge from the system GIR
-typelibs.
 
 ## Running from source
 
@@ -65,36 +64,50 @@ to refresh `~/.local/share/gnome-shell/extensions/clipman@clipman.com`.
 ## Running tests
 
 ```bash
-python3 -m unittest discover -s tests
+scripts/dev.sh test                  # or: make test
+scripts/dev.sh test -k database      # or: make test ARGS="-k database"
 ```
 
-The full suite (~265 tests) hits the actual SQLite layer, mocks
-clipboard subprocesses, and exercises the keybinding parser. Tests
-require the system `python3-gi` package (the project's CI matrix
-covers Python 3.10–3.12 on `ubuntu-24.04`).
+This is the exact command CI runs: pytest under `xvfb-run -a` with
+`CLIPMAN_REQUIRE_GTK4=1`, so a missing GTK 4 fails the widget tests
+instead of skipping them. When pytest is not importable it falls back
+to `unittest discover -s tests`. The interpreter is `$CLIPMAN_PYTHON`,
+else `.venv/bin/python`, else `python3`.
 
-Targeted runs:
+The full suite (331 tests) hits the actual SQLite layer, mocks
+clipboard subprocesses, and exercises the keybinding parser. The CI
+matrix covers Python 3.10–3.12 on `ubuntu-24.04`.
+
+Targeted runs (pytest syntax):
 
 ```bash
-python3 -m unittest tests.test_keybindings
-python3 -m unittest tests.test_database.TestClipboardDB.test_add_text_entry
+scripts/dev.sh test tests/test_keybindings.py
+scripts/dev.sh test tests/test_database.py::TestClipboardDB::test_add_text_entry
 ```
 
 ## Lint
 
 ```bash
-ruff check clipman tests
+scripts/dev.sh lint                  # or: make lint  — ruff + shellcheck
+scripts/dev.sh check                 # or: make check — lint, then test
 ```
+
+`lint` runs `ruff check clipman tests` and
+`shellcheck --severity=warning install.sh uninstall.sh launcher.sh scripts/*.sh`,
+the same scopes CI uses; `scripts/dev.sh ruff` and
+`scripts/dev.sh shellcheck` run either half alone. Ruff is pinned in
+the `lint` extra so the local version matches CI.
 
 Configuration lives in `pyproject.toml`. The two per-file ignores for
 `E402` in `clipman/app.py` and `clipman/window.py` are intentional —
 `gi.require_version()` legitimately must precede `from gi.repository
 import ...`.
 
-Shell scripts use `shellcheck --severity=warning`:
+Headless screenshots of the real window and preferences:
 
 ```bash
-shellcheck --severity=warning install.sh uninstall.sh launcher.sh
+scripts/dev.sh screenshot --out /tmp/clipman.png
+# or: make screenshot ARGS="--out /tmp/clipman.png"
 ```
 
 ## Debugging

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -38,9 +38,8 @@ git reset --hard origin/main
 #    `## [Unreleased]` block at the top.
 $EDITOR CHANGELOG.md
 
-# 4. Verify locally.
-python3 -m unittest discover -s tests
-ruff check clipman tests
+# 4. Verify locally (lint, then the suite).
+scripts/dev.sh check
 
 # 5. Commit the bump.
 git add pyproject.toml snap/snapcraft.yaml aur/PKGBUILD \

--- a/install.sh
+++ b/install.sh
@@ -11,23 +11,21 @@ EXTENSION_DIR="$HOME/.local/share/gnome-shell/extensions/$EXTENSION_UUID"
 
 echo "=== Installing Clipman ==="
 
-# Determine package manager
-if command -v dnf &> /dev/null; then
-    PKG_MANAGER="dnf"
-elif command -v apt &> /dev/null; then
-    PKG_MANAGER="apt"
-else
-    echo "Error: No supported package manager found (apt or dnf)"
-    exit 1
-fi
-
-# Step 1: Install system dependencies
+# Step 1: Install system dependencies (package lists live in scripts/deps.sh)
 echo "[1/6] Installing dependencies..."
-if [ "$PKG_MANAGER" = "apt" ]; then
-    sudo apt install -y wl-clipboard wtype python3-gi python3-dbus \
-        gir1.2-gtk-4.0 gir1.2-adw-1 libadwaita-1-0
-elif [ "$PKG_MANAGER" = "dnf" ]; then
-    sudo dnf install -y wl-clipboard wtype python3-gobject gtk4 libadwaita python3-dbus
+# shellcheck source=scripts/deps.sh
+source "$SCRIPT_DIR/scripts/deps.sh"
+# Assume yes as 'apt install -y' did; CLIPMAN_DEPS_YES=0 restores the prompt.
+: "${CLIPMAN_DEPS_YES:=1}"
+# Capture the status instead of letting set -e abort, so the exit-3 hint runs.
+deps_rc=0
+clipman_deps_install runtime || deps_rc=$?
+if [ "$deps_rc" -eq 3 ]; then
+    echo "Error: run the sudo command printed above, then re-run ./install.sh"
+    exit 1
+elif [ "$deps_rc" -ne 0 ]; then
+    echo "Error: dependency installation failed (exit $deps_rc)"
+    exit 1
 fi
 
 # Step 2: Create data directories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ Sponsor = "https://github.com/sponsors/MohammedEl-sayedAhmed"
 [project.scripts]
 clipman = "clipman.clipman:main"
 
+[project.optional-dependencies]
+lint = ["ruff==0.15.13"]
+# PyGObject cap: CI builds it from source against noble's GLib 2.80; bump deliberately.
+test = ["pytest==9.1.1", "PyGObject>=3.46,<3.59", "dbus-python>=1.3"]
+dev = ["clipman-clipboard[lint,test]"]
+
 [build-system]
 requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+#
+# System package manifest for clipman: source it for the clipman_deps_*
+# functions, or run it as a CLI (see --help).
+# shellcheck disable=SC2034  # arrays are read through a nameref
+
+# Package lists: runtime (app), test (Xvfb + build headers), lint (shellcheck)
+
+CLIPMAN_DEPS_RUNTIME_APT=(
+    wl-clipboard wtype python3-gi python3-dbus
+    gir1.2-gtk-4.0 gir1.2-adw-1 libadwaita-1-0
+)
+CLIPMAN_DEPS_RUNTIME_DNF=(
+    wl-clipboard wtype python3-gobject python3-dbus gtk4 libadwaita
+)
+CLIPMAN_DEPS_RUNTIME_PACMAN=(
+    wl-clipboard wtype python-gobject python-dbus gtk4 libadwaita
+)
+
+CLIPMAN_DEPS_TEST_APT=(
+    xvfb python3-venv python3-dev pkg-config
+    libcairo2-dev libgirepository-2.0-dev libdbus-1-dev libglib2.0-dev
+)
+CLIPMAN_DEPS_TEST_DNF=(
+    xorg-x11-server-Xvfb python3-devel pkgconf-pkg-config
+    cairo-devel cairo-gobject-devel gobject-introspection-devel
+    dbus-devel glib2-devel
+)
+CLIPMAN_DEPS_TEST_PACMAN=(
+    xorg-server-xvfb python-pip pkgconf cairo gobject-introspection dbus glib2
+)
+
+CLIPMAN_DEPS_LINT_APT=(shellcheck)
+CLIPMAN_DEPS_LINT_DNF=(ShellCheck)
+CLIPMAN_DEPS_LINT_PACMAN=(shellcheck)
+
+# primary=fallback, consulted with `apt-cache policy` for the apt backend.
+declare -A CLIPMAN_DEPS_ALTERNATIVES_APT=(
+    [libgirepository-2.0-dev]=libgirepository1.0-dev
+)
+
+# Helpers
+
+_clipman_deps_log() {
+    printf 'deps: %s\n' "$*" >&2
+}
+
+_clipman_deps_have_tty() {
+    [ -t 0 ]
+}
+
+# Whether the assume-yes flag should be passed to the package manager.
+_clipman_deps_assume_yes() {
+    if [ "${CLIPMAN_DEPS_YES:-0}" = "1" ]; then
+        return 0
+    fi
+    if [ "${CI:-}" = "true" ] && ! _clipman_deps_have_tty; then
+        return 0
+    fi
+    return 1
+}
+
+#######################################
+# Detect the host's package manager.
+# Outputs:
+#   Writes apt, dnf or pacman to stdout.
+# Returns:
+#   1 when none is present.
+#######################################
+clipman_deps_detect_pm() {
+    if command -v apt-get >/dev/null 2>&1; then
+        echo apt
+    elif command -v dnf >/dev/null 2>&1; then
+        echo dnf
+    elif command -v pacman >/dev/null 2>&1; then
+        echo pacman
+    else
+        return 1
+    fi
+}
+
+# Validate/normalize a package-manager name; echo it back.
+_clipman_deps_pm() {
+    local pm="${1:-}"
+    if [ -z "$pm" ]; then
+        if ! pm=$(clipman_deps_detect_pm); then
+            _clipman_deps_log "no supported package manager found (apt-get, dnf or pacman)"
+            return 1
+        fi
+    fi
+    case "$pm" in
+        apt|dnf|pacman) echo "$pm" ;;
+        *)
+            _clipman_deps_log "unknown package manager '$pm' (expected apt, dnf or pacman)"
+            return 1
+            ;;
+    esac
+}
+
+# Echo the raw (unresolved) list for one base set and one pm.
+_clipman_deps_raw_list() {
+    local set="$1" pm="$2" var
+    var="CLIPMAN_DEPS_$(printf '%s' "$set" | tr '[:lower:]' '[:upper:]')_$(printf '%s' "$pm" | tr '[:lower:]' '[:upper:]')"
+    local -n _ref="$var"
+    printf '%s\n' "${_ref[@]}"
+}
+
+# Expand set aliases (dev -> runtime test lint); one set name per line.
+_clipman_deps_expand_sets() {
+    local set
+    for set in "$@"; do
+        case "$set" in
+            runtime|test|lint) echo "$set" ;;
+            dev) printf '%s\n' runtime test lint ;;
+            *)
+                _clipman_deps_log "unknown set '$set' (expected runtime, test, lint or dev)"
+                return 1
+                ;;
+        esac
+    done
+}
+
+# apt only: does the local index know a candidate? Without apt-cache on the
+# host (e.g. `--pm apt --print` elsewhere) we cannot tell, so assume yes.
+_clipman_deps_apt_has_candidate() {
+    local pkg="$1" candidate
+    if ! command -v apt-cache >/dev/null 2>&1; then
+        return 0
+    fi
+    candidate=$(apt-cache policy "$pkg" 2>/dev/null | awk '/^ *Candidate:/ { print $2; exit }')
+    [ -n "$candidate" ] && [ "$candidate" != "(none)" ]
+}
+
+# Apply the alternatives map to one package name and echo the result.
+_clipman_deps_resolve() {
+    local pm="$1" pkg="$2"
+    if [ "$pm" = "apt" ] && [ -n "${CLIPMAN_DEPS_ALTERNATIVES_APT[$pkg]:-}" ]; then
+        if ! _clipman_deps_apt_has_candidate "$pkg"; then
+            pkg="${CLIPMAN_DEPS_ALTERNATIVES_APT[$pkg]}"
+        fi
+    fi
+    echo "$pkg"
+}
+
+# Union of the resolved lists for several sets, one package per line, in
+# first-seen order and de-duplicated.
+_clipman_deps_union() {
+    local pm="$1"
+    shift
+    local sets set pkg
+    sets=$(_clipman_deps_expand_sets "$@") || return 1
+    declare -A seen=()
+    for set in $sets; do
+        while IFS= read -r pkg; do
+            [ -n "$pkg" ] || continue
+            pkg=$(_clipman_deps_resolve "$pm" "$pkg")
+            if [ -z "${seen[$pkg]:-}" ]; then
+                seen[$pkg]=1
+                echo "$pkg"
+            fi
+        done < <(_clipman_deps_raw_list "$set" "$pm")
+    done
+}
+
+# Is one package installed? Uses the pm's own database.
+_clipman_deps_installed() {
+    local pm="$1" pkg="$2"
+    case "$pm" in
+        apt)
+            [ "$(dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null)" = "install ok installed" ]
+            ;;
+        dnf)
+            rpm -q "$pkg" >/dev/null 2>&1
+            ;;
+        pacman)
+            pacman -Qi "$pkg" >/dev/null 2>&1
+            ;;
+    esac
+}
+
+# Missing packages across several sets, one per line.
+_clipman_deps_missing_lines() {
+    local pm="$1"
+    shift
+    local pkgs pkg
+    pkgs=$(_clipman_deps_union "$pm" "$@") || return 1
+    for pkg in $pkgs; do
+        if ! _clipman_deps_installed "$pm" "$pkg"; then
+            echo "$pkg"
+        fi
+    done
+}
+
+# Root, passwordless sudo, or a TTY for sudo's prompt; otherwise return 3 so
+# the caller prints the command instead of hanging or hitting "sudo: not found".
+_clipman_deps_run_privileged() {
+    if [ "$(id -u)" = "0" ]; then
+        "$@"
+    elif ! command -v sudo >/dev/null 2>&1; then
+        return 3
+    elif sudo -n true 2>/dev/null || _clipman_deps_have_tty; then
+        sudo "$@"
+    else
+        return 3
+    fi
+}
+
+# Public API
+
+#######################################
+# Resolve one set's package list for a package manager.
+# Arguments:
+#   set  runtime, test, lint or dev
+#   pm   apt, dnf or pacman (default: detected)
+# Outputs:
+#   Writes the space-separated list to stdout.
+# Returns:
+#   1 on an unknown set or package manager.
+#######################################
+clipman_deps_list() {
+    local set="${1:-}" pm
+    if [ -z "$set" ]; then
+        _clipman_deps_log "usage: clipman_deps_list <set> [pm]"
+        return 1
+    fi
+    pm=$(_clipman_deps_pm "${2:-}") || return 1
+    local lines
+    lines=$(_clipman_deps_union "$pm" "$set") || return 1
+    # shellcheck disable=SC2086  # word-splitting the newline list is intended
+    echo $lines
+}
+
+#######################################
+# List the packages of one set that are not installed.
+# Arguments:
+#   set  runtime, test, lint or dev
+#   pm   apt, dnf or pacman (default: detected)
+# Outputs:
+#   Writes the missing packages, space-separated, to stdout.
+# Returns:
+#   0 when nothing is missing, 1 otherwise.
+#######################################
+clipman_deps_missing() {
+    local set="${1:-}" pm
+    if [ -z "$set" ]; then
+        _clipman_deps_log "usage: clipman_deps_missing <set> [pm]"
+        return 1
+    fi
+    pm=$(_clipman_deps_pm "${2:-}") || return 1
+    local lines
+    lines=$(_clipman_deps_missing_lines "$pm" "$set") || return 1
+    if [ -n "$lines" ]; then
+        # shellcheck disable=SC2086
+        echo $lines
+        return 1
+    fi
+    return 0
+}
+
+#######################################
+# Install the missing packages of one or more sets on the host.
+# Globals:
+#   CLIPMAN_DEPS_YES        1 passes the assume-yes flag (implied on CI)
+#   CLIPMAN_DEPS_NO_UPDATE  1 skips apt-get update
+# Arguments:
+#   One or more of runtime, test, lint, dev.
+# Outputs:
+#   Progress to stderr; on return 3, the sudo command to run.
+# Returns:
+#   0 when all packages are present, 3 when root cannot be obtained
+#   non-interactively, 1 otherwise.
+#######################################
+clipman_deps_install() {
+    if [ "$#" -eq 0 ]; then
+        _clipman_deps_log "usage: clipman_deps_install <set...>"
+        return 1
+    fi
+    local pm
+    pm=$(_clipman_deps_pm "") || return 1
+
+    local missing_lines
+    missing_lines=$(_clipman_deps_missing_lines "$pm" "$@") || return 1
+    if [ -z "$missing_lines" ]; then
+        _clipman_deps_log "all $pm packages for '$*' are already installed"
+        return 0
+    fi
+
+    local -a yes=()
+    if _clipman_deps_assume_yes; then
+        case "$pm" in
+            apt|dnf) yes=(-y) ;;
+            pacman) yes=(--noconfirm) ;;
+        esac
+    fi
+    # A 30 s fetch timeout lets a stalled mirror fail and retry within CI's
+    # 4-minute step cap.
+    local -a apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o DPkg::Lock::Timeout=60)
+    local -a update_cmd=()
+    if [ "$pm" = "apt" ] && [ "${CLIPMAN_DEPS_NO_UPDATE:-0}" != "1" ]; then
+        update_cmd=(env DEBIAN_FRONTEND=noninteractive apt-get update "${apt_opts[@]}")
+    fi
+
+    local rc=0
+    if [ "${#update_cmd[@]}" -gt 0 ]; then
+        _clipman_deps_run_privileged "${update_cmd[@]}" || rc=$?
+        # Re-resolve the alternatives against the refreshed index.
+        if [ "$rc" -eq 0 ]; then
+            missing_lines=$(_clipman_deps_missing_lines "$pm" "$@") || return 1
+        fi
+    fi
+    local -a missing=()
+    local pkg
+    for pkg in $missing_lines; do
+        missing+=("$pkg")
+    done
+    if [ "${#missing[@]}" -eq 0 ]; then
+        _clipman_deps_log "all $pm packages for '$*' are already installed"
+        return 0
+    fi
+
+    local -a install_cmd=()
+    case "$pm" in
+        apt) install_cmd=(env DEBIAN_FRONTEND=noninteractive apt-get install "${apt_opts[@]}" "${yes[@]}" "${missing[@]}") ;;
+        dnf) install_cmd=(dnf install "${yes[@]}" "${missing[@]}") ;;
+        pacman) install_cmd=(pacman -S --needed "${yes[@]}" "${missing[@]}") ;;
+    esac
+    _clipman_deps_log "missing $pm packages: ${missing[*]}"
+
+    if [ "$rc" -eq 0 ]; then
+        _clipman_deps_run_privileged "${install_cmd[@]}" || rc=$?
+    fi
+
+    if [ "$rc" -eq 3 ]; then
+        _clipman_deps_log "cannot obtain root privileges non-interactively; run:"
+        if [ "${#update_cmd[@]}" -gt 0 ]; then
+            printf '  sudo %s\n' "${update_cmd[*]}" >&2
+        fi
+        printf '  sudo %s\n' "${install_cmd[*]}" >&2
+        return 3
+    fi
+    if [ "$rc" -ne 0 ]; then
+        _clipman_deps_log "package installation failed (exit $rc)"
+        return 1
+    fi
+
+    if missing_lines=$(_clipman_deps_missing_lines "$pm" "$@") && [ -z "$missing_lines" ]; then
+        _clipman_deps_log "installed: ${missing[*]}"
+        return 0
+    fi
+    # shellcheck disable=SC2086
+    _clipman_deps_log "still missing after install:" $missing_lines
+    return 1
+}
+
+# CLI (only when executed, never when sourced)
+
+_clipman_deps_usage() {
+    cat <<'EOF'
+usage: scripts/deps.sh [--runtime|--test|--lint|--dev]... [--pm apt|dnf|pacman]
+                       [--print|--check|--install] [--yes] [--no-update]
+
+Sets (repeatable; default --dev = runtime + test + lint):
+  --runtime   packages the app needs to run
+  --test      Xvfb plus the headers needed to build PyGObject / dbus-python
+  --lint      shellcheck
+  --dev       all of the above
+
+Actions (default --print):
+  --print     print the resolved package list for the target package manager
+  --check     print missing packages; exit 1 if any are missing
+  --install   install the missing packages (sudo when needed)
+
+Options:
+  --pm NAME   target package manager instead of auto-detecting
+  --yes       pass the assume-yes flag to the package manager
+  --no-update skip `apt-get update` before installing
+  -h, --help  show this help
+
+Exit codes: 0 ok · 1 missing/failure · 2 usage · 3 privileges needed
+EOF
+}
+
+_clipman_deps_main() {
+    local -a sets=()
+    local action="" pm=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --runtime|--test|--lint|--dev) sets+=("${1#--}") ;;
+            --print|--check|--install)
+                if [ -n "$action" ] && [ "$action" != "${1#--}" ]; then
+                    _clipman_deps_log "conflicting actions --$action and $1"
+                    _clipman_deps_usage >&2
+                    return 2
+                fi
+                action="${1#--}"
+                ;;
+            --pm)
+                if [ "$#" -lt 2 ]; then
+                    _clipman_deps_log "--pm needs an argument"
+                    return 2
+                fi
+                pm="$2"
+                shift
+                ;;
+            --pm=*) pm="${1#--pm=}" ;;
+            --yes) CLIPMAN_DEPS_YES=1 ;;
+            --no-update) CLIPMAN_DEPS_NO_UPDATE=1 ;;
+            -h|--help)
+                _clipman_deps_usage
+                return 0
+                ;;
+            *)
+                _clipman_deps_log "unknown argument '$1'"
+                _clipman_deps_usage >&2
+                return 2
+                ;;
+        esac
+        shift
+    done
+    if [ "${#sets[@]}" -eq 0 ]; then sets=(dev); fi
+    [ -n "$action" ] || action=print
+    case "$pm" in
+        ""|apt|dnf|pacman) ;;
+        *)
+            _clipman_deps_log "unknown package manager '$pm' (expected apt, dnf or pacman)"
+            _clipman_deps_usage >&2
+            return 2
+            ;;
+    esac
+
+    case "$action" in
+        print)
+            pm=$(_clipman_deps_pm "$pm") || return 1
+            local lines
+            lines=$(_clipman_deps_union "$pm" "${sets[@]}") || return 1
+            # shellcheck disable=SC2086
+            echo $lines
+            ;;
+        check)
+            pm=$(_clipman_deps_pm "$pm") || return 1
+            local lines
+            lines=$(_clipman_deps_missing_lines "$pm" "${sets[@]}") || return 1
+            if [ -n "$lines" ]; then
+                _clipman_deps_log "missing $pm packages for '${sets[*]}':"
+                # shellcheck disable=SC2086
+                echo $lines
+                return 1
+            fi
+            _clipman_deps_log "all $pm packages for '${sets[*]}' are installed"
+            ;;
+        install)
+            if [ -n "$pm" ]; then
+                local detected
+                detected=$(clipman_deps_detect_pm || true)
+                if [ "$pm" != "$detected" ]; then
+                    _clipman_deps_log "--pm $pm does not match this host (${detected:-none}); --install uses the host's package manager"
+                    return 2
+                fi
+            fi
+            clipman_deps_install "${sets[@]}"
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    set -euo pipefail
+    _clipman_deps_main "$@"
+fi

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Idempotent dev bootstrap: system packages, .venv (--system-site-packages)
+# with the dev extras, git hooks, identity check.
+# Env: CLIPMAN_PYTHON (default python3); CLIPMAN_NO_NETWORK=1 skips PyPI.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+log() {
+    printf 'setup: %s\n' "$*" >&2
+}
+
+step() {
+    printf '\n== %s\n' "$*" >&2
+}
+
+notices=()
+
+# 1. System packages
+step "System packages (scripts/deps.sh --dev --install)"
+deps_rc=0
+scripts/deps.sh --dev --install || deps_rc=$?
+case "$deps_rc" in
+    0) ;;
+    3)
+        log "system packages could not be installed without a password; the command"
+        log "to run is printed above. Continuing with the remaining steps."
+        notices+=("System packages: run the sudo command printed by scripts/deps.sh, then re-run this script.")
+        ;;
+    *)
+        log "warning: scripts/deps.sh exited with $deps_rc; continuing (the venv step may fail)"
+        notices+=("System packages: scripts/deps.sh --dev --install failed (exit $deps_rc); re-run it after fixing the cause.")
+        ;;
+esac
+
+# 2. Virtualenv
+step "Virtualenv (.venv, --system-site-packages)"
+PYTHON="${CLIPMAN_PYTHON:-python3}"
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    log "error: interpreter '$PYTHON' not found"
+    exit 1
+fi
+# Distro bindings older than 3.46, or a non-distro interpreter, make pip
+# build PyGObject from source.
+if ! "$PYTHON" -c 'import gi, sys; sys.exit(tuple(gi.version_info) < (3, 46))' 2>/dev/null; then
+    log "warning: $PYTHON has no PyGObject >= 3.46 (Ubuntu 24.04+ / Fedora 40+ is the baseline);"
+    log "         pip will build it from source, which needs a C compiler and GLib 2.80"
+fi
+
+if [ -x .venv/bin/python ]; then
+    log ".venv already exists ($(.venv/bin/python --version 2>&1))"
+else
+    if [ -e .venv ]; then
+        log "removing incomplete .venv from an earlier run"
+        rm -rf .venv
+    fi
+    if "$PYTHON" -c 'import ensurepip' >/dev/null 2>&1; then
+        log "creating .venv with $PYTHON"
+        "$PYTHON" -m venv --system-site-packages .venv
+    else
+        if [ "${CLIPMAN_NO_NETWORK:-0}" = "1" ]; then
+            log "error: $PYTHON has no ensurepip module and CLIPMAN_NO_NETWORK=1 forbids"
+            log "       bootstrapping pip from the network. Install the distro's venv"
+            log "       support (apt: python3-venv) and re-run."
+            exit 1
+        fi
+        log "notice: $PYTHON has no ensurepip module (python3-venv not installed);"
+        log "        creating .venv --without-pip and bootstrapping pip from"
+        log "        https://bootstrap.pypa.io/get-pip.py"
+        "$PYTHON" -m venv --system-site-packages --without-pip .venv
+    fi
+fi
+
+if ! .venv/bin/python -m pip --version >/dev/null 2>&1; then
+    if [ "${CLIPMAN_NO_NETWORK:-0}" = "1" ]; then
+        log "error: .venv has no pip and CLIPMAN_NO_NETWORK=1 forbids bootstrapping it."
+        log "       Install python3-venv (apt) and recreate .venv, or unset CLIPMAN_NO_NETWORK."
+        exit 1
+    fi
+    log "bootstrapping pip into .venv"
+    if ! command -v curl >/dev/null 2>&1; then
+        log "error: curl is required to bootstrap pip (or install python3-venv and recreate .venv)"
+        exit 1
+    fi
+    curl -sSL https://bootstrap.pypa.io/get-pip.py | .venv/bin/python -
+fi
+
+if [ "${CLIPMAN_NO_NETWORK:-0}" = "1" ]; then
+    log "CLIPMAN_NO_NETWORK=1: skipping 'pip install -e .[dev]'"
+    notices+=("Python extras: run '.venv/bin/python -m pip install -e \".[dev]\"' once you are online.")
+else
+    log "installing the project with its dev extras into .venv"
+    .venv/bin/python -m pip install -e ".[dev]"
+fi
+
+# 3. Git hooks
+step "Git hooks"
+hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
+if [ -z "$hooks_path" ]; then
+    log "core.hooksPath unset; installing the repo's hooks"
+    scripts/install-hooks.sh --replace
+elif [ "$hooks_path" = ".githooks" ]; then
+    log "hooks already installed (core.hooksPath=.githooks)"
+else
+    log "core.hooksPath is '$hooks_path' — left untouched"
+    notices+=("Git hooks: core.hooksPath already points at '$hooks_path' (another hook manager). \
+This script does not replace it. If your hook manager can chain to a previous hooks directory, \
+point it at the repo's hooks with: git config guard.prevHooksPath \"$PWD/.githooks\" \
+(the convention for managers that honor a prevHooksPath). Otherwise, to hand the clone over \
+to the repo's hooks instead, run: scripts/install-hooks.sh --replace")
+fi
+
+# 4. Git identity
+step "Git identity"
+if [ -z "$(git config user.email 2>/dev/null || true)" ]; then
+    log "git user.email is not set for this clone; configure it before committing:"
+    printf '  git config user.name  "Your Name"\n  git config user.email "you@example.com"\n' >&2
+    notices+=("Git identity: set user.name / user.email (commands printed above).")
+else
+    log "git identity: $(git config user.name 2>/dev/null || true) <$(git config user.email)>"
+fi
+
+# Summary
+step "Done"
+if [ "${#notices[@]}" -gt 0 ]; then
+    printf 'Follow-ups:\n' >&2
+    for n in "${notices[@]}"; do
+        printf '  - %s\n' "$n" >&2
+    done
+    printf '\n' >&2
+fi
+cat >&2 <<'EOF'
+Next:
+  scripts/dev.sh test          # full suite under xvfb (make test)
+  scripts/dev.sh lint          # ruff + shellcheck        (make lint)
+  scripts/dev.sh check         # both                     (make check)
+  scripts/dev.sh screenshot --out /tmp/clipman.png
+EOF

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# dev.sh — clipman's task runner (pure bash, no make required).
+#
+#   scripts/dev.sh setup                one-command bootstrap (dev-setup.sh)
+#   scripts/dev.sh deps [args]          system package manifest (deps.sh)
+#   scripts/dev.sh test [args]          the suite, exactly as CI runs it
+#   scripts/dev.sh lint                 ruff + shellcheck
+#   scripts/dev.sh ruff                 ruff check clipman tests
+#   scripts/dev.sh shellcheck           shellcheck on the repo's shell scripts
+#   scripts/dev.sh screenshot [args]    headless render (scripts/screenshot.py)
+#   scripts/dev.sh hooks-test           the git-hook footprint-scanner corpus
+#   scripts/dev.sh check                lint, then test
+#   scripts/dev.sh help
+#
+# Python resolution: $CLIPMAN_PYTHON, else .venv/bin/python when present,
+# else python3 on PATH. The Makefile is a thin wrapper around this file.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+log() {
+    printf 'dev: %s\n' "$*" >&2
+}
+
+die() {
+    log "error: $*"
+    exit 1
+}
+
+resolve_python() {
+    if [ -n "${CLIPMAN_PYTHON:-}" ]; then
+        echo "$CLIPMAN_PYTHON"
+    elif [ -x .venv/bin/python ]; then
+        echo "$ROOT/.venv/bin/python"
+    else
+        echo python3
+    fi
+}
+
+resolve_ruff() {
+    if [ -x .venv/bin/ruff ]; then
+        echo "$ROOT/.venv/bin/ruff"
+    elif command -v ruff >/dev/null 2>&1; then
+        command -v ruff
+    else
+        return 1
+    fi
+}
+
+# Prefix a command with `xvfb-run -a` when available; otherwise warn once
+# and run it against whatever display the environment provides.
+with_display() {
+    if command -v xvfb-run >/dev/null 2>&1; then
+        xvfb-run -a "$@"
+    else
+        log "warning: xvfb-run not found; running without a virtual display" \
+            "(install the 'test' set: scripts/deps.sh --test --install)"
+        "$@"
+    fi
+}
+
+cmd_setup() {
+    exec "$ROOT/scripts/dev-setup.sh" "$@"
+}
+
+cmd_deps() {
+    exec "$ROOT/scripts/deps.sh" "$@"
+}
+
+cmd_test() {
+    local py
+    py=$(resolve_python)
+    export CLIPMAN_REQUIRE_GTK4="${CLIPMAN_REQUIRE_GTK4:-1}"
+    if "$py" -c 'import pytest' >/dev/null 2>&1; then
+        log "runner: pytest ($py)"
+        with_display "$py" -m pytest -q "$@"
+    else
+        log "runner: unittest ($py; pytest not importable — scripts/dev.sh setup installs it)"
+        with_display "$py" -m unittest discover -s tests "$@"
+    fi
+}
+
+cmd_ruff() {
+    local ruff
+    if ! ruff=$(resolve_ruff); then
+        die "ruff not found (.venv/bin/ruff or on PATH); run: scripts/dev.sh setup"
+    fi
+    log "ruff: $ruff"
+    "$ruff" check clipman tests
+}
+
+cmd_shellcheck() {
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        die "shellcheck not found; run: scripts/deps.sh --lint --install (or scripts/dev.sh setup)"
+    fi
+    shellcheck --severity=warning install.sh uninstall.sh launcher.sh scripts/*.sh
+}
+
+cmd_lint() {
+    local rc=0
+    cmd_ruff || rc=1
+    cmd_shellcheck || rc=1
+    if [ "$rc" -ne 0 ]; then
+        die "lint failed"
+    fi
+    log "lint ok"
+}
+
+cmd_screenshot() {
+    local py
+    py=$(resolve_python)
+    with_display "$py" scripts/screenshot.py "$@"
+}
+
+cmd_hooks_test() {
+    bash .githooks/_test.sh
+}
+
+cmd_check() {
+    cmd_lint
+    cmd_test "$@"
+}
+
+cmd_help() {
+    sed -n '2,/^$/p' "$ROOT/scripts/dev.sh" | sed 's/^# \{0,1\}//'
+}
+
+main() {
+    local sub="${1:-help}"
+    shift || true
+    case "$sub" in
+        setup)      cmd_setup "$@" ;;
+        deps)       cmd_deps "$@" ;;
+        test)       cmd_test "$@" ;;
+        lint)       cmd_lint ;;
+        ruff)       cmd_ruff ;;
+        shellcheck) cmd_shellcheck ;;
+        screenshot) cmd_screenshot "$@" ;;
+        hooks-test) cmd_hooks_test ;;
+        check)      cmd_check "$@" ;;
+        help|-h|--help) cmd_help ;;
+        *)
+            log "unknown subcommand '$sub'"
+            cmd_help >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
-# install-hooks.sh — opt-in installer for Clipman's local git hooks.
-#
-# Run once after cloning if you want the local guardrails (identity
-# allowlist + AI-footprint scanner). External contributors do NOT need
-# to run this; the CI does not require it; nothing about your workflow
-# breaks if you skip it.
-#
-# Re-running is safe (idempotent).
+# install-hooks.sh — opt-in installer for the repo's local git hooks (identity allowlist + footprint scanner); safe to re-run.
+# CI never needs them. --replace takes over a foreign core.hooksPath without prompting.
 
 set -euo pipefail
+
+replace=0
+for arg in "$@"; do
+    case "$arg" in
+        --replace) replace=1 ;;
+        -h|--help)
+            printf 'usage: %s [--replace]\n' "$0"
+            exit 0
+            ;;
+        *)
+            printf 'error: unknown argument "%s" (usage: %s [--replace])\n' "$arg" "$0" >&2
+            exit 2
+            ;;
+    esac
+done
 
 cd "$(dirname -- "$0")/.."
 
@@ -24,8 +33,17 @@ existing=$(git config --get core.hooksPath 2>/dev/null || true)
 if [ -n "$existing" ] && [ "$existing" != ".githooks" ]; then
     printf 'warning: core.hooksPath is currently set to "%s"\n' "$existing" >&2
     printf '         Installing Clipman hooks will REPLACE that setting.\n' >&2
-    printf '         Press ENTER to continue, Ctrl-C to abort.\n' >&2
-    read -r _
+    if [ "$replace" -eq 1 ]; then
+        printf '         --replace given; proceeding.\n' >&2
+    elif [ -t 0 ]; then
+        printf '         Press ENTER to continue, Ctrl-C to abort.\n' >&2
+        read -r _
+    else
+        printf '         Not a terminal, so nothing was changed. Re-run with --replace\n' >&2
+        printf '         to take over core.hooksPath, or chain your hook manager to\n' >&2
+        printf '         "%s/.githooks" instead.\n' "$PWD" >&2
+        exit 1
+    fi
 fi
 
 # Make all hook files executable

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import unittest
@@ -34,19 +35,20 @@ class TestDBusMainLoopInit(unittest.TestCase):
                         "D-Bus connection with the wrong mainloop")
 
     def test_toggle_without_daemon_does_not_hang(self):
-        """'clipman.py toggle' must exit promptly when no daemon runs.
-
-        Before the fix, the toggle path would create a SessionBus
-        connection without the GLib mainloop, then start the daemon
-        on a poisoned connection that never dispatched method calls.
-        """
+        """'clipman.py toggle' must exit promptly when no daemon runs."""
+        # No display and a dead bus: the toggle falls through to the daemon
+        # start, which must fail fast instead of running the main loop.
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("DISPLAY", "WAYLAND_DISPLAY")}
+        env["GDK_BACKEND"] = "x11"
+        env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/nonexistent/clipman-test"
         result = subprocess.run(
             [sys.executable, "clipman.py", "toggle"],
-            capture_output=True, timeout=10, cwd=".",
+            capture_output=True, timeout=10, cwd=".", env=env,
         )
-        # It should print "not running" and attempt to start (which will
-        # fail in the test env due to no display), but must not hang.
-        self.assertIsNotNone(result.returncode, "Process should have exited")
+        output = result.stdout + result.stderr
+        expected = (b"not running", b"missing system dependencies")
+        self.assertTrue(any(m in output for m in expected), output[-500:])
 
     def test_dbus_import_order(self):
         """dbus.mainloop.glib must be imported before dbus in clipman.py."""

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -4,27 +4,16 @@ from unittest.mock import patch
 
 from clipman import keybindings
 
-# Probe for real GTK / Gdk so the TestKeyvalToBinding class can skip
-# cleanly when running on a stock CI image without the typelibs. We do
-# NOT mutate sys.modules from these tests — previous iterations stubbed
-# ``gi`` in setUp and ``addCleanup``-restored a captured snapshot, but
-# the snapshot was taken AFTER the stubs were already installed so
-# tearDown left the stub in place and leaked it into every subsequent
-# test module (test_window.py errored with AttributeError: 'module'
-# object has no attribute 'require_version'). Skipping is simpler and
-# safer than mock-patching sys.modules.
+# Probe for the Gdk typelib so TestKeyvalToBinding skips cleanly without
+# it. Never stub sys.modules here: a leaked stub breaks later modules.
 try:
     import importlib
 
     import gi
     gi.require_version("Gdk", "4.0")
-    # Touching the attribute is the actual typelib probe: importing
-    # ``gi.repository`` succeeds even when the Gdk typelib is missing,
-    # but the attribute lookup raises in that case. Using importlib
-    # avoids binding an unused name (CodeQL py/unused-import fires on
-    # ``from gi.repository import Gdk as _RealGdk`` even with a ruff
-    # suppression comment).
-    importlib.import_module("gi.repository").Gdk
+    # Import the submodule, not an attribute of gi.repository, so the
+    # probe does not depend on test import order.
+    importlib.import_module("gi.repository.Gdk")
     _HAS_GDK = True
 except (ImportError, ValueError, AttributeError, RuntimeError):
     _HAS_GDK = False


### PR DESCRIPTION
## Summary

One source of truth for system dependencies, a one-command developer bootstrap, and CI that runs the same commands a contributor runs.

Before this change the apt package list was a literal copied into `install.sh`, `test.yml` and `release.yml`, and the release copy had drifted: it installed GTK 3 typelibs for a GTK 4 app, set no `CLIPMAN_REQUIRE_GTK4`, and ran without xvfb, so the widget suite was silently skipped in the job that gates a release. CI also installed `pydbus` (module `pydbus`) where the app imports `dbus` (dbus-python); the resulting `ImportError` made `test_app.py` skip, and because `test_keybindings.py` probed `gi.repository.Gdk` as an attribute that only exists after another module imports Gdk, it skipped too. Every CI run reported `OK (skipped=18)` (run 34591560773).

## What changed

- **`scripts/deps.sh`**: the only place package lists live. Sets `runtime`, `test`, `lint` (`dev` = all) for apt, dnf and pacman. `--print`, `--check`, `--install`; safe to `source`; resolves `libgirepository-2.0-dev` to `libgirepository1.0-dev` on older Ubuntu; prints the exact `sudo` command and exits 3 when it cannot escalate (no sudo, no TTY).
- **`scripts/dev-setup.sh`**: idempotent bootstrap. System deps, then `.venv` with `--system-site-packages` so the distro's PyGObject and dbus-python are reused rather than rebuilt (falls back to `get-pip.py` when `ensurepip` is absent), then `pip install -e '.[dev]'`, then hooks (never replaces an existing `core.hooksPath` non-interactively), then an identity check.
- **`scripts/dev.sh`**: pure-bash task runner (`test`, `lint`, `ruff`, `shellcheck`, `check`, `screenshot`, `hooks-test`, `deps`, `setup`). `test` sets `CLIPMAN_REQUIRE_GTK4=1`, wraps in `xvfb-run` when available, uses pytest when installed and falls back to `unittest`. **`Makefile`** is an optional thin wrapper.
- **`pyproject.toml`**: `lint`/`test`/`dev` extras. `ruff==0.15.13` (the version Lint already used; 0.16 adds 60 findings here), `pytest==9.1.1`, `PyGObject>=3.46,<3.59`, `dbus-python>=1.3`. Pins now live where Dependabot's pip ecosystem can see them. The PyGObject ceiling is deliberate: 3.58 requires GLib 2.80.0, exactly noble's version, so the next upstream bump would break the matrix without it.
- **`install.sh`**: sources `scripts/deps.sh` instead of carrying its own list; keeps assume-yes; gains pacman support.
- **Workflows**: `test.yml`, `lint.yml`, and the `tests` job of `release.yml` install through `scripts/deps.sh --install --yes` (4-minute step timeout, apt retries and fetch/lock timeouts; the last red run on `main` was a runner apt stall that consumed the whole 10-minute budget), install Python deps through the extras, and run `scripts/dev.sh test|ruff|shellcheck`. The release test job is now step-for-step identical to the PR test job.
- **`tests/test_keybindings.py`**: the Gdk probe imports `gi.repository.Gdk` as a module, so it no longer depends on collection order.
- **`tests/test_entry_point.py`**: the `toggle` smoke test runs the entry point without a display and against a dead session bus. It used to pass only because the missing `dbus` module made the script exit early; with real dependencies and xvfb it started the daemon and hit its 10 s timeout (first CI run of this PR). It also can no longer toggle a developer's real daemon.
- **`scripts/install-hooks.sh`**: `--replace` flag; without a TTY it refuses to clobber an existing `core.hooksPath` instead of blocking on `read`.
- **Docs**: CONTRIBUTING, `docs/development.md`, `docs/ci-cd.md`, the PR template, the release checklist's verify step, and the AGENTS.md verification recipes point at the new commands; a second hand-maintained package list in CONTRIBUTING is gone. CHANGELOG `[Unreleased]` updated.

## Verification (local, Ubuntu 26.04, Python 3.14 / GTK 4.22)

- `scripts/dev-setup.sh` end to end, twice: no-sudo path prints the command and continues; venv created via the get-pip fallback; `pip install -e '.[dev]'` satisfied by system PyGObject/dbus-python (no source build); `core.hooksPath` untouched; second run idempotent.
- `scripts/dev.sh test`: pytest 9.1.1, **331 passed, 0 skipped**. `CLIPMAN_PYTHON=/usr/bin/python3 scripts/dev.sh test`: unittest fallback, 331 OK.
- `scripts/dev.sh lint`: ruff 0.15.13 clean; shellcheck 0.11 `--severity=warning` clean over `install.sh uninstall.sh launcher.sh scripts/*.sh`.
- `scripts/deps.sh --print` for all 4 sets × 3 package managers matches the manifest; `--check` and the exit-3 path behave as documented; sourcing applies no `set -e`/`-u`.
- With the `dbus` module hidden (simulating CI's matrix interpreter), `tests/test_keybindings.py` alone now runs 32 tests with 0 skipped.
- First CI run: 330 passed, 1 failed, **0 skipped** on all three Python versions; the failure was the toggle test above, fixed in the same commit and verified locally on both its paths (dependencies present via a `wl-paste` shim, and dependencies missing).
- The three workflows YAML-parse; no `uses:` line, action SHA, `permissions:` or `concurrency:` block changed.

Not verifiable on this machine (no xvfb, no sudo): the from-source build of PyGObject and dbus-python against the matrix interpreters and the xvfb run. The first CI run covered both: all three jobs built the extras and executed the suite with `skipped=0`.

## Notes for review

- Shellcheck scope is `install.sh uninstall.sh launcher.sh scripts/*.sh`; `.githooks/` has two pre-existing findings and its test corpus has one pre-existing failure (case 12), both left for a hooks PR. Ruff scope stays `clipman tests`.
- Comments in the new scripts follow the Google Shell Style Guide (one-sentence file header, boxed headers on the library's public functions, implementation comments only where non-obvious); the Python change follows PEP 8.
