### PR TITLE
Daemon: refuse a second instance, survive a dead bus, pause the extension in incognito

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,24 @@ All notable changes to Clipman are documented in this file.
 - The benchmark corpus ships as `tests/sensitive_corpus.py` and
   `tests/test_sensitive.py` asserts zero false positives on it.
 
+### Fixed — daemon start-up and incognito on the bus
+
+- A second daemon was never refused the `com.clipman.Daemon` name. It
+  waited in the bus queue, and the code that should have logged and
+  quit never ran. The name is now requested with `do_not_queue`, so a
+  second daemon exits at once. A new test starts two daemons on a
+  private bus and checks that the second one is refused.
+- When the session bus could not be reached, the error escaped the
+  start-up code as a traceback while the window kept the process
+  alive. The daemon now logs the error and quits.
+- Incognito mode also pauses the GNOME Shell extension (contract v8) so
+  clips never cross the bus while it is on. The daemon calls
+  `SetPaused` when incognito changes, at start-up, and again whenever
+  the extension reappears. Older extensions ignore the call.
+- Reading an image from the clipboard ran `wl-paste` on the main loop
+  and could freeze the popup for up to five seconds. It now runs on a
+  background thread and stores the result on the main loop.
+
 ### Changed — Snap packaging (#237, #238)
 
 - The snap now uses the `gnome` extension: the GTK4/libadwaita runtime

--- a/clipman/app.py
+++ b/clipman/app.py
@@ -25,6 +25,7 @@ from clipman.database import ClipboardDB
 from clipman.clipboard_monitor import ClipboardMonitor
 from clipman.window import ClipmanWindow
 from clipman.dbus_service import ClipmanDBusService
+import clipman.shell_bridge as shell_bridge
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,8 @@ class ClipmanApp(Adw.Application):
         # Surface repeated wl-paste crashes in the popup instead of dying
         # silently (mockup watcher-crashed).
         self.monitor.on_watcher_dead = self._on_watcher_dead
+        # Incognito also pauses the extension (no clip crosses the bus).
+        self.monitor.on_incognito_changed = shell_bridge.set_paused
         # Phase 1 of the GTK 4 + libadwaita port: keyword args only, the
         # window constructor expects (application, db, monitor) now.
         self.window = ClipmanWindow(
@@ -71,11 +74,8 @@ class ClipmanApp(Adw.Application):
         ).lower() == "true":
             self.window.set_incognito(True)
 
-        # Register the D-Bus service BEFORE calling hold() — if another
-        # Clipman daemon is already on the bus, we want to log + quit
-        # cleanly rather than have a held-but-unreachable second daemon
-        # hang around. dbus-python raises NameExistsException when the
-        # well-known bus name is already owned.
+        # Register the service before hold(): a second daemon, or a bus
+        # we cannot reach, must log and quit instead of lingering.
         try:
             self.dbus_service = ClipmanDBusService(
                 self.window, self, self.monitor
@@ -87,6 +87,19 @@ class ClipmanApp(Adw.Application):
             )
             self.quit()
             return
+        except dbus.exceptions.DBusException:
+            logger.exception("Cannot register on the session bus; exiting.")
+            self.quit()
+            return
+
+        # Push the pause state now and after any extension restart.
+        shell_bridge.set_paused(self.monitor.incognito)
+        try:
+            dbus.SessionBus().watch_name_owner(
+                shell_bridge.EXT_BUS_NAME, self._on_extension_owner_changed
+            )
+        except dbus.DBusException:
+            logger.debug("cannot watch the extension name", exc_info=True)
 
         # Keep the app running even when the window is hidden — the daemon
         # owns the lifetime of the clipboard monitor + D-Bus service.
@@ -112,6 +125,10 @@ class ClipmanApp(Adw.Application):
         # Handle SIGINT/SIGTERM gracefully
         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, self._shutdown)
         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, self._shutdown)
+
+    def _on_extension_owner_changed(self, owner):
+        if owner and self.monitor is not None:
+            shell_bridge.set_paused(self.monitor.incognito)
 
     def _on_watcher_dead(self):
         if self.window is not None:

