### PR TITLE
Extension: accept D-Bus calls only from the daemon (contract v8)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,9 +109,10 @@ written with `sensitive = 1` and auto-deleted by
 
 ## IPC contract
 
-All IPC is on the session bus. Both interfaces are unauthenticated by
-design - access is gated by the user's session bus, which is the same
-trust boundary as GNOME Shell itself.
+All IPC is on the session bus. The daemon's interface is open to any
+process on that bus by design. The extension's interface accepts calls
+only from the connection that owns `com.clipman.Daemon`, because it
+can type keystrokes and move focus inside the compositor.
 
 ### Daemon
 
@@ -138,13 +139,15 @@ trust boundary as GNOME Shell itself.
 | Method                        | Signature   | Description                                                                                                                                                               |
 | ----------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SimulatePaste(s mode)`       | `(s) -> ()` | Simulates a paste keystroke through a Clutter virtual keyboard. `mode` is one of `auto`, `ctrl-v`, `ctrl-shift-v`, or `shift-insert`; unknown values fall back to `auto`. |
-| `MoveWindowToCursor(s title)` | `(s) -> ()` | Moves the GTK popup window (looked up by `title`) to the current cursor position.                                                                                         |
+| `MoveWindowToCursor(s title)` | `(s) -> ()` | Moves the daemon's popup (matched by `wm_class`, pid and `title`) to the cursor and gives it focus.                                                                     |
+| `RestorePreviousFocus()`      | `() -> ()`  | Gives focus back to the window the user came from, right before the paste.                                                                                                |
+| `SetPaused(b paused)`         | `(b) -> ()` | Stops or resumes clipboard reads; the daemon calls it when incognito changes.                                                                                             |
 
-The `SimulatePaste(s mode)` argument was added later; older
-extensions exposed the no-argument shape. The daemon attempts the
-modern signature first and silently retries without the argument on
-`UnknownMethod`. The rationale and back-compat path are recorded in
-[ADR 0005](docs/adr/0005-paste-mode-as-dbus-arg.md).
+All four methods accept calls only from the connection that owns
+`com.clipman.Daemon`; other callers get `AccessDenied`. The
+`SimulatePaste(s mode)` argument was added in extension v5; the daemon
+calls the current signature only (see
+[ADR 0005](docs/adr/0005-paste-mode-as-dbus-arg.md)).
 
 ## Trust boundaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,30 @@ All notable changes to Clipman are documented in this file.
 - `update_entry_text` had no caller and could break the unique hash
   constraint; removed. `get_latest_text` returns the newest text clip
   regardless of pins, for the `${clipboard}` snippet token.
+### Security — GNOME Shell extension (metadata version 8)
+
+- The extension's D-Bus methods (`SimulatePaste`, `MoveWindowToCursor`,
+  `RestorePreviousFocus`) could be called by any process on the session
+  bus, including through the Shell's own bus name. They could type a
+  paste keystroke into the focused window or focus any window by title.
+  Every method now accepts calls only from the connection that owns
+  `com.clipman.Daemon`; other callers get `AccessDenied`.
+- `MoveWindowToCursor` matched windows by title alone. It now requires
+  the popup's `wm_class`, the daemon's pid and the title. Windows it
+  hides from Alt+Tab on GNOME 49+ are shown again when the extension is
+  disabled.
+- New `SetPaused(b)` method: while paused the extension does not read
+  the clipboard, so incognito can stop clips before they cross the bus.
+- Lifecycle fixes: null-prototype recipe tables (a `__proto__` mode no
+  longer throws), one virtual keyboard instead of one per paste,
+  modifiers are always released, `disable()` clears every reference and
+  cancels in-flight work, and the Alt+Tab/dash patches are installed
+  only on GNOME 45 to 48 where the real API is missing.
+- Clips longer than the daemon's 10 MB limit are no longer sent over the
+  bus; delivery failures are logged.
+- `scripts/extension-smoke.sh` checks the access rule on a real session.
+- Docs: `docs/dbus-api.md` lists all four methods and version 8,
+  `docs/threat-model.md` covers the extension surface.
 
 ### Changed — Snap packaging (#237, #238)
 

--- a/docs/dbus-api.md
+++ b/docs/dbus-api.md
@@ -18,9 +18,10 @@ surface is intentionally small.
 
 - **stable** — signature is part of the project's public contract;
   removal or rename triggers a MAJOR version bump (see
-  [ADR 0010](adr/0010-versioning-policy.md)). Argument *addition*
-  with a daemon-side try-with-arg / retry-without-arg fallback is
-  a MINOR (precedent: [ADR 0005](adr/0005-paste-mode-as-dbus-arg.md)).
+  [ADR 0010](adr/0010-versioning-policy.md)). Adding an argument or
+  a method is a MINOR bump, and the extension's `metadata.json`
+  version goes up with it (precedent:
+  [ADR 0005](adr/0005-paste-mode-as-dbus-arg.md)).
 - **experimental** — reserved; no current methods are experimental.
 
 ## com.clipman.Daemon (the daemon)
@@ -137,10 +138,17 @@ gdbus call --session --dest com.clipman.Daemon \
 | Object path      | `/org/gnome/Shell/Extensions/clipman`           |
 | Interface        | `org.gnome.Shell.Extensions.clipman`            |
 
-Note: the extension's `metadata.json` `version` integer (currently 5)
+Note: the extension's `metadata.json` `version` integer (currently 8)
 is the **extension D-Bus contract version**, not the product SemVer.
 See [ADR 0005](adr/0005-paste-mode-as-dbus-arg.md) for the rationale
 behind bumping it on contract changes.
+
+**Access control (v8+).** Every method below is accepted only from the
+connection that owns `com.clipman.Daemon`. Any other caller gets
+`org.freedesktop.DBus.Error.AccessDenied`, and the refusal is logged once
+per sender. When no daemon is running, every call is refused. The
+`gdbus` examples below therefore fail from a plain shell; they are here
+to show the signatures.
 
 ### SimulatePaste
 
@@ -168,11 +176,11 @@ gdbus call --session --dest org.gnome.Shell.Extensions.clipman \
     --method org.gnome.Shell.Extensions.clipman.SimulatePaste 'ctrl-shift-v'
 ```
 
