### PR TITLE
Popup window: SQL type filters, newest-clip token, paste retry and dialog, safe links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,31 @@ All notable changes to Clipman are documented in this file.
 - `update_entry_text` had no caller and could break the unique hash
   constraint; removed. `get_latest_text` returns the newest text clip
   regardless of pins, for the `${clipboard}` snippet token.
+
+### Fixed — popup window
+
+- The Images tab could show "no images" while its badge counted some:
+  the list loaded the 200 newest clips of any type and filtered them in
+  Python. The Text and Images tabs now ask the database for that type.
+- The `${clipboard}` snippet token expanded to the top *pinned* clip,
+  not the newest one. It now uses the newest text clip.
+- The "Snap notes" button opened a page that did not exist. It now
+  opens the install section of the README.
+- After the popup copied a clip, the monitor skipped the next clipboard
+  change with no time limit, so it could swallow a real copy made
+  later. The skip now expires after two seconds.
+- Links from the popup go through the same http(s)-only opener as the
+  Preferences window. The "Reveal folder" button uses its own helper
+  that only opens folders that exist.
+- Paste through the GNOME Shell extension: a failed focus restore no
+  longer aborts the paste; an old extension that rejects the mode
+  argument gets the no-argument call that ADR 0005 promised; and when
+  the extension refuses both calls the popup comes back with a
+  "Couldn't auto-paste" dialog instead of falling back to wtype, which
+  cannot inject keys on Mutter.
+- Masked rows say only "Sensitive" when "Auto-clear sensitive clips"
+  is off, instead of counting down to a purge that will not happen.
+
 ### Security — GNOME Shell extension (metadata version 8)
 
 - The extension's D-Bus methods (`SimulatePaste`, `MoveWindowToCursor`,

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Press **Super+V** to view your clipboard history, search entries, pin favorites,
 
 <br>
 
-<sub><i>Above: the shipped GTK 4 + libadwaita popup. The full settings surface is a sidebar <code>Adw.Dialog</code>, the snippets editor is an <code>Adw.NavigationSplitView</code> dialog, and the 19 edge states (empty, no-results, incognito, sensitive-cleared, first-run, errors…) render as Adwaita <code>StatusPage</code> / <code>Banner</code> / <code>AlertDialog</code> with a shared Catppuccin overlay. <a href="https://mohammedel-sayedahmed.github.io/clipman/#design">Browse the mockups</a> · <a href="https://mohammedel-sayedahmed.github.io/clipman/">project page</a>.</i></sub>
+<sub><i>Above: the shipped GTK 4 + libadwaita popup. The full settings surface is a sidebar <code>Adw.Dialog</code>, the snippets editor is an <code>Adw.NavigationSplitView</code> dialog, and the 20 edge states (empty, no-results, incognito, sensitive-cleared, first-run, errors…) render as Adwaita <code>StatusPage</code> / <code>Banner</code> / <code>AlertDialog</code> with a shared Catppuccin overlay. <a href="https://mohammedel-sayedahmed.github.io/clipman/#design">Browse the mockups</a> · <a href="https://mohammedel-sayedahmed.github.io/clipman/">project page</a>.</i></sub>
 
 </div>
 

--- a/clipman/clipboard_monitor.py
+++ b/clipman/clipboard_monitor.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 MAX_TEXT_SIZE = 10 * 1024 * 1024   # 10 MB
 MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
 MIN_EVENT_INTERVAL = 0.1  # seconds — ignore events faster than this
+SELF_COPY_TTL = 2.0  # seconds — how long a self-copy skip stays armed
 
 
 class _WlPasteWatcher:
@@ -175,6 +176,7 @@ class ClipboardMonitor:
         self._run_in_background = _run_in_thread
         self._run_on_main_loop = GLib.idle_add
         self._self_copy = False
+        self._self_copy_at = 0.0
         self._incognito = False
         self._last_event_time = 0.0
         self._watcher = None
@@ -202,7 +204,20 @@ class ClipboardMonitor:
                 logger.debug("on_watcher_dead callback failed", exc_info=True)
 
     def set_self_copy(self, val: bool):
-        self._self_copy = val
+        """Arm or clear the skip for a clipboard change we caused."""
+        self._self_copy = bool(val)
+        self._self_copy_at = time.monotonic() if val else 0.0
+
+    def _consume_self_copy(self) -> bool:
+        """Clear the skip flag; return True only while it is still fresh.
+
+        Without the time limit, a self-copy that no clipboard event
+        followed would swallow the user's next real copy.
+        """
+        if not self._self_copy:
+            return False
+        self._self_copy = False
+        return time.monotonic() - self._self_copy_at < SELF_COPY_TTL
 
     @property
     def incognito(self) -> bool:
