### PR TITLE
Fix the PyPI entry point, ship style.css in the wheel, repair the AppImage launcher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,7 @@ jobs:
           # Entrypoint
           cat > "$stage/entrypoint.sh" <<'EOF'
           #!/bin/sh
-          "{{ python-executable }}" -m clipman.app "$@"
+          "{{ python-executable }}" -m clipman "$@"
           EOF
           chmod +x "$stage/entrypoint.sh"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,40 @@ jobs:
 
       - name: Run tests
         run: scripts/dev.sh test
+
+  package:
+    name: package (wheel smoke)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: pip install build && python -m build
+
+      - name: Install the wheel into a clean venv and run the entry point
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --no-deps dist/*.whl
+          tar tzf dist/*.tar.gz > /tmp/sdist-files.txt
+          grep -q 'clipman/style.css' /tmp/sdist-files.txt
+          # Leave the checkout so the installed package, not the source tree, is imported.
+          cd /tmp
+          /tmp/smoke/bin/clipman --version
+          /tmp/smoke/bin/python -m clipman --version
+          /tmp/smoke/bin/python -c "from importlib.resources import files; assert files('clipman').joinpath('style.css').is_file()"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ All notable changes to Clipman are documented in this file.
   no terminal and, without one, only replaces a foreign
   `core.hooksPath` when `--replace` is given.
 
+### Fixed — PyPI and AppImage entry points
+
+- `pip install clipman-clipboard` produced a `clipman` command that failed
+  with `ModuleNotFoundError`: the console script pointed at
+  `clipman.clipman:main`, which did not exist. The entry point now lives in
+  `clipman.cli` (`clipman`, `clipman toggle`, `clipman --version`,
+  `python -m clipman`); the checkout script `clipman.py` is a thin shim.
+- The wheel and sdist did not include `clipman/style.css`, so a pip install
+  would crash on its first window. It is declared as package data, and a
+  new CI job builds the wheel, installs it into a clean venv and runs the
+  entry point.
+- The AppImage entrypoint ran `python -m clipman.app`, which has no
+  `__main__` and exited at once; it now runs `python -m clipman`.
+
 ### Changed — Snap packaging (#237, #238)
 
 - The snap now uses the `gnome` extension: the GTK4/libadwaita runtime

--- a/clipman.py
+++ b/clipman.py
@@ -1,97 +1,12 @@
 #!/usr/bin/env python3
-import sys
-import os
-import shutil
+"""Checkout and staged-tree launcher; pip installs use clipman.cli."""
 
-# Ensure the project root is on the path
+import os
+import sys
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-_MISSING = []
-
-try:
-    import importlib
-    importlib.import_module("gi")
-except ImportError:
-    _MISSING.append("python3-gi gir1.2-gtk-4.0 gir1.2-adw-1")
-
-try:
-    import dbus
-except ImportError:
-    _MISSING.append("python3-dbus")
-
-if shutil.which("wl-paste") is None:
-    _MISSING.append("wl-clipboard")
-
-if _MISSING:
-    print("Error: missing system dependencies: " + ", ".join(_MISSING))
-    print("Install them with:")
-    print(f"  sudo apt install {' '.join(_MISSING)}")
-    sys.exit(1)
-
-# Must be called before ANY dbus operations so that the GLib main loop
-# is used for all connections, including cached ones created by the
-# toggle client.  Without this, _start_daemon() inherits a connection
-# with the wrong mainloop and D-Bus method calls never get dispatched.
-import dbus.mainloop.glib
-dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-
-
-_MIN_ADW_MINOR = 4
-
-
-def _preflight_libadwaita():
-    """Refuse to boot when libadwaita is too old.
-
-    The GTK 4 port relies on widgets introduced in libadwaita 1.4
-    (Adw.AboutDialog, Adw.Banner action API, etc.). Fail with a
-    readable error before ClipmanApp tries to construct them — the
-    crash deep inside Gtk would otherwise just print a confusing
-    'no such symbol' from C.
-    """
-    import gi
-    gi.require_version("Adw", "1")
-    from gi.repository import Adw
-    minor = getattr(Adw, "MINOR_VERSION", 0)
-    if minor < _MIN_ADW_MINOR:
-        major = getattr(Adw, "MAJOR_VERSION", 1)
-        micro = getattr(Adw, "MICRO_VERSION", 0)
-        print(
-            f"Error: libadwaita {major}.{minor}.{micro} is too old. "
-            f"Clipman requires libadwaita >= 1.{_MIN_ADW_MINOR}.",
-            file=sys.stderr,
-        )
-        print(
-            "On Ubuntu 24.04+ / Debian trixie this ships as "
-            "libadwaita-1-0; on Fedora 40+ as 'libadwaita'.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-
-def main():
-    _preflight_libadwaita()
-
-    if len(sys.argv) > 1 and sys.argv[1] == "toggle":
-        # Send toggle signal to running daemon via D-Bus
-        import dbus
-        try:
-            bus = dbus.SessionBus()
-            proxy = bus.get_object("com.clipman.Daemon", "/com/clipman/Daemon")
-            iface = dbus.Interface(proxy, "com.clipman.Daemon")
-            iface.Toggle()
-        except dbus.exceptions.DBusException:
-            print("Clipman daemon is not running. Starting it now...")
-            _start_daemon()
-        return
-
-    _start_daemon()
-
-
-def _start_daemon():
-    from clipman.app import ClipmanApp
-    app = ClipmanApp()
-    app.run([])
-
+from clipman.cli import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/clipman/__main__.py
+++ b/clipman/__main__.py
@@ -1,0 +1,6 @@
+"""Support ``python -m clipman``."""
+
+from clipman.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/clipman/cli.py
+++ b/clipman/cli.py
@@ -1,0 +1,101 @@
+"""Command-line entry point: run the daemon, or toggle a running one."""
+
+import argparse
+import importlib
+import shutil
+import sys
+
+from clipman._version import __version__
+
+_MIN_ADW_MINOR = 4
+
+
+def _check_dependencies():
+    """Exit with an install hint when a system dependency is missing."""
+    missing = []
+    try:
+        importlib.import_module("gi")
+    except ImportError:
+        missing.append("python3-gi gir1.2-gtk-4.0 gir1.2-adw-1")
+    try:
+        importlib.import_module("dbus")
+    except ImportError:
+        missing.append("python3-dbus")
+    if shutil.which("wl-paste") is None:
+        missing.append("wl-clipboard")
+    if missing:
+        print("Error: missing system dependencies: " + ", ".join(missing))
+        print("Install them with:")
+        print(f"  sudo apt install {' '.join(missing)}")
+        sys.exit(1)
+
+
+def _preflight_libadwaita():
+    """Exit with a readable error on a libadwaita older than 1.4."""
+    import gi
+    gi.require_version("Adw", "1")
+    from gi.repository import Adw
+    minor = getattr(Adw, "MINOR_VERSION", 0)
+    if minor < _MIN_ADW_MINOR:
+        major = getattr(Adw, "MAJOR_VERSION", 1)
+        micro = getattr(Adw, "MICRO_VERSION", 0)
+        print(
+            f"Error: libadwaita {major}.{minor}.{micro} is too old. "
+            f"Clipman requires libadwaita >= 1.{_MIN_ADW_MINOR}.",
+            file=sys.stderr,
+        )
+        print(
+            "On Ubuntu 24.04+ / Debian trixie this ships as "
+            "libadwaita-1-0; on Fedora 40+ as 'libadwaita'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _toggle():
+    """Toggle the popup of a running daemon, or start one."""
+    import dbus
+    try:
+        bus = dbus.SessionBus()
+        proxy = bus.get_object("com.clipman.Daemon", "/com/clipman/Daemon")
+        dbus.Interface(proxy, "com.clipman.Daemon").Toggle()
+    except dbus.exceptions.DBusException:
+        print("Clipman daemon is not running. Starting it now...")
+        _start_daemon()
+
+
+def _start_daemon():
+    from clipman.app import ClipmanApp
+    ClipmanApp().run([])
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        prog="clipman",
+        description="Clipboard history manager for GNOME on Wayland.",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"clipman {__version__}"
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["toggle"],
+        help="toggle the popup of a running daemon (default: run the daemon)",
+    )
+    return parser
+
+
+def main(argv=None):
+    """Parse arguments, check the system, then run or toggle."""
+    args = _parser().parse_args(argv)
+    _check_dependencies()
+    # The GLib loop must be the default before any bus connection, or a
+    # daemon started by the toggle client never dispatches method calls.
+    import dbus.mainloop.glib
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    _preflight_libadwaita()
+    if args.command == "toggle":
+        _toggle()
+    else:
+        _start_daemon()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Issues = "https://github.com/MohammedEl-sayedAhmed/clipman/issues"
 Sponsor = "https://github.com/sponsors/MohammedEl-sayedAhmed"
 
 [project.scripts]
-clipman = "clipman.clipman:main"
+clipman = "clipman.cli:main"
 
 [project.optional-dependencies]
 lint = ["ruff==0.15.13"]
@@ -41,6 +41,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["clipman*"]
 
+[tool.setuptools.package-data]
+clipman = ["style.css"]
+
 [tool.ruff]
 target-version = "py310"
 
@@ -49,3 +52,5 @@ target-version = "py310"
 # which legitimately puts those imports below the require_version() call.
 "clipman/app.py" = ["E402"]
 "clipman/window.py" = ["E402"]
+# The checkout shim puts the project root on sys.path before importing.
+"clipman.py" = ["E402"]

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -1,102 +1,93 @@
 import os
+import re
 import subprocess
 import sys
 import unittest
+from importlib import import_module, resources
+from pathlib import Path
+
+from clipman._version import __version__
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_SOURCE = (ROOT / "clipman" / "cli.py").read_text()
+# Text, not tomllib: that module only exists from Python 3.11.
+PYPROJECT = (ROOT / "pyproject.toml").read_text()
+# Everything from ``def main(`` to the end of the module.
+MAIN_BODY = CLI_SOURCE[CLI_SOURCE.index("def main("):]
+
+
+def _run(*args):
+    """Run the entry point in a subprocess with no display."""
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("DISPLAY", "WAYLAND_DISPLAY")}
+    env["GDK_BACKEND"] = "x11"
+    env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/nonexistent/clipman-test"
+    return subprocess.run(
+        [sys.executable, *args], capture_output=True, timeout=10,
+        cwd=ROOT, env=env,
+    )
 
 
 class TestDBusMainLoopInit(unittest.TestCase):
-    """Verify that DBusGMainLoop is set before any D-Bus connections.
+    """The GLib main loop must be the default before any bus connection.
 
-    Regression test for a bug where the 'toggle' path created a
-    dbus.SessionBus() connection before DBusGMainLoop was set as
-    the default mainloop.  When the toggle fell back to starting
-    the daemon, the cached connection used the wrong (non-GLib)
-    mainloop, making the D-Bus service unresponsive.
+    A toggle client that connected first without it handed the daemon a
+    connection that never dispatched method calls.
     """
 
-    def test_glib_mainloop_set_at_module_level(self):
-        """clipman.py must call DBusGMainLoop(set_as_default=True) at
-        module level, before main() is ever called."""
-        # Read the source and verify the setup happens before def main()
-        with open("clipman.py") as f:
-            source = f.read()
+    def test_mainloop_set_before_toggle_or_daemon_start(self):
+        setup = MAIN_BODY.find("DBusGMainLoop(set_as_default=True)")
+        self.assertNotEqual(setup, -1)
+        for call in ("_toggle()", "_start_daemon()"):
+            self.assertLess(setup, MAIN_BODY.index(call), call)
 
-        # Find positions
-        setup_pos = source.find("DBusGMainLoop(set_as_default=True)")
-        main_pos = source.find("def main():")
-
-        self.assertNotEqual(setup_pos, -1,
-                            "DBusGMainLoop(set_as_default=True) not found in clipman.py")
-        self.assertNotEqual(main_pos, -1,
-                            "def main() not found in clipman.py")
-        self.assertLess(setup_pos, main_pos,
-                        "DBusGMainLoop must be called before def main() "
-                        "to prevent the toggle path from creating a "
-                        "D-Bus connection with the wrong mainloop")
+    def test_dependency_check_runs_before_mainloop_setup(self):
+        check = MAIN_BODY.find("_check_dependencies()")
+        self.assertNotEqual(check, -1)
+        self.assertLess(check, MAIN_BODY.index("DBusGMainLoop"))
 
     def test_toggle_without_daemon_does_not_hang(self):
-        """'clipman.py toggle' must exit promptly when no daemon runs."""
-        # No display and a dead bus: the toggle falls through to the daemon
-        # start, which must fail fast instead of running the main loop.
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("DISPLAY", "WAYLAND_DISPLAY")}
-        env["GDK_BACKEND"] = "x11"
-        env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/nonexistent/clipman-test"
-        result = subprocess.run(
-            [sys.executable, "clipman.py", "toggle"],
-            capture_output=True, timeout=10, cwd=".", env=env,
-        )
+        """'clipman.py toggle' must exit quickly with no daemon."""
+        # Without a display or a bus the toggle falls through to the
+        # daemon start, which must fail fast rather than run the loop.
+        result = _run("clipman.py", "toggle")
         output = result.stdout + result.stderr
         expected = (b"not running", b"missing system dependencies")
         self.assertTrue(any(m in output for m in expected), output[-500:])
 
-    def test_dbus_import_order(self):
-        """dbus.mainloop.glib must be imported before dbus in clipman.py."""
-        with open("clipman.py") as f:
-            source = f.read()
-
-        glib_import_pos = source.find("import dbus.mainloop.glib")
-        # The toggle path does 'import dbus' inside main()
-        main_pos = source.find("def main():")
-
-        self.assertNotEqual(glib_import_pos, -1,
-                            "import dbus.mainloop.glib not found")
-        self.assertLess(glib_import_pos, main_pos,
-                        "dbus.mainloop.glib must be imported at module level, "
-                        "before main() where 'import dbus' happens")
-
 
 class TestDependencyCheck(unittest.TestCase):
-    """Verify that clipman.py checks for system dependencies at startup."""
+    """The entry point names the system packages it needs."""
 
-    def test_dep_check_exists_before_main(self):
-        """Dependency check must run before main() is called."""
-        with open("clipman.py") as f:
-            source = f.read()
-        check_pos = source.find("_MISSING")
-        main_pos = source.find("def main():")
-        self.assertNotEqual(check_pos, -1,
-                            "Dependency check (_MISSING) not found in clipman.py")
-        self.assertLess(check_pos, main_pos,
-                        "Dependency check must happen before def main()")
+    def test_covers_gi(self):
+        self.assertIn('import_module("gi")', CLI_SOURCE)
+        self.assertIn("python3-gi", CLI_SOURCE)
 
-    def test_dep_check_covers_gi(self):
-        """clipman.py must check for gi (python3-gi)."""
-        with open("clipman.py") as f:
-            source = f.read()
-        self.assertIn("gi", source)
-        self.assertIn("python3-gi", source)
+    def test_covers_dbus(self):
+        self.assertIn('import_module("dbus")', CLI_SOURCE)
+        self.assertIn("python3-dbus", CLI_SOURCE)
 
-    def test_dep_check_covers_dbus(self):
-        """clipman.py must check for dbus (python3-dbus)."""
-        with open("clipman.py") as f:
-            source = f.read()
-        self.assertIn("import dbus", source)
-        self.assertIn("python3-dbus", source)
+    def test_covers_wl_clipboard(self):
+        self.assertIn("wl-paste", CLI_SOURCE)
+        self.assertIn("wl-clipboard", CLI_SOURCE)
 
-    def test_dep_check_covers_wl_clipboard(self):
-        """clipman.py must check for wl-paste (wl-clipboard)."""
-        with open("clipman.py") as f:
-            source = f.read()
-        self.assertIn("wl-paste", source)
-        self.assertIn("wl-clipboard", source)
+
+class TestEntryPoints(unittest.TestCase):
+    """What pip installs must resolve and ship its data file."""
+
+    def test_console_script_target_resolves(self):
+        match = re.search(r'^clipman = "([\w.]+):(\w+)"$', PYPROJECT, re.M)
+        self.assertIsNotNone(match, "no clipman console script in pyproject")
+        module, attr = match.groups()
+        self.assertTrue(callable(getattr(import_module(module), attr)))
+
+    def test_style_css_is_package_data(self):
+        section = PYPROJECT[PYPROJECT.index("[tool.setuptools.package-data]"):]
+        self.assertRegex(section.split("\n[", 1)[0], r'clipman = \[.*"style.css"')
+        self.assertTrue(resources.files("clipman").joinpath("style.css").is_file())
+
+    def test_shim_and_module_report_version(self):
+        for args in (("clipman.py", "--version"), ("-m", "clipman", "--version")):
+            result = _run(*args)
+            self.assertEqual(result.returncode, 0, result.stderr[-500:])
+            self.assertEqual(result.stdout.strip(), f"clipman {__version__}".encode())


### PR DESCRIPTION
## Summary

Installing Clipman with `pip` did not work. The `clipman` command crashed at once, and the app would have crashed when it opened its first window. This PR fixes both problems. It also fixes the AppImage start script, and adds a CI job that installs the wheel and runs it.

## What was wrong

- `pyproject.toml` pointed the `clipman` command at `clipman.clipman:main`. That module does not exist. The real `main()` was in the root file `clipman.py`, and pip never ships that file. So `clipman` failed with `ModuleNotFoundError`. The Flatpak desktop file uses `Exec=clipman`, so it had the same problem.
- The wheel and the sdist did not include `clipman/style.css`. The window code opens that file directly. A pip install would have crashed with `FileNotFoundError` on the first popup.
- The AppImage ran `python -m clipman.app`. That module has no `__main__` block, so the AppImage started and exited at once.

## What changed

- **New `clipman/cli.py`**. This is the entry point now. `clipman` runs the daemon. `clipman toggle` toggles a running daemon, or starts one. `clipman --version` prints the version. The dependency check, the libadwaita check, and the GLib main-loop setup moved here in the same order as before. `--version` runs before the dependency check, so it works on any machine.
- **New `clipman/__main__.py`**. `python -m clipman` works.
- **`clipman.py`** (root) is now a small shim. It adds the project root to `sys.path` and calls `clipman.cli.main()`. Snap, Flatpak, AUR, deb/rpm, `launcher.sh` and `install.sh` all run this file directly. They keep working, because each of them copies the `clipman/` folder next to it.
- **`pyproject.toml`**: the command points at `clipman.cli:main`; `style.css` is listed as package data; ruff ignores `E402` for the shim.
- **`release.yml`**: the AppImage runs `python -m clipman`.
- **`test.yml`**: a new `package` job builds the sdist and the wheel, installs the wheel into a clean venv, moves out of the checkout folder, and runs `clipman --version`, `python -m clipman --version`, and a check that `style.css` is in the installed package. It also checks that the sdist contains `style.css`.
- **`tests/test_entry_point.py`**: rewritten for the new layout. It checks the order of steps inside `main`, the dependency names, that the `toggle` path exits fast with no display, that the console script in `pyproject.toml` points at a real function, that `style.css` is package data, and that both `clipman.py --version` and `python -m clipman --version` print `clipman <version>`.
- CHANGELOG: new "Fixed" section for these items.

## How I tested it

- Built the wheel and the sdist with setuptools. Both contain `clipman/style.css`, `clipman/cli.py` and `clipman/__main__.py`. The entry point in the wheel is `clipman = clipman.cli:main`.
- Installed the wheel into a clean folder and ran it from `/tmp`, so the checkout could not shadow it. `clipman --version` and `python -m clipman --version` both print `clipman 1.2.1`. `importlib.resources` finds `style.css` in the installed copy.
- `scripts/dev.sh test`: 333 passed, 0 skipped. The unittest fallback also passes. `scripts/dev.sh ruff` is clean. Both workflow files parse.
- First CI run failed on Python 3.10 because the new test used `tomllib`, which only exists from Python 3.11. The test now reads `pyproject.toml` as plain text. The second CI run is green on 3.10, 3.11 and 3.12.

## Notes for review

- `argparse` now rejects unknown arguments with exit code 2. Before, any argument other than `toggle` silently started the daemon. No shipped launcher passes anything else.
- The `package` job is new. It is not a required check yet.