-The previous extension `metadata.json` v4 exposed
-`SimulatePaste()` with no arguments. New daemons paired with an
-unupgraded v4 extension still paste correctly: the daemon catches
-the `DBusException` and retries `SimulatePaste()` with no
-arguments. See [ADR 0005](adr/0005-paste-mode-as-dbus-arg.md).
+The daemon calls the current signature only. If the installed extension
+is older than the daemon, update it from extensions.gnome.org; the
+popup still works but paste falls back to `wtype`, which does not work
+on GNOME Wayland. See [ADR 0005](adr/0005-paste-mode-as-dbus-arg.md)
+for the history of the `mode` argument.
 
 ### MoveWindowToCursor
 
@@ -182,17 +190,45 @@ arguments. See [ADR 0005](adr/0005-paste-mode-as-dbus-arg.md).
 | Introduced   | 1.0.0                                                       |
 | Stability    | stable                                                      |
 
-Finds the window with the given title and moves it to the cursor
-position, clamped so the window stays inside the active workspace's
-work area. The match is exact (full string equality on
-`meta_window.get_title()`); if no window matches, the call is a
-silent no-op.
+Finds the daemon's popup and moves it to the cursor position, clamped so
+the window stays inside the active workspace's work area. A window
+matches only when its `wm_class` is `com.clipman.Clipman`, its process
+is the daemon (when the pid is known) and its title equals `title`. If
+no window matches, the call is a silent no-op. On GNOME 49+ the popup is
+also removed from Alt+Tab and the dash with `hide_from_window_list()`;
+`disable()` shows it again.
 
 ```bash
 gdbus call --session --dest org.gnome.Shell.Extensions.clipman \
     --object-path /org/gnome/Shell/Extensions/clipman \
     --method org.gnome.Shell.Extensions.clipman.MoveWindowToCursor 'Clipman'
 ```
+
+### RestorePreviousFocus
+
+| Field        | Value                                                       |
+|--------------|-------------------------------------------------------------|
+| Signature    | `()` → `()`                                                 |
+| Introduced   | 1.2.0 (extension metadata.json v6)                          |
+| Stability    | stable                                                      |
+
+Gives focus back to the window that had it before `MoveWindowToCursor`
+focused the popup. The daemon calls it right before `SimulatePaste`, so
+the keystroke lands in the user's window. Only the Shell can move focus
+on Wayland.
+
+### SetPaused
+
+| Field        | Value                                                       |
+|--------------|-------------------------------------------------------------|
+| Signature    | `(b)` → `()` — `paused`                                     |
+| Introduced   | 1.2.2 (extension metadata.json v8)                          |
+| Stability    | stable                                                      |
+
+While paused the extension does not read the clipboard at all, so
+nothing crosses the session bus. The daemon calls it when incognito
+mode is switched on or off. A pending clipboard read is cancelled when
+pausing.
 
 ## Smoke-testing
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -15,13 +15,17 @@ should still be reported through the private channel in
 | History database     | high (transitive — contains past clipboard)        | `~/.local/share/clipman/clipman.db` (SQLite WAL)               |
 | Image files          | medium                                             | `~/.local/share/clipman/images/`                               |
 | Daemon D-Bus surface | medium (injection + control vector)                | session bus, `com.clipman.Daemon`                              |
+| Extension D-Bus surface | high (keystroke synthesis and window focus inside the compositor) | session bus, `org.gnome.Shell.Extensions.clipman`       |
 
 ## Adversaries
 
 - **Local non-clipman processes running as the same UID.** Anything
-  on the session bus can call `NewEntry` to inject fake clipboard
-  content, or `Quit` to terminate the daemon. This is the design;
-  the session bus is the trust boundary, not a defence.
+  on the session bus can call the daemon's `NewEntry` to inject fake
+  clipboard content, or `Quit` to terminate the daemon. This is the
+  design; the session bus is the trust boundary, not a defence. The
+  extension's methods are different: they can type keystrokes and
+  move focus, which Wayland denies to normal apps, so they accept
+  calls only from the connection that owns `com.clipman.Daemon`.
 - **Malicious GNOME Shell extensions.** Extensions run inside the
   Shell's gjs process and can talk to anything on the session bus.
   A malicious extension could read the daemon's D-Bus surface or
@@ -77,10 +81,12 @@ should still be reported through the private channel in
 - **Physical access** to an unlocked machine.
 - **Cold-boot / offline disk forensics.** clipman does not assume
   full-disk encryption.
