### PR TITLE
Storage and update check: safer settings parsing, private DB file, main-loop writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,23 @@ All notable changes to Clipman are documented in this file.
 - Reading an image from the clipboard ran `wl-paste` on the main loop
   and could freeze the popup for up to five seconds. It now runs on a
   background thread and stores the result on the main loop.
+### Fixed — storage and update check
+
+- A `max_entries` setting stored as a float string (for example
+  `500.0`) made every copy fail with `ValueError`. The value is now
+  parsed the same way the Preferences pane reads it.
+- The database file itself was created with the process umask (0644
+  on most systems); only the directory and the WAL side files were
+  0600. It is now clamped to 0600 on every start, as the FAQ said.
+- The update check wrote its result to SQLite from a background
+  thread. It now hands the result to the GLib main loop first, so all
+  database access stays on one thread.
+- Comparing a release tag that is not a valid version (for example
+  `1.2.3-hotfix`) against a valid one could raise inside the update
+  check. Both sides now fall back to the same simple comparison.
+- `update_entry_text` had no caller and could break the unique hash
+  constraint; removed. `get_latest_text` returns the newest text clip
+  regardless of pins, for the `${clipboard}` snippet token.
 
 ### Changed — Snap packaging (#237, #238)
 

--- a/clipman/database.py
+++ b/clipman/database.py
@@ -27,6 +27,7 @@ def _ensure_dirs():
     # that already exist; new ones are clamped by ClipboardDB.__init__
     # right after the WAL pragma fires.
     for sidecar in (
+        DB_PATH,
         DB_PATH.with_name(DB_PATH.name + "-wal"),
         DB_PATH.with_name(DB_PATH.name + "-shm"),
     ):
@@ -252,7 +253,12 @@ class ClipboardDB:
         self.conn.commit()
 
     def enforce_max_entries(self):
-        max_entries = int(self.get_setting("max_entries", str(MAX_ENTRIES)))
+        # Older builds stored the value as a float string; never let a
+        # bad setting break every copy.
+        try:
+            max_entries = int(float(self.get_setting("max_entries", str(MAX_ENTRIES))))
+        except (TypeError, ValueError):
+            max_entries = MAX_ENTRIES
         count = self.conn.execute(
             "SELECT COUNT(*) as cnt FROM entries WHERE pinned = 0"
         ).fetchone()["cnt"]
@@ -296,14 +302,14 @@ class ClipboardDB:
             self.conn.commit()
         return len(rows)
 
-    def update_entry_text(self, entry_id: int, new_text: str):
-        h = content_hash(new_text.encode("utf-8"))
-        self.conn.execute(
-            """UPDATE entries SET content_text = ?, content_hash = ?,
-               accessed_at = ? WHERE id = ?""",
-            (new_text, h, time.time(), entry_id)
-        )
-        self.conn.commit()
+    def get_latest_text(self) -> str:
+        """Return the most recently used text clip, pinned or not."""
+        row = self.conn.execute(
+            """SELECT content_text FROM entries
+               WHERE content_type = 'text' AND content_text IS NOT NULL
+               ORDER BY accessed_at DESC LIMIT 1"""
+        ).fetchone()
+        return row["content_text"] if row else ""
 
     def export_backup(self, path: str):
         import shutil

--- a/clipman/updates.py
+++ b/clipman/updates.py
@@ -73,32 +73,38 @@ def default_enabled() -> bool:
     return install_kind() == "other"
 
 
-def _parse_version(s: str) -> tuple:
-    """Best-effort semantic-version parse.
+def _tuple_version(s: str) -> tuple:
+    """Parse ``X.Y.Z`` into an integer tuple (the fallback).
 
-    Prefers ``packaging.version.parse`` when available (it understands
-    pre-releases, dev tags, epochs). Falls back to a plain
-    integer-tuple comparator that handles ``X.Y.Z`` well enough for
-    Clipman's tag scheme. Returns a value that's safely comparable to
-    another value from the same function.
+    Each chunk contributes its leading digits, so ``1.2.3-hotfix``
+    compares like ``1.2.3``.
     """
+    parts: list[int] = []
+    for chunk in (s or "").strip().lstrip("v").split("."):
+        match = re.match(r"\d+", chunk)
+        if match is None:
+            break
+        parts.append(int(match.group()))
+    return tuple(parts) if parts else (0,)
+
+
+def _parse_version(s: str):
+    """Return a packaging Version, or None if missing or invalid."""
     s = (s or "").strip().lstrip("v")
     try:
         from packaging.version import parse as _pv  # type: ignore
         return _pv(s)
     except Exception:
-        parts: list[int] = []
-        for chunk in s.split("."):
-            try:
-                parts.append(int(chunk))
-            except ValueError:
-                break
-        return tuple(parts) if parts else (0,)
+        return None
 
 
 def _is_newer(candidate: str, current: str) -> bool:
     """``True`` iff ``candidate`` is strictly newer than ``current``."""
-    return _parse_version(candidate) > _parse_version(current)
+    a, b = _parse_version(candidate), _parse_version(current)
+    if a is None or b is None:
+        # One side did not parse; compare both the simple way.
+        return _tuple_version(candidate) > _tuple_version(current)
+    return a > b
 
 
 def _http_get(url: str = RELEASES_URL) -> dict | None:
@@ -183,11 +189,10 @@ def check_async(db, callback=None) -> threading.Thread:
       1. Marks ``last_update_check`` immediately so a flapping check
          doesn't fan out into N concurrent fetches if called rapidly.
       2. Fetches + parses the latest release.
-      3. Persists ``latest_known_version`` if the API gave us one.
-      4. Schedules ``callback(is_newer, latest_version, url)`` on the
-         GTK main loop via ``GLib.idle_add`` (so the caller can update
-         UI without touching threading primitives). ``callback`` may be
-         ``None``; in that case the persisted state is the only output.
+      3. Hands the result to the GTK main loop via ``GLib.idle_add``,
+         which persists ``latest_known_version`` and then calls
+         ``callback(is_newer, latest_version, url)``. SQLite is never
+         touched from the thread. ``callback`` may be ``None``.
 
     Returns the started thread (useful for tests that want to ``join``).
     """