--- a/clipman/clipboard_monitor.py
+++ b/clipman/clipboard_monitor.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import subprocess
+import threading
 import time
 
 from gi.repository import GLib
@@ -167,6 +168,12 @@ class ClipboardMonitor:
         # Optional: invoked (on the GLib main loop) when the wl-paste
         # fallback watcher crashes repeatedly and stops retrying.
         self.on_watcher_dead = None
+        # Optional: invoked with the new state when incognito changes.
+        self.on_incognito_changed = None
+        # The image read blocks on wl-paste, so it leaves the main loop.
+        # Tests replace these two with direct calls.
+        self._run_in_background = _run_in_thread
+        self._run_on_main_loop = GLib.idle_add
         self._self_copy = False
         self._incognito = False
         self._last_event_time = 0.0
@@ -197,8 +204,17 @@ class ClipboardMonitor:
     def set_self_copy(self, val: bool):
         self._self_copy = val
 
+    @property
+    def incognito(self) -> bool:
+        return self._incognito
+
     def set_incognito(self, val: bool):
-        self._incognito = val
+        self._incognito = bool(val)
+        if self.on_incognito_changed is not None:
+            try:
+                self.on_incognito_changed(self._incognito)
+            except Exception:
+                logger.debug("on_incognito_changed callback failed", exc_info=True)
 
     def _rate_limited(self):
         """Return True if this event arrived too fast (debounce)."""
@@ -226,12 +242,7 @@ class ClipboardMonitor:
             self.on_new_entry()
 
     def handle_new_image(self):
-        """Called from D-Bus when the extension detects an image copy.
-
-        Uses a single wl-paste call to read the image data. This only
-        happens when an image is actually copied (not on a timer), so
-        the single subprocess call does not cause visible flicker.
-        """
+        """Called from D-Bus when an image was copied."""
         if self._self_copy:
             self._self_copy = False
             return
@@ -239,15 +250,28 @@ class ClipboardMonitor:
         if self._incognito or self._rate_limited():
             return
 
+        self._run_in_background(self._read_image)
+
+    def _read_image(self):
+        """Read the image with wl-paste, then store it."""
         try:
             result = subprocess.run(
                 ["wl-paste", "--type", "image/png"],
                 capture_output=True, timeout=5
             )
-            if result.returncode == 0 and result.stdout:
-                if len(result.stdout) <= MAX_IMAGE_SIZE:
-                    self.db.add_entry("image", image_data=result.stdout)
-                    if self.on_new_entry:
-                        self.on_new_entry()
         except (subprocess.SubprocessError, OSError):
-            pass
+            logger.debug("wl-paste image read failed", exc_info=True)
+            return
+        if result.returncode == 0 and result.stdout:
+            if len(result.stdout) <= MAX_IMAGE_SIZE:
+                self._run_on_main_loop(self._store_image, result.stdout)
+
+    def _store_image(self, data):
+        self.db.add_entry("image", image_data=data)
+        if self.on_new_entry:
+            self.on_new_entry()
+        return False
+
+
+def _run_in_thread(fn):
+    threading.Thread(target=fn, daemon=True, name="clipman-image-read").start()

--- a/clipman/dbus_service.py
+++ b/clipman/dbus_service.py
@@ -9,7 +9,8 @@ IFACE = "com.clipman.Daemon"
 class ClipmanDBusService(dbus.service.Object):
     def __init__(self, window, app, monitor=None):
         bus = dbus.SessionBus()
-        bus_name = dbus.service.BusName(BUS_NAME, bus)
+        # do_not_queue: a second daemon fails here instead of waiting.
+        bus_name = dbus.service.BusName(BUS_NAME, bus, do_not_queue=True)
         super().__init__(bus_name, OBJ_PATH)
         self.window = window
         self.app = app