-- **D-Bus name-squatting by a malicious GNOME extension.** The
-  session bus grants well-known names on a first-come basis;
-  clipman does not attempt to detect impersonation beyond its own
-  `NewEntry` payload validation.
+- **D-Bus name-squatting.** The session bus grants well-known names
+  on a first-come basis. A process that owns `com.clipman.Daemon`
+  before the daemon starts receives every clipboard text the
+  extension forwards, and is the caller the extension trusts. The
+  daemon refuses to start when the name is already owned; nothing
+  else detects a squatter.
 - **Sandboxed-app clipboard** under Flatpak/Snap confinement —
   whether the host clipboard is readable inside another app's
   sandbox is a question for that sandbox's policy, not clipman's.

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -7,8 +7,17 @@ import Shell from 'gi://Shell';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 // The popup's Wayland app_id / wm_class (clipman/app.py application_id).
-// Used to keep our ephemeral popup out of alt-tab and the dash, like Win+V.
 const CLIPMAN_WM_CLASS = 'com.clipman.Clipman';
+
+// Only the process that owns this name may call the methods below.
+const DAEMON_BUS_NAME = 'com.clipman.Daemon';
+const DAEMON_OBJECT_PATH = '/com/clipman/Daemon';
+
+// Same limit as the daemon's MAX_TEXT_SIZE; it drops longer clips anyway.
+const MAX_TEXT_LENGTH = 10 * 1024 * 1024;
+
+const OWN_BUS_NAME = 'org.gnome.Shell.Extensions.clipman';
+const OWN_OBJECT_PATH = '/org/gnome/Shell/Extensions/clipman';
 
 function _isClipmanWindow(win) {
     if (!win)
@@ -27,6 +36,9 @@ const PASTE_DBUS_IFACE = `
       <arg type="s" direction="in" name="title"/>
     </method>
     <method name="RestorePreviousFocus"/>
+    <method name="SetPaused">
+      <arg type="b" direction="in" name="paused"/>
+    </method>
   </interface>
 </node>`;
 
@@ -37,51 +49,101 @@ const TERMINAL_WM_CLASSES = [
     'lxterminal', 'guake', 'tilda', 'cool-retro-term',
 ];
 
-// Keystroke recipes: ordered list of (keyval, modifiers-implied-by-keystroke).
-// The first element of each pair is the actual keyval to press; modifier
-// keys are emitted around the press/release.
-const PASTE_RECIPES = {
+// Null-prototype tables: a mode such as "__proto__" must not resolve.
+const PASTE_RECIPES = Object.assign(Object.create(null), {
     'ctrl-v': {modifiers: ['Control_L'], key: 'v'},
     'ctrl-shift-v': {modifiers: ['Control_L', 'Shift_L'], key: 'v'},
     'shift-insert': {modifiers: ['Shift_L'], key: 'Insert'},
-};
+});
 
-const KEY_LOOKUP = {
+const KEY_LOOKUP = Object.assign(Object.create(null), {
     'Control_L': Clutter.KEY_Control_L,
     'Shift_L': Clutter.KEY_Shift_L,
-    'Alt_L': Clutter.KEY_Alt_L,
-    'Super_L': Clutter.KEY_Super_L,
     'v': Clutter.KEY_v,
     'Insert': Clutter.KEY_Insert,
-};
+});
 
 export default class ClipmanExtension extends Extension {
     enable() {
+        this._destroyed = false;
+        this._paused = false;
+        this._prevFocus = null;
+        this._hiddenWindows = new Set();
+        this._daemonOwner = null;
+        this._daemonPid = 0;
+        this._deniedSenders = new Set();
+        this._virtualKeyboard = null;
+        this._clipboardTimeout = null;
+
         this._selection = global.display.get_selection();
         this._ownerChangedId = this._selection.connect(
             'owner-changed',
             this._onOwnerChanged.bind(this)
         );
 
-        // Own a bus name so the daemon can find us
-        this._busNameId = Gio.bus_own_name_on_connection(
-            Gio.DBus.session,
-            'org.gnome.Shell.Extensions.clipman',
-            Gio.BusNameOwnerFlags.NONE,
-            null, null
+        // Learn which connection owns the daemon name; only it may call us.
+        this._daemonWatchId = Gio.bus_watch_name(
+            Gio.BusType.SESSION,
+            DAEMON_BUS_NAME,
+            Gio.BusNameWatcherFlags.NONE,
+            (_connection, _name, owner) => this._onDaemonAppeared(owner),
+            () => this._onDaemonVanished()
         );
 
-        // Expose D-Bus interface so the daemon can request paste simulation
+        this._busNameId = Gio.bus_own_name_on_connection(
+            Gio.DBus.session,
+            OWN_BUS_NAME,
+            Gio.BusNameOwnerFlags.NONE,
+            null,
+            () => console.warn(`clipman: lost the bus name ${OWN_BUS_NAME}`)
+        );
+
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(
             PASTE_DBUS_IFACE, this
         );
-        this._dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell/Extensions/clipman');
+        this._dbusImpl.export(Gio.DBus.session, OWN_OBJECT_PATH);
 
-        // Win+V parity: keep the ephemeral popup out of alt-tab and the
-        // dash. There is no writable skip-taskbar API before GNOME 49, so
-        // we monkey-patch the two JS entry points that build those lists
-        // and filter our window out. On 49+ the daemon-side move loop uses
-        // the real Meta.Window.hide_from_window_list() instead (see below).
+        // Before GNOME 49 there is no hide_from_window_list(); filter the
+        // alt-tab and dash lists instead.
+        if (!Meta.Window.prototype.hide_from_window_list)
+            this._installWindowListPatches();
+    }
+
+    disable() {
+        this._destroyed = true;
+        this._removeWindowListPatches();
+        if (this._clipboardTimeout) {
+            GLib.source_remove(this._clipboardTimeout);
+            this._clipboardTimeout = null;
+        }
+        if (this._ownerChangedId) {
+            this._selection.disconnect(this._ownerChangedId);
+            this._ownerChangedId = null;
+        }
+        this._selection = null;
+        if (this._dbusImpl) {
+            this._dbusImpl.unexport();
+            this._dbusImpl = null;
+        }
+        if (this._busNameId) {
+            Gio.bus_unown_name(this._busNameId);
+            this._busNameId = null;
+        }
+        if (this._daemonWatchId) {
+            Gio.bus_unwatch_name(this._daemonWatchId);
+            this._daemonWatchId = 0;
+        }
+        this._showHiddenWindows();
+        this._prevFocus = null;
+        this._daemonOwner = null;
+        this._daemonPid = 0;
+        this._deniedSenders.clear();
+        this._virtualKeyboard = null;
+    }
+
+    // ---- Window list patches (GNOME 45 to 48) -------------------------
+
+    _installWindowListPatches() {
         this._origGetTabList = global.display.get_tab_list;
         const origGetTabList = this._origGetTabList;
         global.display.get_tab_list = function (type, workspace) {
@@ -96,13 +158,9 @@ export default class ClipmanExtension extends Extension {
                 .filter(w => !_isClipmanWindow(w));
         };
 
-        // The dash/dock (incl. Ubuntu Dock / Dash-to-Dock) lists running
-        // apps from AppSystem.get_running(). Our popup has no installed
-        // .desktop, so the Shell tracks it as a window-backed app that
-        // shows up there. Filter that app out of the running list so the
-        // ephemeral popup never appears in the dock — Win+V parity. We use
-        // the ORIGINAL get_windows here (the patched one above hides
-        // clipman windows, which would make this app look window-less).
+        // The dash lists running apps; the popup has no .desktop file, so
+        // it would show up as a window-backed app. Use the original
+        // get_windows here, or the app would look window-less.
         this._origGetRunning = Shell.AppSystem.prototype.get_running;
         const origGetRunning = this._origGetRunning;
         Shell.AppSystem.prototype.get_running = function () {
@@ -118,7 +176,7 @@ export default class ClipmanExtension extends Extension {
         };
     }
 
-    disable() {
+    _removeWindowListPatches() {
         if (this._origGetTabList) {
             global.display.get_tab_list = this._origGetTabList;
             this._origGetTabList = null;
@@ -131,62 +189,162 @@ export default class ClipmanExtension extends Extension {
             Shell.AppSystem.prototype.get_running = this._origGetRunning;
             this._origGetRunning = null;
         }
-        if (this._clipboardTimeout) {
+    }
+
+    // ---- Caller authentication ---------------------------------------
+
+    _onDaemonAppeared(owner) {
+        this._daemonOwner = owner;
+        this._daemonPid = 0;
+        this._deniedSenders.clear();
+        // The pid lets MoveWindowToCursor check that a window is ours.
+        Gio.DBus.session.call(
+            'org.freedesktop.DBus',
+            '/org/freedesktop/DBus',
+            'org.freedesktop.DBus',
+            'GetConnectionUnixProcessID',
+            new GLib.Variant('(s)', [owner]),
+            new GLib.VariantType('(u)'),
+            Gio.DBusCallFlags.NONE,
+            -1,
+            null,
+            (connection, result) => {
+                try {
+                    const [pid] = connection.call_finish(result).deepUnpack();
+                    if (this._daemonOwner === owner)
+                        this._daemonPid = pid;
+                } catch (e) {
+                    console.warn(`clipman: pid lookup failed: ${e.message}`);
+                }
+            }
+        );
+    }
+
+    _onDaemonVanished() {
+        this._daemonOwner = null;
+        this._daemonPid = 0;
+    }
+
+    // Reply with AccessDenied unless the caller owns the daemon name.
+    _authorize(invocation) {
+        const sender = invocation.get_sender();
+        if (this._daemonOwner !== null && sender === this._daemonOwner)
+            return true;
+        if (!this._deniedSenders.has(sender)) {
+            this._deniedSenders.add(sender);
+            console.warn(
+                `clipman: denied ${invocation.get_method_name()} from ` +
+                `${sender}: not the owner of ${DAEMON_BUS_NAME}`
+            );
+        }
+        invocation.return_error_literal(
+            Gio.DBusError,
+            Gio.DBusError.ACCESS_DENIED,
+            `Only the owner of ${DAEMON_BUS_NAME} may call this method`
+        );
+        return false;
+    }
+
+    // ---- D-Bus methods -----------------------------------------------
+
+    SimulatePasteAsync([mode], invocation) {
+        if (!this._authorize(invocation))
+            return;
+        try {
+            this._dispatchKeystroke(this._resolveRecipe(mode));
+            invocation.return_value(null);
+        } catch (e) {
+            invocation.return_dbus_error(
+                'org.gnome.Shell.Extensions.clipman.Error', e.message);
+        }
+    }
+
+    MoveWindowToCursorAsync([title], invocation) {
+        if (!this._authorize(invocation))
+            return;
+        try {
+            this._moveWindowToCursor(title);
+            invocation.return_value(null);
+        } catch (e) {
+            invocation.return_dbus_error(
+                'org.gnome.Shell.Extensions.clipman.Error', e.message);
+        }
+    }
+
+    RestorePreviousFocusAsync(_params, invocation) {
+        if (!this._authorize(invocation))
+            return;
+        const prev = this._prevFocus;
+        this._prevFocus = null;
+        if (prev && !_isClipmanWindow(prev)) {
+            try {
+                prev.activate(global.get_current_time());
+            } catch {
+                // The window closed meanwhile; the paste goes to the
+                // current focus.
+            }
+        }
+        invocation.return_value(null);
+    }
+
+    SetPausedAsync([paused], invocation) {
+        if (!this._authorize(invocation))
+            return;
+        this._paused = Boolean(paused);
+        if (this._paused && this._clipboardTimeout) {
             GLib.source_remove(this._clipboardTimeout);
             this._clipboardTimeout = null;
         }
-        if (this._ownerChangedId) {
-            this._selection.disconnect(this._ownerChangedId);
-            this._ownerChangedId = null;
-        }
-        if (this._dbusImpl) {
-            this._dbusImpl.unexport();
-            this._dbusImpl = null;
-        }
-        if (this._busNameId) {
-            Gio.bus_unown_name(this._busNameId);
-            this._busNameId = null;
-        }
+        invocation.return_value(null);
     }
 
-    SimulatePaste(mode) {
-        const recipe = this._resolveRecipe(mode);
-        this._dispatchKeystroke(recipe);
-    }
+    // ---- Paste -------------------------------------------------------
 
     _resolveRecipe(mode) {
-        // 'auto' (or missing) -> Ctrl+V unless focused window is a terminal,
-        // in which case Ctrl+Shift+V. Explicit modes override.
-        if (mode && PASTE_RECIPES[mode])
+        if (typeof mode === 'string' && Object.hasOwn(PASTE_RECIPES, mode))
             return PASTE_RECIPES[mode];
 
+        // 'auto': Ctrl+V, or Ctrl+Shift+V when a terminal has focus.
         const focusWin = global.display.get_focus_window();
         const wmClass = focusWin?.get_wm_class()?.toLowerCase() ?? '';
         const isTerminal = TERMINAL_WM_CLASSES.some(c => wmClass.includes(c));
         return isTerminal ? PASTE_RECIPES['ctrl-shift-v'] : PASTE_RECIPES['ctrl-v'];
     }
 
-    _dispatchKeystroke(recipe) {
-        const seat = Clutter.get_default_backend().get_default_seat();
-        const vk = seat.create_virtual_device(
-            Clutter.InputDeviceType.KEYBOARD_DEVICE
-        );
-
-        for (const mod of recipe.modifiers) {
-            vk.notify_keyval(Clutter.CURRENT_TIME,
-                KEY_LOOKUP[mod], Clutter.KeyState.PRESSED);
+    _getVirtualKeyboard() {
+        if (!this._virtualKeyboard) {
+            const seat = Clutter.get_default_backend().get_default_seat();
+            this._virtualKeyboard = seat.create_virtual_device(
+                Clutter.InputDeviceType.KEYBOARD_DEVICE);
         }
-        vk.notify_keyval(Clutter.CURRENT_TIME,
-            KEY_LOOKUP[recipe.key], Clutter.KeyState.PRESSED);
-        vk.notify_keyval(Clutter.CURRENT_TIME,
-            KEY_LOOKUP[recipe.key], Clutter.KeyState.RELEASED);
-        for (const mod of [...recipe.modifiers].reverse()) {
+        return this._virtualKeyboard;
+    }
+
+    _dispatchKeystroke(recipe) {
+        const vk = this._getVirtualKeyboard();
+        const pressed = [];
+        try {
+            for (const mod of recipe.modifiers) {
+                vk.notify_keyval(Clutter.CURRENT_TIME,
+                    KEY_LOOKUP[mod], Clutter.KeyState.PRESSED);
+                pressed.push(mod);
+            }
             vk.notify_keyval(Clutter.CURRENT_TIME,
-                KEY_LOOKUP[mod], Clutter.KeyState.RELEASED);
+                KEY_LOOKUP[recipe.key], Clutter.KeyState.PRESSED);
+            vk.notify_keyval(Clutter.CURRENT_TIME,
+                KEY_LOOKUP[recipe.key], Clutter.KeyState.RELEASED);
+        } finally {
+            // Never leave a modifier held down.
+            for (const mod of pressed.reverse()) {
+                vk.notify_keyval(Clutter.CURRENT_TIME,
+                    KEY_LOOKUP[mod], Clutter.KeyState.RELEASED);
+            }
         }
     }
 
-    MoveWindowToCursor(title) {
+    // ---- Popup placement ---------------------------------------------
+
+    _moveWindowToCursor(title) {
         const [x, y] = global.get_pointer();
         const monitor = global.display.get_current_monitor();
         const workArea = global.display.get_workspace_manager()
@@ -194,62 +352,63 @@ export default class ClipmanExtension extends Extension {
 
         for (const actor of global.get_window_actors()) {
             const metaWin = actor.get_meta_window();
-            if (metaWin.get_title() === title) {
-                const rect = metaWin.get_frame_rect();
-                let winX = Math.min(x, workArea.x + workArea.width - rect.width);
-                let winY = Math.min(y, workArea.y + workArea.height - rect.height);
-                winX = Math.max(workArea.x, winX);
-                winY = Math.max(workArea.y, winY);
-                metaWin.move_frame(true, winX, winY);
-                // Remember who had focus BEFORE we steal it below, so paste
-                // can hand focus back to the real target (see
-                // RestorePreviousFocus). Capture now: activate() has not run
-                // yet, so the focus window is still the user's app.
-                const focused = global.display.get_focus_window();
-                if (focused && !_isClipmanWindow(focused))
-                    this._prevFocus = focused;
-                // GNOME 49+: the supported way to drop the popup from the
-                // dash AND alt-tab in one call (no-op / undefined before 49,
-                // where the enable() list overrides handle it instead).
-                if (metaWin.hide_from_window_list)
-                    metaWin.hide_from_window_list();
-                // Give the popup real input focus. A background D-Bus
-                // daemon's window is mapped WITHOUT focus by Mutter's
-                // focus-stealing prevention, so its buttons/keys are inert
-                // until focused. The Shell has the privilege to focus it;
-                // GTK's present() does not. This is what makes Win+V-style
-                // click/type/dismiss work. On hide, focus returns to the
-                // previously-active window, so wtype paste still lands there.
-                metaWin.activate(global.get_current_time());
-                break;
-            }
+            if (!metaWin || !_isClipmanWindow(metaWin))
+                continue;
+            if (this._daemonPid && metaWin.get_pid() !== this._daemonPid)
+                continue;
+            if (metaWin.get_title() !== title)
+                continue;
+
+            const rect = metaWin.get_frame_rect();
+            let winX = Math.min(x, workArea.x + workArea.width - rect.width);
+            let winY = Math.min(y, workArea.y + workArea.height - rect.height);
+            winX = Math.max(workArea.x, winX);
+            winY = Math.max(workArea.y, winY);
+            metaWin.move_frame(true, winX, winY);
+
+            // Remember the user's window before we take focus, so the
+            // paste can go back to it.
+            const focused = global.display.get_focus_window();
+            if (focused && !_isClipmanWindow(focused))
+                this._prevFocus = focused;
+
+            this._hideFromWindowList(metaWin);
+            // A background daemon's window is mapped without focus; only
+            // the Shell can give it focus on Wayland.
+            metaWin.activate(global.get_current_time());
+            break;
         }
     }
 
-    RestorePreviousFocus() {
-        // The popup held input focus (so its buttons/keys worked); before
-        // the daemon fires the paste keystroke it must hand focus back to
-        // the window the user came from, otherwise Ctrl+V lands on nothing.
-        // Only the Shell can refocus another window on Wayland, so the
-        // daemon calls this after hiding the popup and just before wtype.
-        const prev = this._prevFocus;
-        this._prevFocus = null;
-        if (prev && !_isClipmanWindow(prev)) {
+    _hideFromWindowList(metaWin) {
+        if (!metaWin.hide_from_window_list)
+            return;
+        metaWin.hide_from_window_list();
+        this._hiddenWindows.add(metaWin);
+    }
+
+    _showHiddenWindows() {
+        for (const win of this._hiddenWindows) {
             try {
-                prev.activate(global.get_current_time());
+                if (win.show_in_window_list)
+                    win.show_in_window_list();
             } catch {
-                // The target window may have closed meanwhile; the paste
-                // keystroke then goes to whatever is now focused.
+                // The window is gone already.
             }
         }
+        this._hiddenWindows.clear();
     }
+
+    // ---- Clipboard capture -------------------------------------------
 
     _onOwnerChanged(_selection, selectionType, _selectionSource) {
         if (selectionType !== Meta.SelectionType.SELECTION_CLIPBOARD)
             return;
+        if (this._paused)
+            return;
 
-        // Debounce: wait 150ms for the new clipboard owner to make
-        // content available. Rapid copies cancel the previous read.
+        // Wait 150 ms for the new owner to make the content available.
+        // Rapid copies cancel the previous read.
         if (this._clipboardTimeout) {
             GLib.source_remove(this._clipboardTimeout);
             this._clipboardTimeout = null;
@@ -259,11 +418,12 @@ export default class ClipmanExtension extends Extension {
             GLib.PRIORITY_DEFAULT, 150, () => {
                 this._clipboardTimeout = null;
                 this._getClipboardText().then(text => {
-                    if (text) {
+                    if (this._destroyed || this._paused)
+                        return;
+                    if (text)
                         this._sendToDaemon('text', text);
-                    } else {
+                    else
                         this._sendToDaemon('image', '');
-                    }
                 }).catch(() => {});
                 return GLib.SOURCE_REMOVE;
             }
@@ -290,7 +450,7 @@ export default class ClipmanExtension extends Extension {
                     (_cb, bytes) => {
                         if (bytes && bytes.get_size() > 0) {
                             let data = bytes.get_data();
-                            // Trim trailing null byte (some X11 apps include it)
+                            // Some X11 apps include a trailing null byte.
                             if (data.length > 0 && data[data.length - 1] === 0)
                                 data = data.slice(0, -1);
                             resolve(new TextDecoder().decode(data));
@@ -306,17 +466,25 @@ export default class ClipmanExtension extends Extension {
     }
 
     _sendToDaemon(contentType, content) {
+        if (content.length > MAX_TEXT_LENGTH)
+            return;
         Gio.DBus.session.call(
-            'com.clipman.Daemon',
-            '/com/clipman/Daemon',
-            'com.clipman.Daemon',
+            DAEMON_BUS_NAME,
+            DAEMON_OBJECT_PATH,
+            DAEMON_BUS_NAME,
             'NewEntry',
             new GLib.Variant('(ss)', [contentType, content]),
             null,
-            Gio.DBusCallFlags.NONE,
+            Gio.DBusCallFlags.NO_AUTO_START,
             -1,
             null,
-            null
+            (connection, result) => {
+                try {
+                    connection.call_finish(result);
+                } catch (e) {
+                    console.debug(`clipman: NewEntry not delivered: ${e.message}`);
+                }
+            }
         );
     }
 }

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -3,7 +3,7 @@
     "name": "Clipman Clipboard Monitor",
     "description": "Native Wayland clipboard change detection for the Clipman clipboard manager. Listens to Meta.Selection owner-changed signals and forwards clipboard content to the Clipman daemon via D-Bus. Provides paste simulation and window positioning services. Requires the Clipman daemon (clipman.service) to be running.",
     "shell-version": ["45", "46", "47", "48", "49", "50"],
-    "version": 7,
+    "version": 8,
     "url": "https://github.com/MohammedEl-sayedAhmed/clipman",
     "donations": {
         "paypal": "mohammedelsayedammar"

--- a/scripts/extension-smoke.sh
+++ b/scripts/extension-smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Manual smoke test for the GNOME Shell extension's D-Bus access control.
+# Run it inside a GNOME Wayland session with the extension enabled.
+# Exit code 0 means every automated check passed.
+
+set -uo pipefail
+
+EXT_NAME="org.gnome.Shell.Extensions.clipman"
+EXT_PATH="/org/gnome/Shell/Extensions/clipman"
+DAEMON_NAME="com.clipman.Daemon"
+pass=0
+fail=0
+
+ok() { printf '  PASS  %s\n' "$1"; pass=$((pass + 1)); }
+ko() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+# Call a method from this shell. This shell does not own the daemon name,
+# so every call must be refused with AccessDenied.
+expect_denied() {
+    local method="$1"; shift
+    local out
+    out=$(gdbus call --session --dest "$EXT_NAME" --object-path "$EXT_PATH" \
+        --method "$EXT_NAME.$method" "$@" 2>&1)
+    if printf '%s' "$out" | grep -q "AccessDenied"; then
+        ok "$method refused for a foreign caller"
+    else
+        ko "$method was NOT refused: $out"
+    fi
+}
+
+echo "== Extension present"
+if gdbus introspect --session --dest "$EXT_NAME" --object-path "$EXT_PATH" 2>/dev/null \
+        | grep -q "SetPaused"; then
+    ok "interface exports SetPaused (contract version 8)"
+else
+    ko "SetPaused missing: is extension v8 installed and enabled?"
+fi
+
+echo "== Foreign callers are refused (direct name)"
+expect_denied SimulatePaste "'ctrl-v'"
+expect_denied MoveWindowToCursor "'Clipman'"
+expect_denied RestorePreviousFocus
+expect_denied SetPaused true
+
+echo "== Foreign callers are refused (via org.gnome.Shell)"
+out=$(gdbus call --session --dest org.gnome.Shell --object-path "$EXT_PATH" \
+    --method "$EXT_NAME.SimulatePaste" "'ctrl-v'" 2>&1)
+if printf '%s' "$out" | grep -q "AccessDenied"; then
+    ok "SimulatePaste refused through the Shell's own name"
+else
+    ko "SimulatePaste through org.gnome.Shell was NOT refused: $out"
+fi
+
+echo "== Bad mode does not crash the extension"
+out=$(gdbus call --session --dest "$EXT_NAME" --object-path "$EXT_PATH" \
+    --method "$EXT_NAME.SimulatePaste" "'__proto__'" 2>&1)
+if printf '%s' "$out" | grep -q "AccessDenied"; then
+    ok "'__proto__' mode refused before it can reach the recipe table"
+else
+    ko "unexpected reply for '__proto__': $out"
+fi
+
+echo "== Daemon"
+if gdbus call --session --dest org.freedesktop.DBus --object-path /org/freedesktop/DBus \
+        --method org.freedesktop.DBus.NameHasOwner "$DAEMON_NAME" 2>/dev/null | grep -q true; then
+    ok "daemon owns $DAEMON_NAME"
+else
+    ko "daemon is not running; start it and re-run for the manual steps"
+fi
+
+cat <<'EOF'
+
+== Manual steps (need a human)
+  1. Press Super+V, pick a clip, and confirm it pastes into the focused app.
+  2. Turn incognito on in the popup, copy some text, and confirm no new
+     entry appears in the history. Turn incognito off; copies work again.
+  3. Run: gnome-extensions disable clipman@clipman.com
+     Open the popup with `clipman toggle` and confirm it now shows in
+     Alt+Tab (GNOME 49+ only). Re-enable the extension afterwards.
+  4. Check the journal for "clipman: denied" lines from this script:
+     journalctl --user -b -g "clipman: denied" | tail
+EOF
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

The GNOME Shell extension exported three D-Bus methods that any process on the session bus could call: type a paste keystroke into the focused window, move and focus any window with a given title, and re-focus the window the user came from. Wayland normally forbids all of that to normal apps. This PR makes the extension accept calls only from the process that owns the daemon's bus name, fixes the window match, and cleans up lifecycle issues. It bumps the extension contract to version 8 and adds a `SetPaused` method so incognito mode also stops the extension from reading the clipboard.

**Test status:** the automated part of `scripts/extension-smoke.sh` passed on a GNOME Shell 50.1 machine, with the Shell running in headless mode on a private session bus (see the comment below for the full result). The three manual steps (paste into a focused app, incognito on and off, Alt+Tab hiding) still need a person in a real session.

## What was wrong

- `SimulatePaste`, `MoveWindowToCursor` and `RestorePreviousFocus` had no check on who called them. With `gdbus call` from any shell, or from any Flatpak that may talk to `org.gnome.Shell`, a process could press Ctrl+V into whatever window had focus, or focus a window it chose. The object is also reachable through the Shell's own bus name, so owning our name was never a protection.
- `MoveWindowToCursor` matched windows by title only. Any window called "Clipman" was picked. On GNOME 49+ it then called `hide_from_window_list()` on that window, and nothing ever undid that.
- Incognito mode only stopped the daemon. The extension still read every copy and sent it over the bus.
- `PASTE_RECIPES` was a normal object, so a mode like `"__proto__"` returned a non-recipe and threw. A new virtual keyboard was created for every paste. The key press sequence had no `finally`, so an error could leave Ctrl held down. `disable()` did not clear `_prevFocus` and an in-flight clipboard read could still send after disable. The alt-tab and dash patches were installed even on GNOME 49+, where the real API exists.
- The docs listed contract version 5 (it is 7), did not mention `RestorePreviousFocus` at all, and described a "retry without arguments" that the daemon does not do.

## What changed

- **Caller check.** The extension watches `com.clipman.Daemon` with `Gio.bus_watch_name`. Every method is now an `...Async(params, invocation)` handler and checks `invocation.get_sender()` against the daemon's unique bus name. Anyone else gets `org.freedesktop.DBus.Error.AccessDenied`, logged once per sender. When no daemon is running, every caller is refused.
- **Window match.** `MoveWindowToCursor` requires the popup's `wm_class` and, when known, the daemon's pid (from `GetConnectionUnixProcessID`), then the title. Windows hidden with `hide_from_window_list()` are tracked and shown again with `show_in_window_list()` in `disable()`.
- **`SetPaused(b)`.** New method. While paused, the extension does not read the clipboard at all. The daemon will call it when incognito is toggled (daemon side comes in the next PR; a v8 extension with today's daemon just never pauses, same as before).
- **Lifecycle.** Null-prototype recipe and key tables; one virtual keyboard created on first use; `try/finally` releases modifiers; `disable()` sets a destroyed flag, clears focus and selection references, stops the name watch, and re-shows hidden windows. The alt-tab and dash patches are installed only when `hide_from_window_list` does not exist (GNOME 45 to 48).
- **Sending clips.** Text longer than the daemon's 10 MB limit is not sent. Calls use `NO_AUTO_START` and log delivery failures instead of dropping them silently.
- **`metadata.json`** version 7 → 8. This needs a manual upload to extensions.gnome.org at release time.
- **Docs.** `docs/dbus-api.md` now lists all four methods, says "currently 8", explains the access rule, and drops the false retry claim. `docs/threat-model.md` gets the extension surface as an asset and the real consequence of name squatting. `ARCHITECTURE.md` table updated. CHANGELOG entry.
- **`scripts/extension-smoke.sh`**: a script for the maintainer to run on a real GNOME session. It checks that the interface exports `SetPaused`, that every method refuses a foreign caller (directly and through `org.gnome.Shell`), that `"__proto__"` is refused, and then lists the manual steps.

## What I could verify here

- The module loads in `gjs` 1.88 against the real Mutter 18 and Clutter typelibs (only the Shell-private `St`, `Shell` and `resource://` imports were stubbed). A harness confirmed: the owner passes the check and a foreign sender gets `AccessDenied`; with no daemon everyone is refused; `SetPaused` works for the owner and is ignored for others; `"__proto__"`, `"constructor"`, `""`, `42` and `null` modes all fall back to auto; text over the cap is not sent; normal text is sent with `NO_AUTO_START`.
- API facts: `Meta.Window.get_pid` exists in Mutter 45.0; `hide_from_window_list` / `show_in_window_list` exist from 49.0 and are feature-detected; `Gio.DBusMethodInvocation.get_sender`, `Gio.bus_watch_name` and `Gio.DBusError.ACCESS_DENIED` are present.
- `scripts/extension-smoke.sh` passes shellcheck. The existing Python tests are unchanged and pass.

## How to test (real GNOME Wayland session)

1. Install the extension from this branch, log out and in, start the daemon.
2. Run `scripts/extension-smoke.sh`. All automated checks should print PASS.
3. Follow the manual steps it prints: paste from the popup, incognito on/off, disable the extension and check Alt+Tab.

## Residual risk

- A same-UID process can still `ptrace` the daemon or take `com.clipman.Daemon` first if it starts before the daemon. The daemon-side `do_not_queue` fix for the second case is in the next PR. The session bus is still the trust boundary; this PR stops any random process or sandboxed app from driving the Shell through us.