@@ -226,8 +241,7 @@ class ClipboardMonitor:
 
     def handle_new_text(self, text):
         """Called from D-Bus when the extension detects a text copy."""
-        if self._self_copy:
-            self._self_copy = False
+        if self._consume_self_copy():
             return
 
         if self._incognito or self._rate_limited():
@@ -243,8 +257,7 @@ class ClipboardMonitor:
 
     def handle_new_image(self):
         """Called from D-Bus when an image was copied."""
-        if self._self_copy:
-            self._self_copy = False
+        if self._consume_self_copy():
             return
 
         if self._incognito or self._rate_limited():

--- a/clipman/edge_states.py
+++ b/clipman/edge_states.py
@@ -64,7 +64,7 @@ class StateSpec:
 
 
 # ---------------------------------------------------------------------
-# The specs (16 mockup states + 3 plumbed error states). Order matches the mockup picker (states.html), reading
+# The specs (16 mockup states + 4 plumbed error states). Order matches the mockup picker (states.html), reading
 # top-to-bottom: Baseline / Informational / Privacy / Setup / Errors.
 # "populated" is a sentinel: it represents the normal list-view popup,
 # is never actually rendered through ``render_edge_state`` (the list
@@ -227,6 +227,18 @@ STATES: dict[str, StateSpec] = {
                "on your clipboard. Paste it manually with Ctrl+V."),
         primary_action=(_("Got it"), "close-dialog"),
         secondary_action=(_("Install help"), "open-install-guide"),
+    ),
+    "paste-failed": StateSpec(
+        id="paste-failed",
+        kind="alertdialog",
+        tone="warning",
+        icon_name="input-keyboard-symbolic",
+        title=_("Couldn't auto-paste"),
+        body=_("The GNOME Shell extension did not accept the paste "
+               "request, so we left the clip on your clipboard. Paste "
+               "it manually with Ctrl+V."),
+        primary_action=(_("Got it"), "close-dialog"),
+        secondary_action=(_("Open Extensions"), "open-extensions"),
     ),
     "clipboard-blocked": StateSpec(
         id="clipboard-blocked",

--- a/clipman/window.py
+++ b/clipman/window.py
@@ -344,6 +344,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
             self._sensitive_timeout = max(10, min(300, int(float(saved_sensitive))))
         except (TypeError, ValueError):
             self._sensitive_timeout = DEFAULT_SENSITIVE_TIMEOUT
+        self._sensitive_autoclear = str(
+            self.db.get_setting("sensitive_autoclear", "true")
+        ).lower() == "true"
 
         self._apply_theme()
         self._apply_css()
@@ -827,18 +830,18 @@ class ClipmanWindow(Adw.ApplicationWindow):
             items = [ClipItem(e, "snippet") for e in entries]
         else:
             if self._search_query:
-                entries = self.db.search(self._search_query)
+                # search() covers text only, so the Images tab has no
+                # search results.
+                entries = (
+                    [] if self._active_filter == "images"
+                    else self.db.search(self._search_query)
+                )
+            elif self._active_filter == "text":
+                entries = self.db.get_entries(limit=200, content_type="text")
+            elif self._active_filter == "images":
+                entries = self.db.get_entries(limit=200, content_type="image")
             else:
                 entries = self.db.get_entries(limit=200)
-            if self._active_filter == "text":
-                entries = [
-                    e for e in entries
-                    if (e.get("content_type") or "text") == "text"
-                ]
-            elif self._active_filter == "images":
-                entries = [
-                    e for e in entries if e.get("content_type") == "image"
-                ]
             items = [ClipItem(e, "entry") for e in entries]
 
         # Cancel any in-flight incremental fill from a previous refresh.
@@ -1029,7 +1032,7 @@ class ClipmanWindow(Adw.ApplicationWindow):
     )
     _SNAP_NOTES_URL = (
         "https://github.com/MohammedEl-sayedAhmed/clipman"
-        "/blob/main/docs/snap-confinement.md"
+        "#alternative-installation"
     )
 
     # Authoritative list of action_ids the dispatcher handles. The
@@ -1203,10 +1206,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._on_prefs_clicked(None)
 
     def _action_reveal_db_folder(self):