@@ -195,15 +200,21 @@ def check_async(db, callback=None) -> threading.Thread:
 
     def _run() -> None:
         is_newer, latest, url = check_for_update()
-        if latest:
-            db.set_setting(SETTING_LATEST_VERSION, latest)
-        if callback is not None:
-            try:
-                from gi.repository import GLib
-                GLib.idle_add(callback, is_newer, latest, url)
-            except Exception:
-                # No GTK loop (test context) — call inline.
+
+        def _finish():
+            # SQLite is only touched from the main loop.
+            if latest:
+                db.set_setting(SETTING_LATEST_VERSION, latest)
+            if callback is not None:
                 callback(is_newer, latest, url)
+            return False
+
+        try:
+            from gi.repository import GLib
+            GLib.idle_add(_finish)
+        except Exception:
+            # No GTK loop (test context) — run inline.
+            _finish()
 
     thread = threading.Thread(target=_run, daemon=True, name="clipman-update-check")
     thread.start()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -494,25 +494,18 @@ class TestClipboardDB(unittest.TestCase):
         val = self.db.get_setting("nonexistent_key", "42")
         self.assertEqual(val, "42")
 
-    # ── Update entry text ─────────────────────────────────────────
+    # ── Latest text clip ──────────────────────────────────────────
 
-    def test_update_entry_text(self):
-        entry_id = self.db.add_entry("text", content_text="original text")
-        self.db.update_entry_text(entry_id, "updated text")
+    def test_get_latest_text_ignores_pins(self):
+        pinned = self.db.add_entry("text", content_text="old pinned note")
+        self.db.toggle_pin(pinned)
+        self.db.add_entry("text", content_text="newest copy")
+        self.db.add_entry("image", image_data=b"\x89PNG\r\n\x1a\nxx")
 
-        entries = self.db.get_entries()
-        self.assertEqual(entries[0]["content_text"], "updated text")
+        self.assertEqual(self.db.get_latest_text(), "newest copy")
 
-    def test_update_entry_text_changes_hash(self):
-        from clipman.database import content_hash
-        entry_id = self.db.add_entry("text", content_text="original")
-        original_hash = content_hash(b"original")
-
-        self.db.update_entry_text(entry_id, "modified")
-
-        entries = self.db.get_entries()
-        self.assertNotEqual(entries[0]["content_hash"], original_hash)
-        self.assertEqual(entries[0]["content_hash"], content_hash(b"modified"))
+    def test_get_latest_text_empty_history(self):
+        self.assertEqual(self.db.get_latest_text(), "")
 
     # ── Backup / Restore ──────────────────────────────────────────
 