--- a/clipman/shell_bridge.py
+++ b/clipman/shell_bridge.py
@@ -1,0 +1,41 @@
+"""Best-effort calls from the daemon to the GNOME Shell extension."""
+
+import logging
+
+import dbus
+
+logger = logging.getLogger(__name__)
+
+EXT_BUS_NAME = "org.gnome.Shell.Extensions.clipman"
+EXT_OBJECT_PATH = "/org/gnome/Shell/Extensions/clipman"
+EXT_IFACE = "org.gnome.Shell.Extensions.clipman"
+
+
+def extension_iface():
+    """Return a proxy for the extension, or None when it is absent."""
+    try:
+        bus = dbus.SessionBus()
+        if not bus.name_has_owner(EXT_BUS_NAME):
+            return None
+        proxy = bus.get_object(EXT_BUS_NAME, EXT_OBJECT_PATH)
+        return dbus.Interface(proxy, EXT_IFACE)
+    except dbus.DBusException:
+        logger.debug("extension proxy unavailable", exc_info=True)
+        return None
+
+
+def set_paused(paused):
+    """Tell the extension to stop or resume clipboard reads.
+
+    Return True when the call succeeded. Extensions older than
+    contract version 8 have no SetPaused method; that returns False.
+    """
+    iface = extension_iface()
+    if iface is None:
+        return False
+    try:
+        iface.SetPaused(bool(paused))
+        return True
+    except dbus.DBusException as exc:
+        logger.debug("SetPaused not accepted by the extension: %s", exc)
+        return False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -164,6 +164,21 @@ class TestClipmanAppHelpers(unittest.TestCase):
             app._shutdown()
         q.assert_called_once()
 
+    # -- _on_extension_owner_changed ------------------------------------
+
+    def test_extension_reappearing_pushes_the_pause_state(self):
+        app = self._make_app()
+        app.monitor.incognito = True
+        with patch("clipman.app.shell_bridge.set_paused") as set_paused:
+            app._on_extension_owner_changed(":1.77")
+        set_paused.assert_called_once_with(True)
+
+    def test_extension_vanishing_pushes_nothing(self):
+        app = self._make_app()
+        with patch("clipman.app.shell_bridge.set_paused") as set_paused:
+            app._on_extension_owner_changed("")
+        set_paused.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_clipboard_monitor.py
+++ b/tests/test_clipboard_monitor.py
@@ -24,6 +24,10 @@ class TestClipboardMonitor(unittest.TestCase):
 
         from clipman.clipboard_monitor import ClipboardMonitor
         self.monitor = ClipboardMonitor(self.mock_db, on_new_entry=on_new_entry)
+        # Run the image read and its store step inline instead of on a
+        # thread and the GLib loop.
+        self.monitor._run_in_background = lambda fn: fn()
+        self.monitor._run_on_main_loop = lambda fn, *args: fn(*args)
 
     def test_detects_new_text(self):
         self.monitor.handle_new_text("hello clipboard")
@@ -495,6 +499,8 @@ class TestDebounce(unittest.TestCase):
         self.mock_db = MagicMock()
         from clipman.clipboard_monitor import ClipboardMonitor
         self.monitor = ClipboardMonitor(self.mock_db)