-        # xdg-open a directory hands off to the user's file manager.
         from clipman.database import DATA_DIR
 
-        self._open_url(str(DATA_DIR))
+        self._reveal_path(str(DATA_DIR))
 
     def _action_retry_update_check(self):
         self.refresh_update_banner()
@@ -1234,14 +1236,24 @@ class ClipmanWindow(Adw.ApplicationWindow):
         self._current_edge_banner = None
 
     def _open_url(self, url):
+        """Open a web link in the browser. Other schemes are dropped."""
+        from clipman.preferences import open_url
+
+        open_url(url)
+
+    def _reveal_path(self, path):
+        """Show an existing local folder in the file manager."""
+        if not os.path.isdir(path):
+            logger.debug("not a folder, not revealing: %r", path)
+            return
         try:
             subprocess.Popen(
-                ["xdg-open", url],
+                ["xdg-open", path],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
         except OSError:
-            logger.debug("xdg-open failed for %s", url, exc_info=True)
+            logger.debug("xdg-open failed for %s", path, exc_info=True)
 
     def _thumbnail_texture(self, image_path, size=48):
         """Decode a stored image to a small, HiDPI-crisp ``Gdk.Texture``.
@@ -1499,12 +1511,11 @@ class ClipmanWindow(Adw.ApplicationWindow):
         # --- title + meta line (mockup .preview / .meta) -----------------
         if sensitive:
             # Masked preview: never render sensitive content, its length,
-            # or its thumbnail. Meta carries the auto-clear countdown.
+            # or its thumbnail.
             title = _SENSITIVE_MASK
             row._clip_title.add_css_class("masked")
             row._clip_subtitle.add_css_class("warning")
-            remaining = self._sensitive_remaining(entry)
-            subtitle = _("Sensitive — auto-clear in {n} s").format(n=remaining)
+            subtitle = self._sensitive_subtitle(entry)
         else:
             row._clip_title.remove_css_class("masked")
             row._clip_subtitle.remove_css_class("warning")
@@ -1578,6 +1589,13 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """Seconds until the purge loop removes this sensitive entry."""
         created = entry.get("created_at") or time.time()
         return max(0, int(self._sensitive_timeout - (time.time() - created)))
+
+    def _sensitive_subtitle(self, entry):
+        """Meta text for a masked row; no countdown when auto-clear is off."""
+        if not self._sensitive_autoclear:
+            return _("Sensitive")
+        remaining = self._sensitive_remaining(entry)
+        return _("Sensitive — auto-clear in {n} s").format(n=remaining)
 
     def _image_info(self, image_path):
         """(bytes, width, height) for an image row's meta, cached; None if
@@ -1880,10 +1898,15 @@ class ClipmanWindow(Adw.ApplicationWindow):
         GLib.timeout_add(80, self._simulate_paste)
 
     def _paste_via_shell(self, mode):
-        """Best-effort paste via the GNOME Shell extension: restore focus,
-        then inject the keystroke through Clutter. Returns True once the
-        requests are dispatched, False if the extension isn't reachable (so
-        the caller can fall back to wtype/ydotool)."""
+        """Paste through the GNOME Shell extension.
+
+        Return True once the requests are dispatched and False when the
+        extension is not reachable, so the caller can fall back to
+        wtype/ydotool. A failed focus restore is logged and the paste
+        still goes ahead. When the extension refuses the keystroke the
+        popup comes back with the ``paste-failed`` dialog; wtype cannot
+        inject keys on Mutter, so there is no point in trying it.
+        """
         iface = self._shell_extension_iface()
         if iface is None:
             return False
@@ -1891,23 +1914,39 @@ class ClipmanWindow(Adw.ApplicationWindow):
             iface.RestorePreviousFocus()
         except Exception as exc:
             logger.debug("Shell focus-restore failed: %s", exc, exc_info=True)
-            return False
 
         # Give the compositor a frame to move focus onto the restored window
         # before the keys land, then inject via the Shell (not wtype).
         def _fire_keystroke():
-            try:
-                iface.SimulatePaste(mode)
-            except Exception as exc:
-                logger.debug(
-                    "Shell SimulatePaste failed: %s", exc, exc_info=True
-                )
+            if not self._shell_simulate_paste(iface, mode):
+                self._present_focused()
+                self._show_edge_state("paste-failed")
             return False
 
         # ~120ms: comfortably longer than a compositor focus cycle so the
         # keys land on the restored window, still imperceptible to the user.
         GLib.timeout_add(120, _fire_keystroke)
         return True
+
+    def _shell_simulate_paste(self, iface, mode):
+        """Call ``SimulatePaste(mode)``; retry without the argument.
+
+        Extensions before contract version 5 only know the no-argument
+        form (ADR 0005). Return True when either call was accepted.
+        """
+        try:
+            iface.SimulatePaste(mode)
+            return True
+        except Exception as exc:
+            logger.debug(
+                "Shell SimulatePaste(%r) failed: %s", mode, exc, exc_info=True
+            )
+        try:
+            iface.SimulatePaste()
+            return True
+        except Exception as exc:
+            logger.debug("Shell SimulatePaste() failed: %s", exc, exc_info=True)
+            return False
 
     def _extension_connected(self):
         """Whether the GNOME Shell extension owns its bus name (cached 60s —
@@ -1951,11 +1990,9 @@ class ClipmanWindow(Adw.ApplicationWindow):
         """
         recent = ""
         try:
-            entries = self.db.get_entries(limit=1)
-            if entries:
-                recent = entries[0].get("content_text") or ""
+            recent = self.db.get_latest_text()
         except Exception:
-            logger.debug("get_entries failed for ${clipboard} expansion",
+            logger.debug("get_latest_text failed for ${clipboard} expansion",
                          exc_info=True)
         return Template(text).safe_substitute(
             date=time.strftime("%Y-%m-%d"),
@@ -2156,6 +2193,10 @@ class ClipmanWindow(Adw.ApplicationWindow):
                 self._sensitive_timeout = max(10, min(300, int(value)))
             except (TypeError, ValueError):
                 self._sensitive_timeout = DEFAULT_SENSITIVE_TIMEOUT
+        elif key == "sensitive_autoclear":
+            self._sensitive_autoclear = str(value).lower() == "true"
+            if self.get_visible():
+                self.refresh()
         elif key in ("backup_succeeded", "restore_succeeded",
                      "sensitive_purged"):
             if self.get_visible():

--- a/tests/test_clipboard_monitor.py
+++ b/tests/test_clipboard_monitor.py
@@ -398,6 +398,16 @@ class TestClipboardMonitor(unittest.TestCase):
             "text", content_text="recorded", sensitive=False
         )
 
+    def test_self_copy_skip_expires(self):
+        """A stale self-copy flag must not swallow a real copy."""
+        self.monitor.set_self_copy(True)
+        later = time.monotonic() + 5
+        with patch("clipman.clipboard_monitor.time.monotonic",
+                   return_value=later):
+            self.monitor.handle_new_text("real copy")
+        self.mock_db.add_entry.assert_called_once()
+        self.assertFalse(self.monitor._self_copy)
+
     @patch("clipman.clipboard_monitor.subprocess.run")
     def test_self_copy_auto_resets_after_image(self, mock_run):
         mock_run.return_value = FakeCompletedProcess(

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -14,6 +14,7 @@ ARE importable, the tests assert that:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import tempfile
 import unittest
@@ -74,8 +75,8 @@ class TestEdgeStates(unittest.TestCase):
         "incognito-on", "sensitive-shown", "sensitive-cleared",
         "extension-missing", "backup-failed", "restore-failed",
         "network-error", "db-locked", "paused", "paste-target-missing",
-        "history-too-large", "clipboard-blocked", "watcher-crashed",
-        "shortcut-failed",
+        "paste-failed", "history-too-large", "clipboard-blocked",
+        "watcher-crashed", "shortcut-failed",
     }
 
     def test_state_id_inventory(self):
@@ -87,7 +88,7 @@ class TestEdgeStates(unittest.TestCase):
         """
         from clipman.edge_states import STATES
         self.assertEqual(set(STATES.keys()), self.EXPECTED_IDS)
-        self.assertEqual(len(STATES), 19)
+        self.assertEqual(len(STATES), 20)
 
     def test_render_each_state_returns_widget(self):
         from clipman.edge_states import STATES, render_edge_state
@@ -454,6 +455,154 @@ class TestWindowConstruction(unittest.TestCase):
         window = ClipmanWindow(application=app, db=db, monitor=None)
         window._shell_extension_iface = lambda: None
         self.assertFalse(window._paste_via_shell("auto"))
+
+    def test_paste_via_shell_ignores_focus_restore_failure(self):
+        """A failed focus restore must not abort the paste."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestFocusFail")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        fake_iface = MagicMock()
+        fake_iface.RestorePreviousFocus.side_effect = RuntimeError("no window")
+        window._shell_extension_iface = lambda: fake_iface
+
+        with patch("clipman.window.GLib.timeout_add") as timeout_add:
+            self.assertTrue(window._paste_via_shell("auto"))
+        timeout_add.call_args[0][1]()
+        fake_iface.SimulatePaste.assert_called_once_with("auto")
+
+    def test_paste_via_shell_retries_without_mode(self):
+        """An old extension that rejects the mode gets the no-argument call."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestPasteRetry")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        calls = []
+
+        def simulate(*args):
+            calls.append(args)
+            if args:
+                raise RuntimeError("UnknownMethod")
+
+        fake_iface = MagicMock()
+        fake_iface.SimulatePaste.side_effect = simulate
+        window._shell_extension_iface = lambda: fake_iface
+        window._show_edge_state = MagicMock()
+
+        with patch("clipman.window.GLib.timeout_add") as timeout_add:
+            window._paste_via_shell("ctrl-v")
+        timeout_add.call_args[0][1]()
+        self.assertEqual(calls, [("ctrl-v",), ()])
+        window._show_edge_state.assert_not_called()
+
+    def test_paste_via_shell_shows_dialog_when_both_calls_fail(self):
+        """No wtype fallback on GNOME: the popup comes back with a dialog."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestPasteFailed")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        fake_iface = MagicMock()
+        fake_iface.SimulatePaste.side_effect = RuntimeError("refused")
+        window._shell_extension_iface = lambda: fake_iface
+        window._present_focused = MagicMock()
+        window._show_edge_state = MagicMock()
+        window._simulate_paste = MagicMock()
+
+        with patch("clipman.window.GLib.timeout_add") as timeout_add:
+            self.assertTrue(window._paste_via_shell("auto"))
+        timeout_add.call_args[0][1]()
+        window._present_focused.assert_called_once()
+        window._show_edge_state.assert_called_once_with("paste-failed")
+        window._simulate_paste.assert_not_called()
+
+    def test_type_filters_query_the_database_by_type(self):
+        """The Text and Images tabs filter in SQL, not on the newest 200 rows."""
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestTypeFilter")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        window.db = MagicMock(wraps=db)
+
+        window._active_filter = "images"
+        window.refresh()
+        window.db.get_entries.assert_called_with(limit=200, content_type="image")
+
+        window._active_filter = "text"
+        window.refresh()
+        window.db.get_entries.assert_called_with(limit=200, content_type="text")
+
+    def test_clipboard_token_uses_newest_text_not_pinned(self):
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        older = db.add_entry("text", content_text="older clip")
+        db.toggle_pin(older)
+        db.add_entry("text", content_text="newer clip")
+        app = Adw.Application(application_id="com.clipman.TestClipToken")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+
+        self.assertEqual(
+            window._expand_snippet_tokens("> ${clipboard}"), "> newer clip"
+        )
+
+    def test_snap_notes_url_points_at_a_readme_heading(self):
+        from clipman.window import ClipmanWindow
+
+        fragment = ClipmanWindow._SNAP_NOTES_URL.rsplit("#", 1)[1]
+        readme = Path(__file__).resolve().parents[1] / "README.md"
+        slugs = set()
+        for line in readme.read_text(encoding="utf-8").splitlines():
+            if line.startswith("#"):
+                heading = line.lstrip("#").strip().lower()
+                slugs.add(re.sub(r"[^\w\- ]", "", heading).replace(" ", "-"))
+        self.assertIn(fragment, slugs)
+
+    def test_open_url_drops_non_http_links(self):
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestOpenUrl")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+
+        with patch("clipman.preferences.subprocess.Popen") as popen:
+            window._open_url("file:///etc/passwd")
+            popen.assert_not_called()
+            window._open_url("https://example.org/")
+            popen.assert_called_once()
+
+    def test_reveal_path_opens_existing_folders_only(self):
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestReveal")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        folder = tempfile.mkdtemp(prefix="clipman-reveal-")
+        self.addCleanup(shutil.rmtree, folder, ignore_errors=True)
+
+        with patch("clipman.window.subprocess.Popen") as popen:
+            window._reveal_path(folder)
+            self.assertEqual(popen.call_args[0][0], ["xdg-open", folder])
+            popen.reset_mock()
+            window._reveal_path(os.path.join(folder, "missing"))
+            popen.assert_not_called()
+
+    def test_masked_row_has_no_countdown_when_autoclear_is_off(self):
+        from clipman.window import ClipmanWindow
+
+        db = self._make_db()
+        app = Adw.Application(application_id="com.clipman.TestMaskedRow")
+        window = ClipmanWindow(application=app, db=db, monitor=None)
+        entry = {"created_at": 0}
+
+        self.assertTrue(window._sensitive_autoclear)
+        self.assertIn("auto-clear in", window._sensitive_subtitle(entry))
+        window._on_setting_changed("sensitive_autoclear", "false")
+        self.assertFalse(window._sensitive_autoclear)
+        self.assertEqual(window._sensitive_subtitle(entry), "Sensitive")
 
     def test_classify_text_code_vs_prose(self):
         """The row-type classifier catches obvious code without flagging


### PR DESCRIPTION
## Summary

Seven small fixes in the popup window and one in the clipboard monitor. This is the one PR from the audit plan that touches `window.py`, so it bundles every window item (A6, A7, A12, A13, A14, C4) plus the follow-up from the sensitive-data PR (#272).

## What was wrong

- **Images tab could be empty while its badge counted images.** `refresh()` loaded the 200 newest clips of any type and filtered them in Python. With 200 newer text clips, the Images tab showed the empty state.
- **`${clipboard}` expanded to the top pinned clip.** The snippet token used `get_entries(limit=1)`, which sorts pinned clips first. The docstring promised the newest text clip.
- **"Snap notes" opened a 404.** The button pointed at `docs/snap-confinement.md`, which does not exist.
- **The self-copy skip had no time limit.** After the popup copied a clip, the monitor skipped the next clipboard change, whenever it came. If no event followed the copy, the flag swallowed the user's next real copy.
- **Two link openers with different rules.** `preferences.open_url` only accepts http(s); the window's `_open_url` passed anything to `xdg-open`, including the data folder path.
- **The paste fallback the docs describe did not exist.** ADR 0005 and `docs/maintaining.md` say the daemon retries `SimulatePaste()` without the mode argument on an old extension. The code only logged. Worse, a failed `RestorePreviousFocus` made the daemon fall back to wtype, which cannot inject keys on Mutter, so the paste silently did nothing.
- **Masked rows counted down to a purge that would not happen** when "Auto-clear sensitive clips" is off (#272 put the gate in the database layer only).

## What changed

- `refresh()` asks the database for the type: `get_entries(limit=200, content_type="text" | "image")`. With a search query the Images tab shows nothing, because `search()` covers text only (same result as before, now explicit).
- `_expand_snippet_tokens` uses `get_latest_text()` (added in #275).
- `_SNAP_NOTES_URL` points at the README's "Alternative Installation" section, where the snap note lives. A test checks that the anchor matches a README heading.
- `clipboard_monitor.py`: `set_self_copy` records the time; `_consume_self_copy` clears the flag and only skips the event when the flag is younger than `SELF_COPY_TTL` (2 seconds).
- `_open_url` delegates to `preferences.open_url` (http(s) only). New `_reveal_path` opens a folder in the file manager and refuses anything that is not an existing folder; the "Reveal folder" button uses it.
- `_paste_via_shell`: a failed focus restore is logged and the paste goes ahead. New `_shell_simulate_paste` calls `SimulatePaste(mode)` and retries `SimulatePaste()` when that raises. If both fail, the popup comes back with a new `paste-failed` alert dialog ("Couldn't auto-paste", with an "Open Extensions" button). No wtype fallback when the extension is reachable.
- New `_sensitive_subtitle`: "Sensitive" when auto-clear is off, the countdown when it is on. The flag is read at start-up and updated live from the Preferences switch.
- `edge_states.py`: the `paste-failed` state (20 states now). It reuses the existing `close-dialog` and `open-extensions` actions, so the dispatcher coverage test still holds.

## Tests

- 9 new tests in `tests/test_window.py`: type filters query by type; `${clipboard}` prefers the newest clip over a pinned one; the snap URL anchor exists in the README; `_open_url` drops `file://`; `_reveal_path` opens folders only; focus-restore failure does not abort the paste; the no-argument retry; the `paste-failed` dialog with no wtype fallback; the masked-row subtitle with auto-clear on and off.
- 1 new test in `tests/test_clipboard_monitor.py`: a stale self-copy flag does not swallow a real copy.
- Full suite: 369 passed with pytest and with the unittest fallback. ruff 0.15.13 clean.
- No screenshots: this machine has no xvfb. The only visible changes are the masked-row subtitle text and a new alert dialog that goes through the existing `render_edge_state` path.