@@ -855,11 +848,22 @@ class TestClipboardDB(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertIsNone(entries[0]["image_path"])
 
-    # ── update_entry_text on non-existent id ───────────────────────
+    # ── Robustness: settings and file modes ───────────────────────
 
-    def test_update_entry_text_nonexistent_is_noop(self):
-        self.db.update_entry_text(99999, "ghost update")
-        self.assertEqual(self.db.count_entries(), 0)
+    def test_max_entries_stored_as_float_string_still_works(self):
+        self.db.set_setting("max_entries", "2.0")
+        for i in range(3):
+            self.db.add_entry("text", content_text=f"clip {i}")
+        self.assertEqual(self.db.count_entries(), 2)
+
+    def test_max_entries_garbage_falls_back_to_default(self):
+        self.db.set_setting("max_entries", "lots")
+        self.db.add_entry("text", content_text="still stored")
+        self.assertEqual(self.db.count_entries(), 1)
+
+    def test_database_file_is_private(self):
+        mode = os.stat(self.db_path).st_mode & 0o777
+        self.assertEqual(mode, 0o600)
 
     # ── Security: image magic bytes validation ─────────────────────
 

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -59,6 +59,23 @@ class TestIsNewer(unittest.TestCase):
         self.assertTrue(updates._is_newer("v1.0.5", "1.0.4"))
         self.assertTrue(updates._is_newer("1.0.5", "v1.0.4"))
 
+    def test_invalid_tag_against_valid_version_does_not_raise(self):
+        # With packaging present, "1.2.3-hotfix" fails to parse while
+        # "1.2.1" parses; both sides must then use the simple compare.
+        fake_pkg = MagicMock()
+
+        def _parse(s):
+            if not s.replace(".", "").isdigit():
+                raise ValueError(s)
+            return tuple(int(x) for x in s.split("."))
+
+        fake_pkg.parse.side_effect = _parse
+        with patch.dict("sys.modules", {"packaging": MagicMock(),
+                                        "packaging.version": fake_pkg}):
+            self.assertTrue(updates._is_newer("1.2.3-hotfix", "1.2.1"))
+            self.assertFalse(updates._is_newer("1.2.1", "1.2.3-hotfix"))
+            self.assertTrue(updates._is_newer("1.2.3", "1.2.1"))
+
 
 class TestInstallKind(unittest.TestCase):
     def test_snap_detected(self):
@@ -304,6 +321,26 @@ class TestCheckAsync(unittest.TestCase):
         # The value at the time of the urlopen call must already be set.
         self.assertNotEqual(seen_last[0], "0")
         self.assertNotEqual(seen_last[0], None)
+
+    def test_result_is_stored_from_the_main_loop_not_the_thread(self):
+        db = _fake_db({updates.SETTING_ENABLED: "true"})
+        scheduled = []
+        fake_glib = MagicMock()
+        fake_glib.GLib.idle_add.side_effect = lambda fn, *a: scheduled.append((fn, a))
+
+        with patch.dict("sys.modules", {"gi.repository": fake_glib}), \
+             patch("clipman.updates.urllib.request.urlopen",
+                   return_value=_FakeResponse({"tag_name": "v9.9.9",
+                                               "html_url": "u"})):
+            thread = updates.check_async(db, callback=None)
+            thread.join(timeout=5)
+
+        # The thread only scheduled the work; nothing was written yet.
+        self.assertNotIn(updates.SETTING_LATEST_VERSION, db._store)
+        self.assertEqual(len(scheduled), 1)
+        fn, args = scheduled[0]
+        self.assertFalse(fn(*args))
+        self.assertEqual(db._store[updates.SETTING_LATEST_VERSION], "9.9.9")
 
 
 class TestDismissAndLatestKnown(unittest.TestCase):


### PR DESCRIPTION
## Summary

Five small fixes in the storage layer and the update checker. None of them change the UI.

## What was wrong

- **A bad `max_entries` setting broke every copy.** `enforce_max_entries` ran `int()` on the stored string. A value such as `500.0` raised `ValueError` inside `add_entry`, so every new clip failed. The Preferences pane already read the same key with `int(float(...))`; the database layer did not.
- **The database file was not private.** The data folder was 0700 and the WAL side files were 0600, but `clipman.db` itself was created with the process umask (0644 on most systems). The FAQ claimed 0600.
- **The update check wrote to SQLite from a thread.** `check_async` stored `latest_known_version` inside the background thread. The database code says all access happens on the main loop; this was the one place that broke the rule.
- **Version compare could raise.** With `packaging` installed, a release tag that is not a valid version (for example `1.2.3-hotfix`) parsed to a tuple while the current version parsed to a `Version`. Comparing the two raised `TypeError`, reachable from the update thread and from the banner code.
- **Dead code.** `update_entry_text` had no caller and could violate the unique `content_hash` constraint if it ever got one.

## What changed

- `enforce_max_entries` parses with `int(float(...))` and falls back to the default on garbage.
- `_ensure_dirs` also clamps `clipman.db` to 0600. It runs before and after the connection opens, so a new file is covered too.
- `check_async` hands the result to the main loop with `GLib.idle_add`; the `set_setting` call and the callback both run there. Without a GLib loop (tests) the same function runs inline.
- `_is_newer` uses `packaging` only when both sides parse. Otherwise both sides use the simple tuple compare, which now keeps the leading digits of each chunk, so `1.2.3-hotfix` compares like `1.2.3`.
- `update_entry_text` is removed. `get_latest_text` is added: it returns the newest text clip regardless of pins. The `${clipboard}` snippet token in `window.py` currently returns the top *pinned* entry; the window PR will switch it to this method.

## Tests

- Database: `max_entries` as `"2.0"` still trims to 2; garbage falls back to the default; the database file is 0600 after start; `get_latest_text` ignores pins and images and returns `""` on an empty history. The three tests for the removed method are gone.
- Update check: a mixed valid/invalid compare returns the expected results and does not raise (with a fake `packaging` module); the thread only schedules the write, and the scheduled function does the write.
- Full suite: 348 passed on pytest and on the unittest fallback. ruff clean.