+        self.monitor._run_in_background = lambda fn: fn()
+        self.monitor._run_on_main_loop = lambda fn, *args: fn(*args)
 
     def test_min_event_interval_value(self):
         """MIN_EVENT_INTERVAL must be at least 100ms to complement the
@@ -986,6 +992,55 @@ class TestWlPasteWatcher(unittest.TestCase):
         mock_proc.terminate.assert_called_once()
         # New process should have been started
         mock_popen.assert_called_once()
+
+
+class TestIncognitoHookAndImageThread(unittest.TestCase):
+    """Incognito is reported; the image read leaves the main loop."""
+
+    def setUp(self):
+        from clipman.clipboard_monitor import ClipboardMonitor
+        self.mock_db = MagicMock()
+        self.monitor = ClipboardMonitor(self.mock_db)
+
+    def test_incognito_hook_receives_each_change(self):
+        seen = []
+        self.monitor.on_incognito_changed = seen.append
+        self.monitor.set_incognito(True)
+        self.monitor.set_incognito(False)
+        self.assertEqual(seen, [True, False])
+        self.assertFalse(self.monitor.incognito)
+
+    def test_incognito_hook_errors_are_swallowed(self):
+        self.monitor.on_incognito_changed = MagicMock(side_effect=RuntimeError)
+        self.monitor.set_incognito(True)
+        self.assertTrue(self.monitor.incognito)
+
+    @patch("clipman.clipboard_monitor.subprocess.run")
+    def test_image_read_runs_in_background_then_stores_on_main_loop(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"\x89PNG\r\n\x1a\nxx")
+        background, main_loop = [], []
+        self.monitor._run_in_background = background.append
+        self.monitor._run_on_main_loop = lambda fn, *args: main_loop.append((fn, args))
+
+        self.monitor.handle_new_image()
+        self.assertEqual(len(background), 1)
+        self.mock_db.add_entry.assert_not_called()
+
+        background[0]()
+        self.assertEqual(len(main_loop), 1)
+        fn, args = main_loop[0]
+        fn(*args)
+        self.mock_db.add_entry.assert_called_once_with(
+            "image", image_data=b"\x89PNG\r\n\x1a\nxx"
+        )
+
+    @patch("clipman.clipboard_monitor.subprocess.run")
+    def test_failed_image_read_stores_nothing(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired("wl-paste", 5)
+        self.monitor._run_in_background = lambda fn: fn()
+        self.monitor._run_on_main_loop = lambda fn, *args: fn(*args)
+        self.monitor.handle_new_image()
+        self.mock_db.add_entry.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_dbus_service.py
+++ b/tests/test_dbus_service.py
@@ -1,0 +1,69 @@
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Runs on a private bus from dbus-run-session, so the developer's real
+# session bus and daemon are never touched. A child process owns the
+# daemon name through the real service class; the parent then tries the
+# same and must be refused instead of queued behind the child.
+WORKER = textwrap.dedent(
+    """
+    import subprocess
+    import sys
+    import textwrap
+    from unittest.mock import MagicMock
+
+    import dbus
+    import dbus.mainloop.glib
+
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    from clipman.dbus_service import BUS_NAME, ClipmanDBusService
+
+    HOLDER = textwrap.dedent('''
+        import time
+        from unittest.mock import MagicMock
+        import dbus.mainloop.glib
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        from clipman.dbus_service import ClipmanDBusService
+        ClipmanDBusService(MagicMock(), MagicMock())
+        print("holding", flush=True)
+        time.sleep(30)
+    ''')
+    holder = subprocess.Popen(
+        [sys.executable, "-c", HOLDER], stdout=subprocess.PIPE, text=True)
+    try:
+        assert holder.stdout.readline().strip() == "holding"
+        assert dbus.SessionBus().name_has_owner(BUS_NAME)
+        try:
+            ClipmanDBusService(MagicMock(), MagicMock())
+        except dbus.exceptions.NameExistsException:
+            print("second-owner-refused")
+            sys.exit(0)
+        print("second-owner-queued")
+        sys.exit(1)
+    finally:
+        holder.kill()
+    """
+)
+
+
+@unittest.skipUnless(shutil.which("dbus-run-session"), "dbus-run-session missing")
+class TestSingleInstance(unittest.TestCase):
+    """A second daemon must be refused the bus name, not queued."""
+
+    def test_second_owner_is_refused(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("DISPLAY", "WAYLAND_DISPLAY")}
+        env["PYTHONPATH"] = str(ROOT)
+        result = subprocess.run(
+            ["dbus-run-session", "--", sys.executable, "-c", WORKER],
+            capture_output=True, timeout=30, cwd=ROOT, env=env, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr[-800:])
+        self.assertIn("second-owner-refused", result.stdout)

--- a/tests/test_shell_bridge.py
+++ b/tests/test_shell_bridge.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import dbus
+
+import clipman.shell_bridge as shell_bridge
+
+
+class TestSetPaused(unittest.TestCase):
+    """set_paused never raises; it only reports success or failure."""
+
+    def _bus(self, owned=True):
+        bus = MagicMock()
+        bus.name_has_owner.return_value = owned
+        return bus
+
+    def test_calls_the_extension(self):
+        bus = self._bus()
+        iface = MagicMock()
+        with patch("clipman.shell_bridge.dbus.SessionBus", return_value=bus), \
+             patch("clipman.shell_bridge.dbus.Interface", return_value=iface):
+            self.assertTrue(shell_bridge.set_paused(True))
+        iface.SetPaused.assert_called_once_with(True)
+
+    def test_extension_absent(self):
+        with patch("clipman.shell_bridge.dbus.SessionBus",
+                   return_value=self._bus(owned=False)):
+            self.assertFalse(shell_bridge.set_paused(True))
+
+    def test_old_extension_without_the_method(self):
+        bus = self._bus()
+        iface = MagicMock()
+        iface.SetPaused.side_effect = dbus.DBusException(
+            "org.freedesktop.DBus.Error.UnknownMethod")
+        with patch("clipman.shell_bridge.dbus.SessionBus", return_value=bus), \
+             patch("clipman.shell_bridge.dbus.Interface", return_value=iface):
+            self.assertFalse(shell_bridge.set_paused(False))
+
+    def test_bus_unreachable(self):
+        with patch("clipman.shell_bridge.dbus.SessionBus",
+                   side_effect=dbus.DBusException("no bus")):
+            self.assertFalse(shell_bridge.set_paused(True))


### PR DESCRIPTION
## Summary

Four daemon-side fixes around the session bus. None of them touch the window code.

## What was wrong

- **A second daemon was never refused.** `ClipmanDBusService` asked for the `com.clipman.Daemon` name without `do_not_queue`. dbus-python only raises `NameExistsException` when that flag is set, so the second daemon quietly joined the bus queue and the "another daemon is running, exiting" code never ran. The second process then stayed alive, held, with no bus name.
- **An unreachable bus crashed start-up.** Only `NameExistsException` was caught around the service registration. If the bus itself could not be reached, the `DBusException` escaped `do_activate` as a traceback while the window kept the process alive.
- **Incognito did not stop the extension.** It only stopped the daemon from storing clips. The extension still read every copy and sent it over the bus.
- **The image read blocked the main loop.** `handle_new_image` ran `wl-paste` with a 5 second timeout on the GTK thread, so a slow or stuck `wl-paste` froze the popup. Any process could trigger it up to 10 times a second through `NewEntry`.

## What changed

- `dbus_service.py`: the name is requested with `do_not_queue=True`.
- `app.py`: a `DBusException` during registration is logged and the daemon quits. After registration the daemon pushes its incognito state to the extension with `SetPaused`, and pushes it again whenever the extension's bus name reappears (`watch_name_owner`).
- New `clipman/shell_bridge.py`: `set_paused(bool)` calls the extension's `SetPaused` (contract v8, PR #273). It never raises. With an older extension or no extension it returns `False`.
- `clipboard_monitor.py`: `set_incognito` reports each change through an `on_incognito_changed` hook, and an `incognito` property exposes the state. The image read runs on a background thread and stores the result from the main loop. The two runners are attributes, so tests can call them inline.

## Tests

- `tests/test_dbus_service.py`: starts a daemon on a private bus from `dbus-run-session`, then a second one, and checks that the second is refused. I confirmed this test fails on the old code (the second daemon was queued) and passes with the fix. It skips when `dbus-run-session` is missing.
- `tests/test_shell_bridge.py`: success, no extension, old extension without the method, unreachable bus.
- `tests/test_app.py`: the extension reappearing pushes the pause state; the name vanishing pushes nothing.
- `tests/test_clipboard_monitor.py`: the hook fires on each change and swallows errors; the image read is handed to the background runner and stored through the main-loop runner; a failed read stores nothing.
- Full suite: 355 passed on pytest and on the unittest fallback. ruff clean.

## Notes

- Works with today's extension (v7): `SetPaused` returns `False` and nothing else changes. With #273 merged, incognito also stops the extension from reading the clipboard.
- The `window.py` copy of the extension proxy code is untouched; it moves to `shell_bridge` in the window PR.
